### PR TITLE
improve mineral database documentation

### DIFF
--- a/burnman/minerals/Matas_etal_2007.py
+++ b/burnman/minerals/Matas_etal_2007.py
@@ -6,17 +6,13 @@
 Matas_etal_2007
 ^^^^^^^^^^^^^^^
 
-Minerals from Matas et al. 2007 and references therein
+Minerals from Matas et al. 2007 and references therein. See Table 1 and 2.
 """
 
 from burnman.mineral import Mineral
 
 
-
-class mg_perovskite(Mineral): # Matas et al 2007 Tables 1&2
-    """
-    Matas et al. 2007 and references therein
-    """
+class mg_perovskite(Mineral):
     def __init__(self):
         self.params = {
             'equation_of_state':'mgd2',
@@ -31,10 +27,8 @@ class mg_perovskite(Mineral): # Matas et al 2007 Tables 1&2
             'grueneisen_0': 1.48,
             'q_0': 1.4}
 
-class fe_perovskite(Mineral): # Matas et al 2007 Tables 1&2
-    """
-    Matas et al. 2007 and references therein
-    """
+
+class fe_perovskite(Mineral):
     def __init__(self):
         self.params = {
             'equation_of_state':'mgd2',
@@ -49,10 +43,8 @@ class fe_perovskite(Mineral): # Matas et al 2007 Tables 1&2
             'grueneisen_0': 1.48,
             'q_0': 1.4}
 
-class al_perovskite(Mineral): # Matas et al 2007 Tables 1&2
-    """
-    Matas et al. 2007 and references therein
-    """
+
+class al_perovskite(Mineral):
     def __init__(self):
         self.params = {
             'equation_of_state':'mgd2',
@@ -67,10 +59,8 @@ class al_perovskite(Mineral): # Matas et al 2007 Tables 1&2
             'grueneisen_0': 1.48,
             'q_0': 1.4}
 
-class ca_perovskite(Mineral): # Matas et al 2007 Tables 1&2
-    """
-    Matas et al. 2007 and references therein
-    """
+
+class ca_perovskite(Mineral):
     def __init__(self):
         self.params = {
             'equation_of_state':'mgd2',
@@ -86,10 +76,7 @@ class ca_perovskite(Mineral): # Matas et al 2007 Tables 1&2
             'q_0': 1.6}
 
 
-class periclase (Mineral): # Matas et al 2007 Tables 1&2
-    """
-    Matas et al. 2007 and references therein
-    """
+class periclase (Mineral):
     def __init__(self):
         self.params = {
             'equation_of_state':'mgd2',
@@ -104,10 +91,8 @@ class periclase (Mineral): # Matas et al 2007 Tables 1&2
             'grueneisen_0': 1.41,
             'q_0': 1.3 }
 
-class wuestite (Mineral): # Matas et al 2007 Tables 1&2
-    """
-    Matas et al. 2007 and references therein
-    """
+
+class wuestite (Mineral):
     def __init__(self):
         self.params = {
             'equation_of_state':'mgd2',

--- a/burnman/minerals/Murakami_2013.py
+++ b/burnman/minerals/Murakami_2013.py
@@ -6,7 +6,7 @@
 Murakami_2013
 ^^^^^^^^^^^^^
 
-Minerals from Murakami 2013 and references therein
+Minerals from Murakami 2013 and references therein.
 
 """
 
@@ -14,13 +14,7 @@ import burnman.mineral_helpers as bmb
 from burnman.mineral import Mineral
 
 
-
-
-
 class periclase (Mineral):
-    """
-    Murakami 2013 and references therine
-    """
     def __init__(self):
         self.params = {
             'equation_of_state':'slb2',
@@ -36,10 +30,8 @@ class periclase (Mineral):
             'q_0': 1.5,
             'eta_s_0': 2.3 }
 
+
 class wuestite (Mineral):
-    """
-    Muarakami 2013 and references therein
-    """
     def __init__(self):
         self.params = {
             'equation_of_state':'slb2',
@@ -56,13 +48,11 @@ class wuestite (Mineral):
             'eta_s_0': 0.8 }
 
 
-
 class ferropericlase(bmb.HelperSolidSolution):
     def __init__(self, fe_num):
         base_materials = [periclase(), wuestite()]
         molar_fraction = [1. - fe_num, 0.0 + fe_num] # keep the 0.0 +, otherwise it is an array sometimes
         bmb.HelperSolidSolution.__init__(self, base_materials, molar_fraction)
