### PR TITLE
Additional check in set_method to avoid user-defined minerals needing to call Mineral.__init__

### DIFF
--- a/burnman/mineral.py
+++ b/burnman/mineral.py
@@ -51,10 +51,12 @@ class Mineral(Material):
         'slb3' or 'mtait'.  Alternatively, you can pass a user defined
         class which derives from the equation_of_state base class.
         """
-
         if equation_of_state is None:
             self.method = None
             return
+
+        if hasattr(self, 'method') == False:
+            self.method = None
 
         new_method = eos.create(equation_of_state)
         if self.method is not None and 'equation_of_state' in self.params:


### PR DESCRIPTION
Not sure what the best way to do this is, but Mark Panning (as well as myself) ran into issues where, with a user-defined mineral, everything fails if **init** is not called.  This breaks backwards compatibility for a fairly silly reason.  

What you you think of this?  It still requires a set_method() call if **init** is not called, but at least it does not crash.
