### PR TITLE
fix return value parameter order

### DIFF
--- a/examples/example_composition.py
+++ b/examples/example_composition.py
@@ -132,8 +132,9 @@ if __name__ == "__main__":
     mat_K = np.array([m.K for m in moduli])
     mat_G = np.array([m.G for m in moduli])
     mat_rho = np.array([m.rho for m in moduli])
-    [rho_err,vphi_err,vs_err]=burnman.compare_chifactor \
-            ([mat_vs,mat_vphi,mat_rho],[seis_vs,seis_vphi,seis_rho])
+
+    [vs_err, vphi_err, rho_err] = burnman.compare_chifactor (
+        [mat_vs,mat_vphi,mat_rho],[seis_vs,seis_vphi,seis_rho])
 
 
     # PLOTTING

--- a/examples/example_optimize_pv.py
+++ b/examples/example_optimize_pv.py
@@ -68,8 +68,8 @@ if __name__ == "__main__":
         print "Calculations are done for:"
         rock.debug_print()
 
-        #[rho_err,vphi_err,vs_err]=burnman.compare_chifactor([mat_vs,mat_vphi,mat_rho],[seis_vs,seis_vphi,seis_rho])
-        [rho_err,vphi_err,vs_err]=burnman.compare_l2(depths,[mat_vs,mat_vphi,mat_rho],[seis_vs,seis_vphi,seis_rho])
+        [vs_err, vphi_err, rho_err] = \
+            burnman.compare_l2(depths, [mat_vs,mat_vphi,mat_rho], [seis_vs,seis_vphi,seis_rho])
 
         return vs_err, vphi_err
 

--- a/examples/example_partition_coef.py
+++ b/examples/example_partition_coef.py
@@ -98,7 +98,7 @@ if __name__ == "__main__":
     print "Calculations are done for:"
     rock.debug_print()
 
-    [rho_err,vphi_err,vs_err]=burnman.compare_chifactor \
+    [vs_err, vphi_err, rho_err]=burnman.compare_chifactor \
             ([mat_vs,mat_vphi,mat_rho],[seis_vs,seis_vphi,seis_rho])
 
 

--- a/examples/example_user_input_material.py
+++ b/examples/example_user_input_material.py
@@ -105,5 +105,7 @@ if __name__ == "__main__":
         burnman.velocities_from_rock(rock, seis_p, temperature, \
                                      burnman.averaging_schemes.VoigtReussHill())
 
-    [rho_err,vphi_err,vs_err]= \
-        burnman.compare_chifactor([mat_vs,mat_vphi,mat_rho],[seis_vs,seis_vphi,seis_rho])
+    [vs_err, vphi_err, rho_err]= \
+        burnman.compare_chifactor([mat_vs,mat_vphi,mat_rho], [seis_vs,seis_vphi,seis_rho])
+
+    print vs_err, vphi_err, rho_err

--- a/misc/ref/example_user_input_material.py.out
+++ b/misc/ref/example_user_input_material.py.out
@@ -1,2 +1,3 @@
 Calculations are done for:
 '__main__.own_material'
+247.935799475 138.485603794 987.797836864


### PR DESCRIPTION
compare_\* return values in the same order as the arguments. We messed
this up in several examples.