-
 
 
 class mg_fe_perovskite(bmb.HelperSolidSolution):
@@ -73,9 +63,6 @@ class mg_fe_perovskite(bmb.HelperSolidSolution):
 
 
 class mg_perovskite(Mineral):
-    """
-    Murakami 2013 and references therin
-    """
     def __init__(self):
         self.params = {
             'equation_of_state':'slb2',
@@ -91,10 +78,8 @@ class mg_perovskite(Mineral):
             'q_0': 1.4,
             'eta_s_0': 2.6 }
 
+
 class fe_perovskite(Mineral):
-    """
-    Murakami 2013 and references therein
-    """
     def __init__(self):
         self.params = {
             'equation_of_state':'slb2',

--- a/burnman/minerals/Murakami_etal_2012.py
+++ b/burnman/minerals/Murakami_etal_2012.py
@@ -6,7 +6,8 @@
 Murakami_etal_2012
 ^^^^^^^^^^^^^^^^^^
 
-Minerals from Murakami et al. (2012) supplementary table 5 and references therein, V_0 from Stixrude & Lithgow-Bertolloni 2005
+Minerals from Murakami et al. (2012) supplementary table 5 and references therein, V_0 from
+Stixrude & Lithgow-Bertolloni 2005. Some information from personal communication with Murakami.
 
 
 """
@@ -14,14 +15,7 @@ import burnman.mineral_helpers as bmb
 from burnman.mineral import Mineral
 
 
-
-
-
-
 class mg_perovskite(Mineral):
-    """
-    Murakami et al. (2012) supplementary table 5 and references therein, V_0 from Stixrude & Lithgow-Bertolloni 2005
-    """
     def __init__(self):
         self.params = {
             'equation_of_state':'slb2',
@@ -37,10 +31,8 @@ class mg_perovskite(Mineral):
             'q_0': 1.4,
             'eta_s_0': 2.4 }
 
+
 class mg_perovskite_3rdorder(Mineral):
-    """
-    Murakami et al. (2012) third order fit to supplementary table 1, includes 4% Al
-    """
     def __init__(self):
         self.params = {
             'equation_of_state':'slb3',
@@ -56,10 +48,8 @@ class mg_perovskite_3rdorder(Mineral):
             'q_0': 1.4,
             'eta_s_0': 2.4 }
 
+
 class fe_perovskite(Mineral):
-    """
-    Murakami et al. (2012), personal communication, Mg#=94, Al=4%
-    """
     def __init__(self):
         self.params = {
             'equation_of_state':'slb2',
@@ -76,11 +66,7 @@ class fe_perovskite(Mineral):
             'eta_s_0': 2.4 }
 
 
-
 class mg_periclase(Mineral):
-    """
-    Murakami et al. (2012) supplementary table 5 and references therein, V_0 from Stixrude & Lithgow-Bertolloni 2005
-    """
     def __init__(self):
         self.params = {
             'equation_of_state':'slb2',
@@ -97,19 +83,17 @@ class mg_periclase(Mineral):
             'eta_s_0': 3.0 }
 
 
-
 class fe_periclase(bmb.HelperSpinTransition):
     def __init__(self):
         bmb.HelperSpinTransition.__init__(self, 63.0e9, fe_periclase_LS(), fe_periclase_HS())
+
 
 class fe_periclase_3rd(bmb.HelperSpinTransition):
     def __init__(self):
         bmb.HelperSpinTransition.__init__(self, 63.0e9, fe_periclase_LS(), fe_periclase_HS())
 
+
 class fe_periclase_HS(Mineral):  # From Murakami's emails, see Cayman for details, represents Mg# = .79
-    """
-    Murakami et al. (2012), personal communication, Mg#=79
-    """
     def __init__(self):
         self.params = {
             'equation_of_state':'slb2',
@@ -125,10 +109,8 @@ class fe_periclase_HS(Mineral):  # From Murakami's emails, see Cayman for detail
             'q_0': 1.5,
             'eta_s_0': 2.54 }
 
+
 class fe_periclase_LS(Mineral):  # From Murakami's emails, see Cayman for details, represents Mg# = .79
-    """
-    Murakami et al. (2012), personal communication, Mg#=79
-    """
     def __init__(self):
         self.params = {
             'equation_of_state':'slb2',
@@ -145,11 +127,7 @@ class fe_periclase_LS(Mineral):  # From Murakami's emails, see Cayman for detail
             'eta_s_0': 2.54}
 
 
-
-class fe_periclase_HS_3rd(Mineral):
-    """
-    Murakami et al. (2012), personal communication, Mg#=92
-    """
+class fe_periclase_HS_3rd(Mineral): # personal communication, Mg#=92
     def __init__(self):
         self.params = {
             'equation_of_state':'slb3',
@@ -165,10 +143,8 @@ class fe_periclase_HS_3rd(Mineral):
             'q_0': 1.5,
             'eta_s_0': 2.54 }
 
-class fe_periclase_LS_3rd(Mineral):
-    """
-    Murakami et al. (2012), personal communication, Mg#=92
-    """
+
+class fe_periclase_LS_3rd(Mineral): # personal communication, Mg#=92
     def __init__(self):
         self.params = {
             'equation_of_state':'slb3',

--- a/burnman/minerals/SLB_2005.py
+++ b/burnman/minerals/SLB_2005.py
@@ -14,9 +14,6 @@ from burnman.mineral import Mineral
 
 
 class stishovite (Mineral):
-    """
-    Stixrude & Lithgow-Bertelloni 2005 and references therein
-    """
     def __init__(self):
         self.params = {
             'equation_of_state': 'slb3',
@@ -32,10 +29,8 @@ class stishovite (Mineral):
             'q_0': 2.4,
             'eta_s_0': 5.0 }
 
+
 class periclase (Mineral):
-    """
-    Stixrude & Lithgow-Bertelloni 2005 and references therein
-    """
     def __init__(self):
         self.params = {
             'equation_of_state':'slb3',
@@ -51,10 +46,8 @@ class periclase (Mineral):
             'q_0': 1.5,
             'eta_s_0': 2.8 }
 
+
 class wuestite (Mineral):
-    """
-    Stixrude & Lithgow-Bertelloni 2005 and references therein
-    """
     def __init__(self):
         self.params = {
             'equation_of_state':'slb3',
@@ -71,13 +64,11 @@ class wuestite (Mineral):
             'eta_s_0': 0.8 }
 
 
-
 class ferropericlase(bmb.HelperSolidSolution):
     def __init__(self, fe_num):
         base_materials = [periclase(), wuestite()]
         molar_fraction = [1. - fe_num, 0.0 + fe_num] # keep the 0.0 +, otherwise it is an array sometimes
         bmb.HelperSolidSolution.__init__(self, base_materials, molar_fraction)
-
 
 
 class mg_fe_perovskite(bmb.HelperSolidSolution):
@@ -88,9 +79,6 @@ class mg_fe_perovskite(bmb.HelperSolidSolution):
 
 
 class mg_perovskite(Mineral):
-    """
-    Stixrude & Lithgow-Bertelloni 2005 and references therein
-    """
     def __init__(self):
         self.params = {
             'equation_of_state':'slb3',
@@ -106,10 +94,8 @@ class mg_perovskite(Mineral):
             'q_0': 1.4,
             'eta_s_0': 2.6 }
 
+
 class fe_perovskite(Mineral):
-    """
-    Stixrude & Lithgow-Bertelloni 2005 and references therein
-    """
     def __init__(self):
         self.params = {
             'equation_of_state':'slb3',
@@ -132,6 +118,7 @@ class mg_fe_perovskite_pt_dependent(bmb.HelperFeDependent):
 
     def create_inner_material(self, iron_number):
         return mg_fe_perovskite(iron_number)
+
 
 class ferropericlase_pt_dependent(bmb.HelperFeDependent):
     def __init__(self, iron_number_with_pt, idx):

--- a/burnman/minerals/SLB_2011.py
+++ b/burnman/minerals/SLB_2011.py
@@ -16,9 +16,6 @@ from burnman.mineral import Mineral
 
 
 class stishovite (Mineral):
-    """
-    Stixrude & Lithgow-Bertelloni 2011 and references therein
-    """
     def __init__(self):
         self.params = {
             'equation_of_state': 'slb3',
@@ -47,9 +44,6 @@ class stishovite (Mineral):
 
 
 class periclase (Mineral):
-    """
-    Stixrude & Lithgow-Bertelloni 2011 and references therein
-    """
     def __init__(self):
         self.params = {
             'equation_of_state':'slb3',
@@ -75,10 +69,8 @@ class periclase (Mineral):
         'err_q_0':.2,
         'err_eta_s_0':.2 }
 
+
 class wuestite (Mineral):
-    """
-    Stixrude & Lithgow-Bertelloni 2011 and references therein
-    """
     def __init__(self):
         self.params = {
             'equation_of_state':'slb3',
@@ -111,16 +103,15 @@ class ferropericlase(bmb.HelperSolidSolution):
         molar_fraction = [1. - fe_num, 0.0 + fe_num] # keep the 0.0 +, otherwise it is an array sometimes
         bmb.HelperSolidSolution.__init__(self, base_materials, molar_fraction)
 
+
 class mg_fe_perovskite(bmb.HelperSolidSolution):
     def __init__(self, fe_num):
         base_materials = [mg_perovskite(), fe_perovskite()]
         molar_fraction = [1. - fe_num, 0.0 + fe_num] # keep the 0.0 +, otherwise it is an array sometimes
         bmb.HelperSolidSolution.__init__(self, base_materials, molar_fraction)
 
+
 class mg_perovskite(Mineral):
-    """
-    Stixrude & Lithgow-Bertelloni 2011 and references therein
-    """
     def __init__(self):
         self.params = {
             'equation_of_state':'slb3',
@@ -148,9 +139,6 @@ class mg_perovskite(Mineral):
 
 
 class fe_perovskite(Mineral):
-    """
-    Stixrude & Lithgow-Bertelloni 2011 and references therein
-    """
     def __init__(self):
         self.params = {
             'equation_of_state':'slb3',
@@ -176,6 +164,7 @@ class fe_perovskite(Mineral):
             'err_q_0':1.0,
             'err_eta_s_0':1.0}
 
+
 class mg_fe_perovskite_pt_dependent(bmb.HelperFeDependent):
     def __init__(self, iron_number_with_pt, idx):
         bmb.HelperFeDependent.__init__(self, iron_number_with_pt, idx)
@@ -183,12 +172,14 @@ class mg_fe_perovskite_pt_dependent(bmb.HelperFeDependent):
     def create_inner_material(self, iron_number):
         return mg_fe_perovskite(iron_number)
 
+
 class ferropericlase_pt_dependent(bmb.HelperFeDependent):
     def __init__(self, iron_number_with_pt, idx):
         bmb.HelperFeDependent.__init__(self, iron_number_with_pt, idx)
 
     def create_inner_material(self, iron_number):
         return ferropericlase(iron_number)
+
 
 mg_bridgmanite = mg_perovskite
 fe_bridgmanite = fe_perovskite

--- a/burnman/minerals/SLB_2011_ZSB_2013.py
+++ b/burnman/minerals/SLB_2011_ZSB_2013.py
@@ -6,7 +6,7 @@
 SLB_2011_ZSB_2013
 ^^^^^^^^^^^^^^^^^
 
-Minerals from Stixrude & Lithgow-Bertelloni 2011 and references therein.
+Minerals from Stixrude & Lithgow-Bertelloni 2011, Zhang, Stixrude & Brodholt 2013, and references therein.
 
 """
 
@@ -14,13 +14,7 @@ import burnman.mineral_helpers as bmb
 from burnman.mineral import Mineral
 
 
-
-
-
 class stishovite (Mineral):
-    """
-    Stixrude & Lithgow-Bertelloni 2011 and references therein
-    """
     def __init__(self):
         self.params = {
             'equation_of_state': 'slb3',
@@ -49,9 +43,6 @@ class stishovite (Mineral):
 
 
 class periclase (Mineral):
-    """
-    Stixrude & Lithgow-Bertelloni 2011 and references therein
-    """
     def __init__(self):
         self.params = {
             'equation_of_state':'slb3',
@@ -77,10 +68,8 @@ class periclase (Mineral):
         'err_q_0':.2,
         'err_eta_s_0':.2 }
 
+
 class wuestite (Mineral):
-    """
-    Stixrude & Lithgow-Bertelloni 2011 and references therein
-    """
     def __init__(self):
         self.params = {
             'equation_of_state':'slb3',
@@ -113,16 +102,15 @@ class ferropericlase(bmb.HelperSolidSolution):
         molar_fraction = [1. - fe_num, 0.0 + fe_num] # keep the 0.0 +, otherwise it is an array sometimes
         bmb.HelperSolidSolution.__init__(self, base_materials, molar_fraction)
 
+
 class mg_fe_perovskite(bmb.HelperSolidSolution):
     def __init__(self, fe_num):
         base_materials = [mg_perovskite(), fe_perovskite()]
         molar_fraction = [1. - fe_num, 0.0 + fe_num] # keep the 0.0 +, otherwise it is an array sometimes
         bmb.HelperSolidSolution.__init__(self, base_materials, molar_fraction)
 
+
 class mg_perovskite(Mineral):
-    """
-    Zhang, Stixrude & Brodholt 2013
-    """
     def __init__(self):
         self.params = {
             'equation_of_state':'slb3',
@@ -150,9 +138,6 @@ class mg_perovskite(Mineral):
 
 
 class fe_perovskite(Mineral):
-    """
-    Stixrude & Lithgow-Bertelloni 2011 and references therein
-    """
     def __init__(self):
         self.params = {
             'equation_of_state':'slb3',
@@ -178,6 +163,7 @@ class fe_perovskite(Mineral):
             'err_q_0':1.0,
             'err_eta_s_0':1.0}
 
+
 class mg_fe_perovskite_pt_dependent(bmb.HelperFeDependent):
     def __init__(self, iron_number_with_pt, idx):
         bmb.HelperFeDependent.__init__(self, iron_number_with_pt, idx)
@@ -185,12 +171,14 @@ class mg_fe_perovskite_pt_dependent(bmb.HelperFeDependent):
     def create_inner_material(self, iron_number):
         return mg_fe_perovskite(iron_number)
 
+
 class ferropericlase_pt_dependent(bmb.HelperFeDependent):
     def __init__(self, iron_number_with_pt, idx):
         bmb.HelperFeDependent.__init__(self, iron_number_with_pt, idx)
 
     def create_inner_material(self, iron_number):
         return ferropericlase(iron_number)
+
 
 mg_bridgmanite = mg_perovskite
 fe_bridgmanite = fe_perovskite

--- a/burnman/minerals/__init__.py
+++ b/burnman/minerals/__init__.py
@@ -4,6 +4,14 @@
 
 """
 Mineral database
+
+  - :mod:`~burnman.minerals.Matas_etal_2007`
+  - :mod:`~burnman.minerals.Murakami_2013`
+  - :mod:`~burnman.minerals.Murakami_etal_2012`
+  - :mod:`~burnman.minerals.SLB_2005`
+  - :mod:`~burnman.minerals.SLB_2011_ZSB_2013`
+  - :mod:`~burnman.minerals.SLB_2011`
+  - :mod:`~burnman.minerals.other`
 """
 
 import Murakami_etal_2012

--- a/burnman/minerals/other.py
+++ b/burnman/minerals/other.py
@@ -6,19 +6,17 @@
 Other minerals
 ^^^^^^^^^^^^^^
 
-Other minerals in burnman.minerals.other are:
-
 """
 
 import burnman.mineral_helpers as bmb
 from burnman.mineral import Mineral
 
 
-
 class Speziale_fe_periclase(bmb.HelperSpinTransition):
     def __init__(self):
         bmb.HelperSpinTransition.__init__(self, 60.0e9, Speziale_fe_periclase_LS(), Speziale_fe_periclase_HS())
         self.cite = 'Speziale et al. 2007'
+
 
 class Speziale_fe_periclase_HS(Mineral):
     """
@@ -35,6 +33,7 @@ class Speziale_fe_periclase_HS(Mineral):
                         'Debye_0': 587,
                         'grueneisen_0': 1.46,
                         'q_0': 1.2 }
+
 
 class Speziale_fe_periclase_LS(Mineral):
     """

--- a/sphinx/mineral_database.rst
+++ b/sphinx/mineral_database.rst
@@ -4,9 +4,16 @@ Mineral database
 .. automodule:: burnman.minerals
 
 .. automodule::  burnman.minerals.Murakami_2013
+  :no-inherited-members:
 .. automodule::  burnman.minerals.SLB_2011
+  :no-inherited-members:
 .. automodule::  burnman.minerals.Matas_etal_2007
+  :no-inherited-members:
 .. automodule::  burnman.minerals.Murakami_etal_2012
+  :no-inherited-members:
 .. automodule::  burnman.minerals.SLB_2005
+  :no-inherited-members:
 .. automodule::  burnman.minerals.SLB_2011_ZSB_2013
+  :no-inherited-members:
 .. automodule::  burnman.minerals.other
+  :no-inherited-members:


### PR DESCRIPTION
By not displaying all the inherited member functions, the mineral
database help page becomes more useful. This commit contains some cleanup in
the .py files. Most notably removing redundant comments mentioning the
source for the minerals.
