### PR TITLE
Update GitHub owner for webpage links.

### DIFF
--- a/homepage/download.html
+++ b/homepage/download.html
@@ -40,7 +40,7 @@ margin-right: 1em;
 
 <a class="toplink" href="download.html">Download</a>
 
-<a class="toplink" href="https://github.com/burnman-project/burnman">Source</a>
+<a class="toplink" href="https://github.com/geodynamics/burnman">Source</a>
 
 <a class="toplink" href="examples.html">Examples</a>
 

--- a/homepage/examples.html
+++ b/homepage/examples.html
@@ -40,7 +40,7 @@ margin-right: 1em;
 
 <a class="toplink" href="download.html">Download</a>
 
-<a class="toplink" href="https://github.com/burnman-project/burnman">Source</a>
+<a class="toplink" href="https://github.com/geodynamics/burnman">Source</a>
 
 <a class="toplink" href="examples.html">Examples</a>
 
@@ -54,8 +54,8 @@ margin-right: 1em;
 
 <p>
 <ul>
-<li><a href="http://nbviewer.ipython.org/github/burnman-project/burnman/blob/master/ipython/Compute_seismic_velocities_beginner.ipynb">Beginner Example</a>
-<li><a href="http://nbviewer.ipython.org/github/burnman-project/burnman/blob/master/ipython/Compute_seismic_velocities_advanced.ipynb">Advanced Example</a>
+<li><a href="http://nbviewer.ipython.org/github/geodynamics/burnman/blob/master/ipython/Compute_seismic_velocities_beginner.ipynb">Beginner Example</a>
+<li><a href="http://nbviewer.ipython.org/github/geodynamics/burnman/blob/master/ipython/Compute_seismic_velocities_advanced.ipynb">Advanced Example</a>
 </ul>
 </p>
 
@@ -67,7 +67,7 @@ margin-right: 1em;
 <li> go to <a href="https://cloud.sagemath.com">https://cloud.sagemath.com</a> and create an account
 <li> create a new project, name it whatever you want, make it private, hit create.
 <li> click on your project to open it
-<li> hit "new", paste in "https://github.com/burnman-project/burnman.git", click
+<li> hit "new", paste in "https://github.com/geodynamics/burnman.git", click
 "from the web" (this will install burnman)
 <li> Go to "file", "open" and navigate to the folder "burnman/ipython" and open one of the ipython example projects.
 <li> You can also copy the files to create your own programs, or upload other ipython files.

--- a/homepage/index.html
+++ b/homepage/index.html
@@ -40,7 +40,7 @@ margin-right: 1em;
 
 <a class="toplink" href="download.html">Download</a>
 
-<a class="toplink" href="https://github.com/burnman-project/burnman">Source</a>
+<a class="toplink" href="https://github.com/geodynamics/burnman">Source</a>
 
 <a class="toplink" href="examples.html">Examples</a>
 

--- a/readme.txt
+++ b/readme.txt
@@ -28,7 +28,7 @@ BurnMan is released under the GNU GPL v2 or newer
 
 Homepage: http://burnman.org
 Documentation: http://burnman.org/current-doc
-Source code: https://github.com/burnman-project/burnman
+Source code: https://github.com/geodynamics/burnman
 
 *** Requirements
 


### PR DESCRIPTION
In perusing the website, I noticed that the IPython examples were broken. This is because the project changed owners, and the old links do not work on nbviewer. I figured now would be a good time to fix the other instances of the old link as well.
