### PR TITLE
Use setuptools or distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,24 @@
-from setuptools import setup, find_packages
 
-setup ( name = 'burnman',
-        version = '0.6b3',
-        description='a lower mantle toolkit',
-        url='http://burnman.org',
-        author='Ian Rose',
-        author_email='ian.rose@berkeley.edu',
-        license='GPL',
-        long_description='BurnMan is a lower mantle shear velocity generator constrained by mineral physics.',
-        packages = ['burnman', 'burnman.minerals'],
-        package_data = { 'burnman' : ['data/input_*/*'] },
-        install_requires=['numpy', 'matplotlib', 'scipy']
-       )
+metadata = dict( name= 'burnman',
+                 version = '0.6b3',
+                 description='a lower mantle toolkit',
+                 url='http://burnman.org',
+                 author='Ian Rose',
+                 author_email='ian.rose@berkeley.edu',
+                 license='GPL',
+                 long_description='BurnMan calculates elastic properties of lower mantle assemblages constrained by mineral physics.',
+                 packages = ['burnman', 'burnman.minerals'],
+                 package_data = { 'burnman' : ['data/input_*/*'] },
+               )
+
+#Try to use setuptools in order to check dependencies.
+#if the system does not have setuptools, fall back on
+#distutils.
+try:
+  from setuptools import setup, find_packages
+  metadata['install_requires'] = ['numpy', 'matplotlib', 'scipy']
+except ImportError:
+  from distutils.core import setup
+
+
+setup ( **metadata )


### PR DESCRIPTION
My laptop python distribution did not come with setuptools by default.  It is simple enough to install, but it is also pretty simple to fall back on distutils if this occurs.  What do you think of this?
