### PR TITLE
When running tests, don't call savefig.

### DIFF
--- a/misc/paper_averaging.py
+++ b/misc/paper_averaging.py
@@ -150,5 +150,6 @@ if __name__ == "__main__":
 
     plt.xlabel('Pressure (GPa)')
     plt.ylabel('Shear velocity $V_s$ (km/s)')
-    plt.savefig("example_averaging.pdf",bbox_inches='tight')
+    if "RUNNING_TESTS" not in globals():
+        plt.savefig("example_averaging.pdf",bbox_inches='tight')
     plt.show()

--- a/misc/paper_benchmark.py
+++ b/misc/paper_benchmark.py
@@ -113,7 +113,8 @@ def check_slb_fig7_txt():
     plt.xlabel("Temperature (K)")
     plt.ylabel("Difference (\%)")
     plt.legend(loc="lower center",prop=prop,ncol=4)
-    plt.savefig("benchmark1.pdf", bbox_inches='tight')
+    if "RUNNING_TESTS" not in globals():
+        plt.savefig("benchmark1.pdf", bbox_inches='tight')
     plt.show()
 
 if __name__ == "__main__":

--- a/misc/paper_fit_data.py
+++ b/misc/paper_fit_data.py
@@ -109,5 +109,6 @@ if __name__ == "__main__":
         plt.ylabel(r'Shear velocity ${V}_{\mathlarger{\mathlarger{\mathlarger{s}}}}$ (km/s)')
     plt.xlabel("Pressure (GPa)")
     plt.legend(loc = "lower right",prop=prop)
-    plt.savefig("example_fit_data.pdf", bbox_inches='tight')
+    if "RUNNING_TESTS" not in globals():
+        plt.savefig("example_fit_data.pdf", bbox_inches='tight')
     plt.show()

--- a/misc/paper_incorrect_averaging.py
+++ b/misc/paper_incorrect_averaging.py
@@ -200,7 +200,8 @@ if __name__ == "__main__":
     plt.xlabel("Pressure (GPa)")
     plt.ylabel("Shear Velocity Vs (km/s)")
     plt.tight_layout()
-    plt.savefig("example_incorrect_averaging.pdf",bbox_inches='tight')
+    if "RUNNING_TESTS" not in globals():
+        plt.savefig("example_incorrect_averaging.pdf",bbox_inches='tight')
     plt.show()
 
 

--- a/misc/paper_onefit.py
+++ b/misc/paper_onefit.py
@@ -280,6 +280,7 @@ if __name__ == "__main__":
     plt.legend(bbox_to_anchor=(1.0, 0.9),prop={'size':12})
     plt.xlim(25,135)
     #plt.ylim(6,11)
-    plt.savefig("onefit.pdf", bbox_inches='tight')
+    if "RUNNING_TESTS" not in globals():
+        plt.savefig("onefit.pdf", bbox_inches='tight')
     print "wrote onefit.pdf"
     #plt.show()

--- a/misc/paper_opt_pv.py
+++ b/misc/paper_opt_pv.py
@@ -204,5 +204,6 @@ if __name__ == "__main__":
 #    plt.show()
 
     plt.tight_layout()
-    plt.savefig("paper_opt_pv.pdf",bbox_inches='tight')
+    if "RUNNING_TESTS" not in globals():
+        plt.savefig("paper_opt_pv.pdf",bbox_inches='tight')
     plt.show()

--- a/misc/paper_uncertain.py
+++ b/misc/paper_uncertain.py
@@ -147,7 +147,8 @@ if __name__ == "__main__":
 
 
 
-    plt.savefig("uncertain.pdf",bbox_inches='tight')
+    if "RUNNING_TESTS" not in globals():
+        plt.savefig("uncertain.pdf",bbox_inches='tight')
 #    plt.show()
 
 

--- a/misc/paper_uncertainty.py
+++ b/misc/paper_uncertainty.py
@@ -143,7 +143,8 @@ if __name__ == "__main__":
 
 
 
-    plt.savefig("uncertain.pdf",bbox_inches='tight')
+    if "RUNNING_TESTS" not in globals():
+        plt.savefig("uncertain.pdf",bbox_inches='tight')
 #    plt.show()
 
 

--- a/misc/pyrolite_uncertainty.py
+++ b/misc/pyrolite_uncertainty.py
@@ -637,5 +637,6 @@ elif whattodo=="plot":
     #save and show the image
     fig = plt.gcf()
     fig.set_size_inches(6.0, 6.0)
-    fig.savefig("pyrolite_uncertainty.pdf",bbox_inches='tight', dpi=100)
+    if "RUNNING_TESTS" not in globals():
+        fig.savefig("pyrolite_uncertainty.pdf",bbox_inches='tight', dpi=100)
     plt.show()


### PR DESCRIPTION
The do-nothing `Template` backend appears to be bugged (as far as I can tell) for at least a few versions of matplotlib when using TeX rendering. Since we don't care about the output when running tests, we can just not call savefig().