### PR TITLE
Updated Composite

### DIFF
--- a/burnman/composite.py
+++ b/burnman/composite.py
@@ -156,6 +156,7 @@ class Composite(Material):
         self.temperature = temperature
         for phase in self.phases:
             phase.set_state(pressure, temperature)
+        self.rho = self.Vp = self.Vs = self.Vphi = self.K = self.G = None
 
     def density(self):
         """
@@ -168,7 +169,7 @@ class Composite(Material):
             raise Exception("Density cannot be computed without phase fractions being defined.")
         return np.sum(densities*volumes)/np.sum(volumes)
 
-    def calculate_moduli(self):
+    def _calculate_moduli(self):
         """
         Calculate the elastic moduli and densities of the individual phases in the assemblage.
 
@@ -230,7 +231,7 @@ class Composite(Material):
     
         return molar_fractions
 
-    def elastic_properties(self, averaging_scheme=averaging_schemes.VoigtReussHill()):
+    def calculate_elastic_properties(self, averaging_scheme=averaging_schemes.VoigtReussHill()):
         """
         Calculates the seismic velocities of the Assemblage, using
         an averaging scheme for the velocities of individual phases
@@ -242,14 +243,12 @@ class Composite(Material):
         :rtype: lists of floats
 
         """
-        moduli = [self.calculate_moduli()]
+        moduli = [self._calculate_moduli()]
         moduli = burnman.average_moduli(moduli, averaging_scheme)[0]
         self.Vp, self.Vs, self.Vphi = burnman.compute_velocity(moduli)
         self.rho = moduli.rho
         self.K = moduli.K
         self.G = moduli.G
-
-        return self.rho, self.Vp, self.Vs, self.Vphi, self.K, self.G
 
     def chemical_potentials(self, component_formulae):
         component_formulae_dict=[chemicalpotentials.dictionarize_formula(f) for f in component_formulae]
@@ -264,3 +263,4 @@ class Composite(Material):
         """
         molar_mass = sum([ self.phases[i][0].molar_mass()*self.molar_fractions[i] for i in range(self.n_endmembers) ])
         return molar_mass
+

--- a/burnman/composite.py
+++ b/burnman/composite.py
@@ -46,45 +46,54 @@ class Composite(Material):
 
         
         assert(len(phases)>0)
+
+        self.phases = phases
         
         if fractions is not None:
             assert(len(phases)==len(fractions))
             for f in fractions:
                 assert (f >= -1e-12)
-                fractions = [max(0.0, fraction) for fraction in fractions]  # turn -1e-12 into 0.0
-                try:
-                    total = sum(fractions)
-                except TypeError:
-                    raise Exception("Since v0.8, burnman.Composite takes an array of Materials, then an array of fractions")
-                if abs(total - 1.0) > 1e-12:
-                    warnings.warn("Warning: list of molar fractions does not add up to one but %g. Normalizing." % total)
-                    fractions = [fr / total for fr in fractions]
+            self.fractions = [max(0.0, fraction) for fraction in fractions]  # turn -1e-12 into 0.0
+            try:
+                total = sum(fractions)
+            except TypeError:
+                raise Exception("Since v0.8, burnman.Composite takes an array of Materials, then an array of fractions")
+            if abs(total - 1.0) > 1e-12:
+                warnings.warn("Warning: list of molar fractions does not add up to one but %g. Normalizing." % total)
+                self.fractions = [fr / total for fr in fractions]
+        else:
+                self.fractions=None
 
-        self.children = zip(phases, fractions)
 
     def debug_print(self, indent=""):
         print "%sComposite:" % indent
         indent += "  "
-        for (phase, fraction) in self.children:
-            print "%s%g of" % (indent, fraction)
-            phase.debug_print(indent + "  ")
-
+        try: # if fractions have been defined
+            for i, phase in enumerate(self.phases):
+                print "%s%g of" % (indent, self.fractions[i])
+                phase.debug_print(indent + "  ")
+        except:
+            for i, phase in enumerate(self.phases):
+                phase.debug_print(indent + "  ")
 
     def set_method(self, method):
         """
         set the same equation of state method for all the phases in the composite
         """
-        for (phase, fraction) in self.children:
+        for phase in self.phases:
             phase.set_method(method)
 
     def unroll(self):
         phases = []
         fractions = []
-        for (phase, fraction) in self.children:
-            p_mineral, p_fraction = phase.unroll()
-            check_pairs(p_mineral, p_fraction)
-            fractions.extend([i*fraction for i in p_fraction])
-            phases.extend(p_mineral)
+        try:
+            for i, phase in enumerate(self.phases):
+                p_mineral, p_fraction = phase.unroll()
+                check_pairs(p_mineral, p_fraction)
+                fractions.extend([f*self.fractions[i] for f in p_fraction])
+                phases.extend(p_mineral)
+        except:
+            raise Exception("Unroll only works if the composite has defined fractions.")
         return (phases, fractions)
 
     def to_string(self):
@@ -99,14 +108,17 @@ class Composite(Material):
         """
         self.pressure = pressure
         self.temperature = temperature
-        for (phase, fraction) in self.children:
+        for phase in self.phases:
             phase.set_state(pressure, temperature)
 
     def density(self):
         """
         Compute the density of the composite based on the molar volumes and masses
         """
-        densities = np.array([phase.density() for (phase,_) in self.children])
-        volumes = np.array([phase.molar_volume()*fraction for (phase, fraction) in self.children])
+        try:
+            densities = np.array([phase.density() for phase in self.phases])
+            volumes = np.array([phase.molar_volume()*fraction for (phase, fraction) in zip(self.phases, self.fractions)])
+        except:
+            raise Exception("Density cannot be computed without phase fractions being defined.")
         return np.sum(densities*volumes)/np.sum(volumes)
 

--- a/burnman/composite.py
+++ b/burnman/composite.py
@@ -8,19 +8,19 @@ import warnings
 from burnman import Material
 from burnman import Mineral
 
-def check_pairs(fractions, minerals):
+def check_pairs(phases, fractions):
         if len(fractions) < 1:
-            raise Exception('ERROR: we need at least one mineral')
+            raise Exception('ERROR: we need at least one phase')
 
-        if len(fractions) != len(minerals):
-            raise Exception('ERROR: different array lengths')
+        if len(phases) != len(fractions):
+            raise Exception('ERROR: different array lengths for phases and fractions')
 
         total = sum(fractions)
         if abs(total-1.0)>1e-10:
             raise Exception('ERROR: list of molar fractions does not add up to one')
-        for p in minerals:
+        for p in phases:
             if not isinstance(p, Mineral):
-                raise Exception('ERROR: object of type ''%s'' is not of type material' % (type(p)))
+                raise Exception('ERROR: object of type ''%s'' is not of type Mineral' % (type(p)))
 
 
 # static composite of minerals/composites
@@ -32,42 +32,40 @@ class Composite(Material):
 
     This class is available as ``burnman.Composite``.
     """
-    def __init__(self, fractions, phases=None):
+    def __init__(self, phases, fractions=None):
         """
         Create a composite using a list of phases and their fractions (adding to 1.0).
 
         Parameters
         ----------
-        fractions: list of floats
-            molar fraction for each phase.
         phases: list of :class:`burnman.Material`
             list of phases.
+        fractions: list of floats
+            molar fraction for each phase.
         """
 
-        if phases is None:
-            # compatibility hack:
-            tmp = fractions
-            fractions = [pt[1] for pt in tmp]
-            phases = [pt[0] for pt in tmp]
-
-        assert(len(phases)==len(fractions))
+        
         assert(len(phases)>0)
-        for f in fractions:
-            # we would like to check for >= 0, but this creates nasty behavior due to
-            # floating point rules: 1.0-0.8-0.1-0.1 is not 0.0 but -1e-14.
-            assert (f >= -1e-12)
-        fractions = [max(0.0, fr) for fr in fractions]  # turn -1e-14 into 0.0
-        total = sum(fractions)
-        if abs(total - 1.0) > 1e-12:
-            warnings.warn("Warning: list of molar fractions does not add up to one but %g. Normalizing." % total)
-            fractions = [fr / total for fr in fractions]
+        
+        if fractions is not None:
+            assert(len(phases)==len(fractions))
+            for f in fractions:
+                assert (f >= -1e-12)
+                fractions = [max(0.0, fraction) for fraction in fractions]  # turn -1e-12 into 0.0
+                try:
+                    total = sum(fractions)
+                except TypeError:
+                    raise Exception("Since v0.8, burnman.Composite takes an array of Materials, then an array of fractions")
+                if abs(total - 1.0) > 1e-12:
+                    warnings.warn("Warning: list of molar fractions does not add up to one but %g. Normalizing." % total)
+                    fractions = [fr / total for fr in fractions]
 
-        self.children = zip(fractions, phases)
+        self.children = zip(phases, fractions)
 
     def debug_print(self, indent=""):
         print "%sComposite:" % indent
         indent += "  "
-        for (fraction, phase) in self.children:
+        for (phase, fraction) in self.children:
             print "%s%g of" % (indent, fraction)
             phase.debug_print(indent + "  ")
 
@@ -76,19 +74,18 @@ class Composite(Material):
         """
         set the same equation of state method for all the phases in the composite
         """
-        for (fraction, phase) in self.children:
+        for (phase, fraction) in self.children:
             phase.set_method(method)
 
     def unroll(self):
+        phases = []
         fractions = []
-        minerals = []
-
-        for (fraction, phase) in self.children:
-            p_fr,p_min = phase.unroll()
-            check_pairs(p_fr, p_min)
-            fractions.extend([i*fraction for i in p_fr])
-            minerals.extend(p_min)
-        return (fractions, minerals)
+        for (phase, fraction) in self.children:
+            p_mineral, p_fraction = phase.unroll()
+            check_pairs(p_mineral, p_fraction)
+            fractions.extend([i*fraction for i in p_fraction])
+            phases.extend(p_mineral)
+        return (phases, fractions)
 
     def to_string(self):
         """
@@ -102,14 +99,14 @@ class Composite(Material):
         """
         self.pressure = pressure
         self.temperature = temperature
-        for (fraction, phase) in self.children:
+        for (phase, fraction) in self.children:
             phase.set_state(pressure, temperature)
 
     def density(self):
         """
         Compute the density of the composite based on the molar volumes and masses
         """
-        densities = np.array([ph.density() for (_,ph) in self.children])
-        volumes = np.array([ph.molar_volume()*fraction for (fraction, ph) in self.children])
+        densities = np.array([phase.density() for (phase,_) in self.children])
+        volumes = np.array([phase.molar_volume()*fraction for (phase, fraction) in self.children])
         return np.sum(densities*volumes)/np.sum(volumes)
 

--- a/burnman/composite.py
+++ b/burnman/composite.py
@@ -5,6 +5,7 @@
 import numpy as np
 import warnings
 
+from burnman import averaging_schemes
 from burnman import Material
 from burnman import Mineral
 
@@ -32,7 +33,7 @@ class Composite(Material):
 
     This class is available as ``burnman.Composite``.
     """
-    def __init__(self, phases, fractions=None):
+    def __init__(self, phases, fractions=None, fraction_type='molar'):
         """
         Create a composite using a list of phases and their fractions (adding to 1.0).
 
@@ -51,18 +52,35 @@ class Composite(Material):
         
         if fractions is not None:
             assert(len(phases)==len(fractions))
-            for f in fractions:
-                assert (f >= -1e-12)
-            self.fractions = [max(0.0, fraction) for fraction in fractions]  # turn -1e-12 into 0.0
+
             try:
                 total = sum(fractions)
             except TypeError:
                 raise Exception("Since v0.8, burnman.Composite takes an array of Materials, then an array of fractions")
+
+            for f in fractions:
+                assert (f >= -1e-12)
+
             if abs(total - 1.0) > 1e-12:
-                warnings.warn("Warning: list of molar fractions does not add up to one but %g. Normalizing." % total)
-                self.fractions = [fr / total for fr in fractions]
+                warnings.warn("Warning: list of fractions does not add up to one but %g. Normalizing." % total)
+                corrected_fractions = [fr / total for fr in fractions]
+                fractions = corrected_fractions
+
+
+            if fraction_type == 'molar':
+                molar_fractions = fractions
+            elif fraction_type == 'mass':
+                molar_fractions = self._mass_to_molar_fractions(self.phases, fractions)
+            elif fraction_type == 'volume':
+                molar_fractions = self._volume_to_molar_fractions(self.phases, fractions)
+            else:
+                raise Exception("Fraction type not recognised. Please use 'molar', 'mass' or 'volume'")
+
+            # Set minimum value of a molar fraction at 0.0 (rather than -1.e-12)
+            self.molar_fractions = [max(0.0, fraction) for fraction in molar_fractions]  
+                
         else:
-                self.fractions=None
+                self.molar_fractions=None
 
 
     def debug_print(self, indent=""):
@@ -70,7 +88,7 @@ class Composite(Material):
         indent += "  "
         try: # if fractions have been defined
             for i, phase in enumerate(self.phases):
-                print "%s%g of" % (indent, self.fractions[i])
+                print "%s%g of" % (indent, self.molar_fractions[i])
                 phase.debug_print(indent + "  ")
         except:
             for i, phase in enumerate(self.phases):
@@ -90,7 +108,7 @@ class Composite(Material):
             for i, phase in enumerate(self.phases):
                 p_mineral, p_fraction = phase.unroll()
                 check_pairs(p_mineral, p_fraction)
-                fractions.extend([f*self.fractions[i] for f in p_fraction])
+                fractions.extend([f*self.molar_fractions[i] for f in p_fraction])
                 phases.extend(p_mineral)
         except:
             raise Exception("Unroll only works if the composite has defined fractions.")
@@ -117,8 +135,104 @@ class Composite(Material):
         """
         try:
             densities = np.array([phase.density() for phase in self.phases])
-            volumes = np.array([phase.molar_volume()*fraction for (phase, fraction) in zip(self.phases, self.fractions)])
+            volumes = np.array([phase.molar_volume()*molar_fraction for (phase, molar_fraction) in zip(self.phases, self.molar_fractions)])
         except:
             raise Exception("Density cannot be computed without phase fractions being defined.")
         return np.sum(densities*volumes)/np.sum(volumes)
 
+    def calculate_moduli(self):
+        """
+        Calculate the elastic moduli and densities of the individual phases in the assemblage.
+
+        :returns:
+        answer -- an array of (n_evaluation_points by n_phases) of
+        elastic_properties(), so the result is of the form
+        answer[pressure_idx][phase_idx].V
+        :rtype: list of list of :class:`burnman.elastic_properties`
+        """
+        elastic_properties_of_phases = []
+        (minerals, molar_fractions) = self.unroll()
+        volume_fractions = self._molar_to_volume_fractions(minerals, molar_fractions)
+
+        for (mineral, volume_fraction) in zip(minerals, volume_fractions):
+
+            e = burnman.ElasticProperties()
+            e.V = volume_fraction * mineral.molar_volume()
+            e.K = mineral.adiabatic_bulk_modulus()
+            e.G = mineral.shear_modulus()
+            e.rho = mineral.molar_mass() / mineral.molar_volume()
+            e.fraction = volume_fraction
+            elastic_properties_of_phases.append(e)
+
+        return elastic_properties_of_phases
+
+    def _molar_to_volume_fractions(self, minerals, molar_fractions):
+        total_volume=0.
+        try:
+            for i, mineral in enumerate(minerals):
+                total_volume+=molar_fractions[i]*mineral.V
+            volume_fractions=[]
+            for i, mineral in enumerate(minerals):
+                volume_fractions.append(molar_fractions[i]*mineral.V/total_volume)
+        except AttributeError:
+            raise Exception("Volume fractions cannot be set before set_state.")
+    
+        return volume_fractions
+
+    def _volume_to_molar_fractions(self, minerals, volume_fractions):
+        total_moles=0.
+        for i, mineral in enumerate(minerals):
+            total_moles+=volume_fractions[i]/mineral.V
+        molar_fractions=[]
+        for i, mineral in enumerate(minerals):
+            molar_fractions.append(volume_fractions[i]/(mineral.V*total_moles))
+            
+        return molar_fractions
+
+    def _mass_to_molar_fractions(self, minerals, mass_fractions):
+        total_moles=0.
+        try:
+            for i, mineral in enumerate(minerals):
+                total_moles+=mass_fractions[i]/mineral.molar_mass()
+            molar_fractions=[]
+            for i, mineral in enumerate(minerals):
+                molar_fractions.append(mass_fractions[i]/(mineral.molar_mass()*total_moles))
+        except AttributeError:
+            raise Exception("Mass fractions cannot be set before composition has been set for all the phases in the composite.")
+    
+        return molar_fractions
+
+    def elastic_properties(self, averaging_scheme=averaging_schemes.VoigtReussHill()):
+        """
+        Calculates the seismic velocities of the Assemblage, using
+        an averaging scheme for the velocities of individual phases
+
+        :type averaging_scheme: :class:`burnman.averaging_schemes.averaging_scheme`
+        :param averaging_scheme: Averaging scheme to use.
+
+        :returns: :math:`\\rho` :math:`[kg/m^3]` , :math:`V_p, V_s,` and :math:`V_{\phi}` :math:`[m/s]`, bulk modulus :math:`K` :math:`[Pa]`,shear modulus :math:`G` :math:`[Pa]`
+        :rtype: lists of floats
+
+        """
+        moduli = [self.calculate_moduli()]
+        moduli = burnman.average_moduli(moduli, averaging_scheme)[0]
+        self.Vp, self.Vs, self.Vphi = burnman.compute_velocity(moduli)
+        self.rho = moduli.rho
+        self.K = moduli.K
+        self.G = moduli.G
+
+        return self.rho, self.Vp, self.Vs, self.Vphi, self.K, self.G
+
+    def chemical_potentials(self, component_formulae):
+        component_formulae_dict=[burnman.chemicalpotentials.dictionarize_formula(f) for f in component_formulae]
+        return burnman.chemicalpotentials.chemical_potentials(self.phases, component_formulae_dict)
+
+    def fugacity(self, standard_material):
+        return burnman.chemicalpotentials.fugacity(standard_material, self.phases)
+
+    def molar_mass(self):
+        """
+        Returns molar mass of the composite [kg/mol]
+        """
+        molar_mass = sum([ self.phases[i][0].molar_mass()*self.molar_fractions[i] for i in range(self.n_endmembers) ])
+        return molar_mass

--- a/burnman/composite.py
+++ b/burnman/composite.py
@@ -60,11 +60,11 @@ class Composite(Material):
                 self.phase_names.append('')
         
         if fractions is not None:
-            self.set_phase_fractions(fractions, fraction_type)
+            self.set_fractions(fractions, fraction_type)
         else:
             self.molar_fractions=None
 
-    def set_phase_fractions(self, fractions, fraction_type='molar'):
+    def set_fractions(self, fractions, fraction_type='molar'):
         assert(len(self.phases)==len(fractions))
 
         try:

--- a/burnman/geotherm.py
+++ b/burnman/geotherm.py
@@ -126,14 +126,14 @@ def dTdP(temperature, pressure, rock):
     top = 0
     bottom = 0
     rock.set_state(pressure, temperature)
-    (fractions,minerals) = rock.unroll()
-    for (fr,mineral) in zip(fractions,minerals):
+    (minerals, fractions) = rock.unroll()
+    for (mineral, fraction) in zip(minerals, fractions):
         gr = mineral.grueneisen_parameter()
         K_s = mineral.adiabatic_bulk_modulus()
         C_p = mineral.heat_capacity_p()
 
-        top += fr*gr*C_p/K_s
-        bottom += fr*C_p
+        top += fraction*gr*C_p/K_s
+        bottom += fraction*C_p
 
     return temperature*top/bottom
 

--- a/burnman/main.py
+++ b/burnman/main.py
@@ -124,17 +124,30 @@ def compute_velocities(moduli):
 
 
     """
-    mat_vs = np.ndarray(len(moduli))
     mat_vp = np.ndarray(len(moduli))
+    mat_vs = np.ndarray(len(moduli))
     mat_vphi = np.ndarray(len(moduli))
 
     for i in range(len(moduli)):
-
-        mat_vs[i] = np.sqrt( moduli[i].G / moduli[i].rho)
-        mat_vp[i] = np.sqrt( (moduli[i].K + 4./3.*moduli[i].G) / moduli[i].rho)
-        mat_vphi[i] = np.sqrt( moduli[i].K / moduli[i].rho)
+        mat_vp[i], mat_vs[i], mat_vphi[i] = compute_velocity(moduli[i])
 
     return mat_vp, mat_vs, mat_vphi
+
+def compute_velocity(moduli):
+    """
+    Given an instance of elastic_properties, compute the seismic velocities :math:`V_p, V_s,` 
+    and :math:`V_{\phi}` :math:`[m/s]`.
+    :type moduli: :class:`ElasticProperties`
+    :param moduli: input elastic properties.
+    :returns: :math:`V_p, V_s,` and :math:`V_{\phi}` :math:`[m/s]`
+    :rtype: float, float, float
+    """
+
+    vs = np.sqrt( moduli.G / moduli.rho)
+    vp = np.sqrt( (moduli.K + 4./3.*moduli.G) / moduli.rho)
+    vphi = np.sqrt( moduli.K / moduli.rho)
+
+    return vp, vs, vphi
 
 
 def velocities_from_rock(rock, pressures, temperatures, averaging_scheme=burnman.averaging_schemes.VoigtReussHill()):

--- a/burnman/main.py
+++ b/burnman/main.py
@@ -58,8 +58,8 @@ def calculate_moduli(rock, pressures, temperatures):
 
     for idx in range(len(pressures)):
         rock.set_state(pressures[idx], temperatures[idx])
-        (fractions,minerals) = rock.unroll()
-        for (fraction,mineral) in zip(fractions,minerals):
+        (minerals,fractions) = rock.unroll()
+        for (mineral,fraction) in zip(minerals,fractions):
             e = ElasticProperties()
             e.V = fraction * mineral.molar_volume()
             e.K = mineral.adiabatic_bulk_modulus()

--- a/burnman/material.py
+++ b/burnman/material.py
@@ -57,13 +57,13 @@ class Material(object):
         Print a human-readable representation of this Material at the current P, T as a list of minerals.
         This requires set_state() has been called before.
         """
-        (frs,mins) = self.unroll()
-        if len(mins)==1:
-            print mins[0].to_string()
+        (minerals, fractions) = self.unroll()
+        if len(minerals)==1:
+            print minerals[0].to_string()
         else:
             print "Material %s:" % self.to_string()
-            for (fr,mi) in zip(frs,mins):
-                print "  %g of phase %s" % (fr, mi.to_string())
+            for (mineral, fraction) in zip(minerals, fractions):
+                print "  %g of phase %s" % (fraction, mineral.to_string())
 
     def set_state(self, pressure, temperature):
         """

--- a/burnman/mineral.py
+++ b/burnman/mineral.py
@@ -96,7 +96,7 @@ class Mineral(Material):
         print "%s%s" % (indent, self.to_string())
 
     def unroll(self):
-        return ([1.0],[self])
+        return ([self], [1.0])
 
     def eos_pressure(self, temperature, volume):
         return self.method.pressure(temperature, volume, self.params)

--- a/burnman/mineral.py
+++ b/burnman/mineral.py
@@ -43,8 +43,6 @@ class Mineral(Material):
         self.method = None
         if 'equation_of_state' in self.params:
             self.set_method(self.params['equation_of_state'])
-        if 'formula' in self.params:
-            self.composition=self.params['formula']
         if 'name' in self.params:
             self.name=self.params['name']
 
@@ -160,6 +158,9 @@ class Mineral(Material):
     def calcgibbs(self, pressure, temperature):
         return self.method.gibbs_free_energy(pressure, temperature, self.params)
 
+    def composition(self):
+        return self.params['formula']
+    
     def molar_mass(self):
         """
         Returns molar mass of the mineral [kg/mol]

--- a/burnman/mineral.py
+++ b/burnman/mineral.py
@@ -43,7 +43,12 @@ class Mineral(Material):
         self.method = None
         if 'equation_of_state' in self.params:
             self.set_method(self.params['equation_of_state'])
+        if 'formula' in self.params:
+            self.composition=self.params['formula']
+        if 'name' in self.params:
+            self.name=self.params['name']
 
+            
     def set_method(self, equation_of_state):
         """
         Set the equation of state to be used for this mineral.

--- a/burnman/mineral_helpers.py
+++ b/burnman/mineral_helpers.py
@@ -117,7 +117,7 @@ class HelperSpinTransition(Material):
 
     def unroll(self):
         """ return (fractions, minerals) where both are arrays. May depend on current state """
-        return ([1.0], [self.active_mat])
+        return ([self.active_mat],[1.0])
 
     def density(self):
         return self.active_mat.density()
@@ -168,7 +168,7 @@ class HelperFeDependent(Material):
 
     def unroll(self):
         """ return (fractions, minerals) where both are arrays. May depend on current state """
-        return ([1.0],[self.endmembers])
+        return ([self.endmembers],[1.0])
 
     def density(self):
         return self.endmembers.density()

--- a/burnman/model.py
+++ b/burnman/model.py
@@ -97,8 +97,8 @@ class Model(object):
 
                 for idx in range(len(self.p)):
                     self.rock.set_state(self.p[idx], self.T[idx])
-                    (fractions, minerals) = self.rock.unroll()
-                    for (fraction, mineral) in zip(fractions, minerals):
+                    (minerals, fractions) = self.rock.unroll()
+                    for (mineral, fraction) in zip(minerals, fractions):
                         e = {}
                         e['fraction'] = fraction
                         e['V'] = fraction * mineral.molar_volume()

--- a/burnman/solidsolution.py
+++ b/burnman/solidsolution.py
@@ -115,9 +115,9 @@ class SolidSolution(Mineral):
         for i, composition in enumerate(self.endmember_compositions):
             for element in composition:
                 if element not in self.composition:
-                    self.composition[element] = molar_fraction[i]*composition[element]
+                    self.composition[element] = molar_fractions[i]*composition[element]
                 else:
-                    self.composition[element] += molar_fraction[i]*composition[element]
+                    self.composition[element] += molar_fractions[i]*composition[element]
 
         
     def set_method(self, method):

--- a/burnman/solidsolution.py
+++ b/burnman/solidsolution.py
@@ -86,11 +86,10 @@ class SolidSolution(Mineral):
             self.endmembers[i][0].set_method(self.endmembers[i][0].params['equation_of_state'])
 
         # Endmember compositions
-        self.endmember_compositions=[self.endmembers[i][0].composition for i in range(self.n_endmembers)]
+        self.endmember_compositions=[self.endmembers[i][0].composition() for i in range(self.n_endmembers)]
         
         # Molar fractions
         if molar_fractions is not None:
-            self.molar_fractions = molar_fractions
             self.set_composition(molar_fractions)
 
     def get_endmembers(self):
@@ -111,15 +110,16 @@ class SolidSolution(Mineral):
         self.molar_fractions = molar_fractions 
 
         # Mineral composition
-        self.composition=dict()
-        for i, composition in enumerate(self.endmember_compositions):
-            for element in composition:
-                if element not in self.composition:
-                    self.composition[element] = molar_fractions[i]*composition[element]
+    def composition(self):
+        bulk_composition=dict()
+        for i, mbr_composition in enumerate(self.endmember_compositions):
+            for element in mbr_composition:
+                if element not in bulk_composition:
+                    bulk_composition[element] = self.molar_fractions[i]*mbr_composition[element]
                 else:
-                    self.composition[element] += molar_fractions[i]*composition[element]
-
-        
+                    bulk_composition[element] += self.molar_fractions[i]*mbr_composition[element]
+        return bulk_composition
+                    
     def set_method(self, method):
         for i in range(self.n_endmembers):
             self.endmembers[i][0].set_method(method)

--- a/burnman/solidsolution.py
+++ b/burnman/solidsolution.py
@@ -72,9 +72,23 @@ class SolidSolution(Mineral):
         # Number of endmembers in the solid solution
         self.n_endmembers = len(self.endmembers)
 
+        # Endmember names
+        self.endmember_names = []
+        for i in range(self.n_endmembers):
+            self.endmembers[i][0].set_method(self.endmembers[i][0].params['equation_of_state'])
+            try:
+                self.endmember_names.append(self.endmembers[i][0].params['name'])
+            except AttributeError:
+                self.endmember_names.append('')
+
+        # Equation of state
         for i in range(self.n_endmembers):
             self.endmembers[i][0].set_method(self.endmembers[i][0].params['equation_of_state'])
 
+        # Endmember compositions
+        self.endmember_compositions=[self.endmembers[i][0].composition for i in range(self.n_endmembers)]
+        
+        # Molar fractions
         if molar_fractions is not None:
             self.molar_fractions = molar_fractions
             self.set_composition(molar_fractions)
@@ -96,6 +110,16 @@ class SolidSolution(Mineral):
         assert(sum(molar_fractions) < 1.0001)
         self.molar_fractions = molar_fractions 
 
+        # Mineral composition
+        self.composition=dict()
+        for i, composition in enumerate(self.endmember_compositions):
+            for element in composition:
+                if element not in self.composition:
+                    self.composition[element] = molar_fraction[i]*composition[element]
+                else:
+                    self.composition[element] += molar_fraction[i]*composition[element]
+
+        
     def set_method(self, method):
         for i in range(self.n_endmembers):
             self.endmembers[i][0].set_method(method)

--- a/examples/example_averaging.py
+++ b/examples/example_averaging.py
@@ -55,9 +55,9 @@ if __name__ == "__main__":
 
     amount_perovskite = 0.6
 
-    rock = burnman.Composite([amount_perovskite, 1.0-amount_perovskite],
-                             [minerals.SLB_2011.mg_perovskite(),
-                              minerals.SLB_2011.periclase()])
+    rock = burnman.Composite([minerals.SLB_2011.mg_perovskite(),
+                              minerals.SLB_2011.periclase()],
+                             [amount_perovskite, 1.0-amount_perovskite])
 
     perovskitite = minerals.SLB_2011.mg_perovskite()
 

--- a/examples/example_beginner.py
+++ b/examples/example_beginner.py
@@ -57,8 +57,9 @@ if __name__ == "__main__":
     # and 20% periclase.  More minerals may be added by simply extending
     # the list given to burnman.composite
     # For the preset minerals from the SLB_2011, the equation of state formulation from Stixrude and Lithgow-Bertolloni (2005) will be used.
-    rock = burnman.Composite([0.8, 0.2], [minerals.SLB_2011.mg_perovskite(),
-                                          minerals.SLB_2011.periclase()])
+    rock = burnman.Composite([minerals.SLB_2011.mg_perovskite(),
+                              minerals.SLB_2011.periclase()], \
+                             [0.8, 0.2])
 
 
     # Here we create and load the PREM seismic velocity model, which will be

--- a/examples/example_build_planet.py
+++ b/examples/example_build_planet.py
@@ -96,9 +96,9 @@ if __name__ == "__main__":
             #The planet will be represented by a two layer model, mantle and core.  
             #The top layer will be a composite of 80% perovskite and 20% periclase.
             amount_olivine = 0.8
-            self.mantle = burnman.Composite( [amount_olivine, 1.0-amount_olivine],
-                                             [minerals.SLB_2011.forsterite(),
-                                              minerals.SLB_2011.enstatite()] )
+            self.mantle = burnman.Composite([minerals.SLB_2011.forsterite(),
+                                             minerals.SLB_2011.enstatite()],
+                                            [amount_olivine, 1.0-amount_olivine] )
              #The core will be represented by solid iron.
             self.core = iron() 
 

--- a/examples/example_compare_all_methods.py
+++ b/examples/example_compare_all_methods.py
@@ -36,9 +36,9 @@ if __name__ == "__main__":
     #Input composition.
 
     amount_perovskite = 0.95
-    rock = burnman.Composite([amount_perovskite, 1.0-amount_perovskite],
-                             [minerals.Murakami_etal_2012.fe_perovskite(),
-                              minerals.Murakami_etal_2012.fe_periclase_LS()])
+    rock = burnman.Composite([minerals.Murakami_etal_2012.fe_perovskite(),
+                              minerals.Murakami_etal_2012.fe_periclase_LS()],\
+                             [amount_perovskite, 1.0-amount_perovskite])
 
     #(min pressure, max pressure, pressure step)
     seis_p = np.arange(25e9, 125e9, 5e9)

--- a/examples/example_compare_enstpyro.py
+++ b/examples/example_compare_enstpyro.py
@@ -45,9 +45,9 @@ if __name__ == "__main__":
     Kd_0 = .5
     iron_content = lambda p,t: burnman.calculate_partition_coefficient \
             (p,t,relative_molar_percent_pyro, Kd_0)
-    pyrolite = burnman.Composite([phase_fractions_pyro['pv'], phase_fractions_pyro['fp']],
-                                 [minerals.SLB_2005.mg_fe_perovskite_pt_dependent(iron_content,0),
-                                  minerals.SLB_2005.ferropericlase_pt_dependent(iron_content,1)])
+    pyrolite = burnman.Composite([minerals.SLB_2005.mg_fe_perovskite_pt_dependent(iron_content,0),
+                                  minerals.SLB_2005.ferropericlase_pt_dependent(iron_content,1)],\
+                                 [phase_fractions_pyro['pv'], phase_fractions_pyro['fp']])
 
     #input pressure range for first model.
     seis_p_1 = np.arange(25e9, 125e9, 5e9)
@@ -68,9 +68,9 @@ if __name__ == "__main__":
         calculate_phase_percents(weight_percents_enst)
     iron_content = lambda p,t: burnman.calculate_partition_coefficient \
             (p,t,relative_molar_percent_enst, Kd_0)
-    enstatite = burnman.Composite ([phase_fractions_enst['pv'], phase_fractions_enst['fp']], \
-                                   [minerals.SLB_2005.mg_fe_perovskite_pt_dependent(iron_content,0), \
-                                    minerals.SLB_2005.ferropericlase_pt_dependent(iron_content,1)] )
+    enstatite = burnman.Composite ([minerals.SLB_2005.mg_fe_perovskite_pt_dependent(iron_content,0), \
+                                    minerals.SLB_2005.ferropericlase_pt_dependent(iron_content,1)], \
+                                   [phase_fractions_enst['pv'], phase_fractions_enst['fp']])
 
 
     #input second pressure range. Same as the first for comparison

--- a/examples/example_composite.py
+++ b/examples/example_composite.py
@@ -53,7 +53,7 @@ if __name__ == "__main__":
 
     assemblage=simple_mantle()
 
-    assemblage.set_phase_fractions([0.8, 0.2])
+    assemblage.set_fractions([0.8, 0.2])
     print assemblage.composition()
     assemblage.set_state(P, T)
     print 'Assemblage 1 (endmembers only)'
@@ -71,7 +71,7 @@ if __name__ == "__main__":
 
     assemblage=mantle_with_solid_solutions()
 
-    assemblage.set_phase_fractions([0.8, 0.2])
+    assemblage.set_fractions([0.8, 0.2])
     assemblage.set_composition([[0.9,0.1], [0.94, 0.06, 0.0, 0.0]])
     assemblage.set_state(P, T)
     print 'Assemblage 2 (with solid solutions), method 1'
@@ -85,7 +85,7 @@ if __name__ == "__main__":
     orthopyroxene=minerals.SLB_2011.orthopyroxene()
     assemblage=burnman.Composite([olivine, orthopyroxene])
     assemblage.set_composition([[0.9,0.1], [0.94, 0.06, 0.0, 0.0]])
-    assemblage.set_phase_fractions([0.8, 0.2])
+    assemblage.set_fractions([0.8, 0.2])
     assemblage.set_state(P, T)
     print 'Assemblage 2 (with solid solutions), method 2'
     print assemblage.phase_names
@@ -96,16 +96,16 @@ if __name__ == "__main__":
     Volume fractions also require state to have been set
     The fractions stored and used by burnman are *always* molar fractions - volume and mass fractions are converted before use. Note that mass fractions will change with set_composition, and volume fractions will change with set_state...
     '''
-    assemblage.set_phase_fractions([0.8, 0.2], 'molar')
+    assemblage.set_fractions([0.8, 0.2], 'molar')
     print 'Assemblage composition when molar phase fractions are', assemblage.molar_fractions
     print assemblage.composition()
     print ''
 
     print 'Converting between fraction types'
-    assemblage.set_phase_fractions([0.8, 0.2], 'mass')
+    assemblage.set_fractions([0.8, 0.2], 'mass')
     print 'Molar fractions from mass fractions:', assemblage.molar_fractions
 
-    assemblage.set_phase_fractions([0.8, 0.2], 'volume')
+    assemblage.set_fractions([0.8, 0.2], 'volume')
     print 'Molar fractions from volume fractions:', assemblage.molar_fractions
     print ''
 
@@ -129,3 +129,17 @@ if __name__ == "__main__":
         print component + ':', FMQ.chemical_potentials(components)[i]/1.e3, 'kJ/mol'
 
     print 'log10(fO2):', np.log10(FMQ.fugacity(O2))
+
+
+
+    """
+    Now we deal with elastic and thermodynamic properties of composites
+    where the individual phases are treated as isotropic. 
+
+    Averaging is conducted over phases (endmembers and solid solutions)
+    which have unique isotropic bulk and shear moduli derived in a 
+    different way to composites.
+
+    """
+
+    

--- a/examples/example_composite.py
+++ b/examples/example_composite.py
@@ -1,0 +1,131 @@
+# BurnMan - a lower mantle toolkit
+# Copyright (C) 2012, 2013, Heister, T., Unterborn, C., Rose, I. and Cottaar, S.
+# Released under GPL v2 or later.
+
+"""
+
+example_composite
+----------------------
+    
+This example shows how to create composites and output
+thermodynamic and thermoelastic quantities.
+
+*Uses:*
+
+* :doc:`mineral_database`
+* :class:`burnman.composite.Composite`
+
+
+*Demonstrates:*
+
+* Different ways to define an instance of the Composite class
+* How to set phase fractions, composition and state
+* How to output thermodynamic and thermoelastic properties
+
+"""
+
+import os, sys, numpy as np, matplotlib.pyplot as plt
+#hack to allow scripts to be placed in subdirectories next to burnman:
+if not os.path.exists('burnman') and os.path.exists('../burnman'):
+    sys.path.insert(1,os.path.abspath('..'))
+
+import burnman
+from burnman import minerals
+
+if __name__ == "__main__":
+    '''
+    First, let's pick a starting pressure and temperature
+    '''
+    P=1.e5
+    T=1000.
+
+    """
+    Now we can make a simple composite assemblage
+    """
+    forsterite=minerals.SLB_2011.forsterite()
+    enstatite=minerals.SLB_2011.enstatite()
+
+    class simple_mantle(burnman.Composite):
+        def __init__(self):
+            self.name='simple_mantle'
+            phases = [forsterite, enstatite]
+            burnman.Composite.__init__(self, phases)
+
+    assemblage=simple_mantle()
+
+    assemblage.set_phase_fractions([0.8, 0.2])
+    print assemblage.composition()
+    assemblage.set_state(P, T)
+    print 'Assemblage 1 (endmembers only)'
+    print assemblage.phase_names
+    print ''
+
+    olivine=minerals.SLB_2011.mg_fe_olivine()
+    orthopyroxene=minerals.SLB_2011.orthopyroxene()
+
+    class mantle_with_solid_solutions(burnman.Composite):
+        def __init__(self):
+            self.name='Mantle with solid solutions'
+            phases = [olivine, orthopyroxene]
+            burnman.Composite.__init__(self, phases)
+
+    assemblage=mantle_with_solid_solutions()
+
+    assemblage.set_phase_fractions([0.8, 0.2])
+    assemblage.set_composition([[0.9,0.1], [0.94, 0.06, 0.0, 0.0]])
+    assemblage.set_state(P, T)
+    print 'Assemblage 2 (with solid solutions), method 1'
+    print assemblage.phase_names
+    print ''
+
+    """
+    Here's a briefer way of doing the same thing
+    """
+    olivine=minerals.SLB_2011.mg_fe_olivine()
+    orthopyroxene=minerals.SLB_2011.orthopyroxene()
+    assemblage=burnman.Composite([olivine, orthopyroxene])
+    assemblage.set_composition([[0.9,0.1], [0.94, 0.06, 0.0, 0.0]])
+    assemblage.set_phase_fractions([0.8, 0.2])
+    assemblage.set_state(P, T)
+    print 'Assemblage 2 (with solid solutions), method 2'
+    print assemblage.phase_names
+    print ''
+    '''
+    Allow fractions to be set as molar (default), volume or mass
+    Volume and mass fractions only possible *after* phase compositions have been set
+    Volume fractions also require state to have been set
+    The fractions stored and used by burnman are *always* molar fractions - volume and mass fractions are converted before use. Note that mass fractions will change with set_composition, and volume fractions will change with set_state...
+    '''
+    assemblage.set_phase_fractions([0.8, 0.2], 'molar')
+    print 'Assemblage composition when molar phase fractions are', assemblage.molar_fractions
+    print assemblage.composition()
+    print ''
+
+    print 'Converting between fraction types'
+    assemblage.set_phase_fractions([0.8, 0.2], 'mass')
+    print 'Molar fractions from mass fractions:', assemblage.molar_fractions
+
+    assemblage.set_phase_fractions([0.8, 0.2], 'volume')
+    print 'Molar fractions from volume fractions:', assemblage.molar_fractions
+    print ''
+
+
+    """
+    An assemblage can also be queried for chemical potential information
+    """
+    fayalite=minerals.HP_2011_ds62.fa()
+    magnetite=minerals.HP_2011_ds62.mt()
+    quartz=minerals.HP_2011_ds62.q()
+    O2=minerals.HP_2011_fluids.O2()
+    O2.set_state(1.e5, T)
+
+    FMQ=burnman.Composite([fayalite, magnetite, quartz])
+    FMQ.set_state(P, T)
+    print 'Chemical potentials for the FMQ buffer at', P/1.e9, "GPa and", T, "K"
+    print FMQ.phase_names
+    components=['FeO', 'SiO2', 'O2']
+
+    for i, component in enumerate(components):
+        print component + ':', FMQ.chemical_potentials(components)[i]/1.e3, 'kJ/mol'
+
+    print 'log10(fO2):', np.log10(FMQ.fugacity(O2))

--- a/examples/example_composition.py
+++ b/examples/example_composition.py
@@ -62,17 +62,17 @@ if __name__ == "__main__":
     #Example 1: two simple fixed minerals
     if True:
         amount_perovskite = 0.95
-        rock = burnman.Composite([amount_perovskite, 1.0-amount_perovskite],
-                                 [minerals.SLB_2011.mg_perovskite(),
-                                  minerals.SLB_2011.periclase()])
+        rock = burnman.Composite([minerals.SLB_2011.mg_perovskite(),
+                                  minerals.SLB_2011.periclase()],\
+                                 [amount_perovskite, 1.0-amount_perovskite])
 
 
     #Example 2: three materials
     if False:
-        rock = burnman.Composite([0.7, 0.2, 0.1],
-                                 [minerals.SLB_2011.fe_perovskite(),
+        rock = burnman.Composite([minerals.SLB_2011.fe_perovskite(),
                                   minerals.SLB_2011.periclase(),
-                                  minerals.SLB_2011.stishovite()])
+                                  minerals.SLB_2011.stishovite()],\
+                                 [0.7, 0.2, 0.1])
 
 
     #Example 3: Mixing solid solutions
@@ -100,7 +100,7 @@ if __name__ == "__main__":
 
         # Set molar fraction of endmembers
         new_solidsolution.set_composition([0.9,0.1])
-        rock=burnman.Composite([0.8, 0.2], [new_solidsolution, minerals.SLB_2011.periclase()])
+        rock=burnman.Composite([new_solidsolution, minerals.SLB_2011.periclase()], [0.8, 0.2])
 
 
 

--- a/examples/example_composition.py
+++ b/examples/example_composition.py
@@ -64,9 +64,8 @@ if __name__ == "__main__":
         amount_perovskite = 0.95
         rock = burnman.Composite([minerals.SLB_2011.mg_perovskite(),
                                   minerals.SLB_2011.periclase()],\
-                                 [amount_perovskite, 1.0-amount_perovskite])
-
-
+                                 [amount_perovskite, 1-amount_perovskite])
+        
     #Example 2: three materials
     if False:
         rock = burnman.Composite([minerals.SLB_2011.fe_perovskite(),

--- a/examples/example_composition.py
+++ b/examples/example_composition.py
@@ -82,7 +82,7 @@ if __name__ == "__main__":
         #print preset_solidsolution.endmembers
         #Set molar_fraction of mg_perovskite, fe_perovskite and al_perovskite
         preset_solidsolution.set_composition([0.9,0.1,0.]) # Set molar_fraction of mg_perovskite, fe_perovskite and al_perovskite
-        rock = burnman.Composite([0.8, 0.2], phases=[preset_solidsolution, minerals.SLB_2011.periclase()])
+        rock = burnman.Composite([preset_solidsolution, minerals.SLB_2011.periclase()], [0.8, 0.2])
 
 
     #Example 4: Defining your own solid solution

--- a/examples/example_geotherms.py
+++ b/examples/example_geotherms.py
@@ -76,7 +76,7 @@ if __name__ == "__main__":
     pc=minerals.SLB_2011.ferropericlase()
     pv.set_composition([1.-fe_pv,fe_pv,0.])
     pc.set_composition([1.-fe_pc,fe_pc])
-    example_rock = burnman.Composite( [amount_perovskite, 1.0-amount_perovskite], [pv,pc] )
+    example_rock = burnman.Composite( [pv,pc], [amount_perovskite, 1.0-amount_perovskite] )
     
     #next, define an anchor temperature at which we are starting.
     #Perhaps 1500 K for the upper mantle

--- a/examples/example_grid.py
+++ b/examples/example_grid.py
@@ -27,9 +27,8 @@ from burnman import minerals
 
 if __name__ == "__main__":
 
-    rock = burnman.Composite([0.8, 0.2],
-                             [minerals.SLB_2011.mg_perovskite(),
-                              minerals.SLB_2011.periclase()])
+    rock = burnman.Composite([minerals.SLB_2011.mg_perovskite(),
+                              minerals.SLB_2011.periclase()], [0.8, 0.2])
 
     seismic_model = burnman.seismic.PREM()
 

--- a/examples/example_inv_murakami.py
+++ b/examples/example_inv_murakami.py
@@ -30,9 +30,9 @@ if __name__ == "__main__":
 
     def calc_velocities(a,b,c):
         amount_perovskite = a
-        rock = burnman.Composite([amount_perovskite, 1.0-amount_perovskite],
-                                 [minerals.SLB_2005.mg_fe_perovskite(b),
-                                  minerals.SLB_2005.ferropericlase(c)])
+        rock = burnman.Composite([minerals.SLB_2005.mg_fe_perovskite(b),
+                                  minerals.SLB_2005.ferropericlase(c)],\
+                                 [amount_perovskite, 1.0-amount_perovskite])
 
 
         mat_rho, mat_vp, mat_vs, mat_vphi, mat_K, mat_G = burnman.velocities_from_rock(rock,seis_p, temperature)

--- a/examples/example_optimize_pv.py
+++ b/examples/example_optimize_pv.py
@@ -51,9 +51,9 @@ if __name__ == "__main__":
     def material_error(amount_perovskite):
         #Define composition using the values from Murakami et al. 2012 (Note: fe_perovskite and fe_periclase do not represent pure iron
         #endmembers here, but contain 6% and 20% Fe respectively. 
-        rock = burnman.Composite([amount_perovskite, 1.0-amount_perovskite],
-                                 [minerals.Murakami_etal_2012.fe_perovskite(),
-                                  minerals.Murakami_etal_2012.fe_periclase()])
+        rock = burnman.Composite([minerals.Murakami_etal_2012.fe_perovskite(),
+                                  minerals.Murakami_etal_2012.fe_periclase()], \
+                                 [amount_perovskite, 1.0-amount_perovskite])
 
 
         mat_rho, mat_vp, mat_vs, mat_vphi, mat_K, mat_G = \

--- a/examples/example_partition_coef.py
+++ b/examples/example_partition_coef.py
@@ -55,9 +55,9 @@ if __name__ == "__main__":
     iron_content = lambda p,t: \
         burnman.calculate_partition_coefficient(p,t,relative_molar_percent,Kd_0)
 
-    rock = burnman.Composite([phase_fractions['pv'], phase_fractions['fp']],
-                             [minerals.SLB_2005.mg_fe_perovskite_pt_dependent(iron_content, 1),
-                              minerals.SLB_2005.ferropericlase_pt_dependent(iron_content, 0)])
+    rock = burnman.Composite([minerals.SLB_2005.mg_fe_perovskite_pt_dependent(iron_content, 1),
+                              minerals.SLB_2005.ferropericlase_pt_dependent(iron_content, 0)], \
+                             [phase_fractions['pv'], phase_fractions['fp']])
 
     #seismic model for comparison:
     seismic_model = burnman.seismic.PREM() # pick from .prem() .slow() .fast()

--- a/examples/example_woutput.py
+++ b/examples/example_woutput.py
@@ -49,7 +49,7 @@ if __name__ == "__main__":
     pc=minerals.SLB_2011.ferropericlase()
     pv.set_composition([1.-fe_pv,fe_pv,0.])
     pc.set_composition([1.-fe_pc,fe_pc])
-    rock = burnman.Composite( [amount_perovskite, 1.0-amount_perovskite], [pv,pc] )
+    rock = burnman.Composite( [pv,pc], [amount_perovskite, 1.0-amount_perovskite] )
     
     #define some pressure range
     pressures = np.arange(25e9,130e9,5e9)

--- a/misc/paper_averaging.py
+++ b/misc/paper_averaging.py
@@ -59,12 +59,12 @@ if __name__ == "__main__":
 
     amount_perovskite = 0.6
 
-    rock = burnman.Composite( [ (minerals.SLB_2011.mg_perovskite(), amount_perovskite),
-                    (minerals.SLB_2011.wuestite(), 1.0-amount_perovskite) ] )
+    rock = burnman.Composite( [minerals.SLB_2011.mg_perovskite(), minerals.SLB_2011.wuestite()],
+                              [amount_perovskite, 1.0-amount_perovskite] )
 
-    perovskitite = burnman.Composite( [ (minerals.SLB_2011.mg_perovskite(), 1.0), ] )
+    perovskitite = burnman.Composite( [minerals.SLB_2011.mg_perovskite()], [1.0] )
 
-    periclasite = burnman.Composite( [ (minerals.SLB_2011.wuestite(), 1.0), ] )
+    periclasite = burnman.Composite( [minerals.SLB_2011.wuestite()], [1.0] )
 
     #seismic model for comparison:
     # pick from .prem() .slow() .fast() (see burnman/seismic.py)

--- a/misc/paper_incorrect_averaging.py
+++ b/misc/paper_incorrect_averaging.py
@@ -124,22 +124,22 @@ if __name__ == "__main__":
     seis_p, seis_rho, seis_vp, seis_vs, seis_vphi = seismic_model.evaluate(['pressure','density','v_p','v_s','v_phi'],depths)
 
     #pure perovskite
-    perovskitite = burnman.Composite( ( (perovskite(0.06), 1.0),) )
+    perovskitite = burnman.Composite( [perovskite(0.06)], [1.0] )
     perovskitite.set_method(method)
 
     #pure periclase
-    periclasite = burnman.Composite( ( (ferropericlase(0.21), 1.0),))
+    periclasite = burnman.Composite( [ferropericlase(0.21)], [1.0])
     periclasite.set_method(method)
 
     #pyrolite (80% perovskite)
-    pyrolite = burnman.Composite( ( (perovskite(0.06), 0.834),
-                                    (ferropericlase(0.21), 0.166) ) )
+    pyrolite = burnman.Composite( [perovskite(0.06), ferropericlase(0.21)],\
+                                  [0.834, 0.166] )
     pyrolite.set_method(method)
 
     #preferred mixture?
     amount_perovskite = 0.92
-    preferred_mixture = burnman.Composite( ( (perovskite(0.06), amount_perovskite),
-                                             (ferropericlase(0.21), 1.0-amount_perovskite) ) )
+    preferred_mixture = burnman.Composite( [perovskite(0.06), ferropericlase(0.21)],\
+                                           [amount_perovskite, 1.0-amount_perovskite] )
     preferred_mixture.set_method(method)
 
 
@@ -203,7 +203,4 @@ if __name__ == "__main__":
     if "RUNNING_TESTS" not in globals():
         plt.savefig("example_incorrect_averaging.pdf",bbox_inches='tight')
     plt.show()
-
-
-
 

--- a/misc/paper_onefit.py
+++ b/misc/paper_onefit.py
@@ -83,7 +83,7 @@ def array_to_rock(arr, names):
     rock, _ = make_rock()
     anchor_t = arr[0]
     idx = 1
-    for (phase, fraction) in rock.children:
+    for phase in rock.phases:
         if isinstance(phase, HelperSolidSolution):
             for min in phase.endmembers:
                 for key in min.params:

--- a/misc/paper_onefit.py
+++ b/misc/paper_onefit.py
@@ -44,7 +44,7 @@ def make_rock():
     perovskite = HelperSolidSolution( [ mg_perovskite, fe_perovskite], [1.0-pv_fe_num, pv_fe_num])
     ferropericlase = HelperSolidSolution( [ periclase, wuestite], [1.0-fp_fe_num, fp_fe_num])
 
-    pyrolite = burnman.Composite( [ (perovskite, x_pv), (ferropericlase, x_fp) ] )
+    pyrolite = burnman.Composite( [perovskite, ferropericlase], [x_pv, x_fp])
     pyrolite.set_method('slb3')
     anchor_temperature = 1935.0
 
@@ -83,7 +83,7 @@ def array_to_rock(arr, names):
     rock, _ = make_rock()
     anchor_t = arr[0]
     idx = 1
-    for (fraction,phase) in rock.children:
+    for (phase, fraction) in rock.children:
         if isinstance(phase, HelperSolidSolution):
             for min in phase.endmembers:
                 for key in min.params:

--- a/misc/paper_opt_pv.py
+++ b/misc/paper_opt_pv.py
@@ -74,12 +74,15 @@ if __name__ == "__main__":
     #temperature = burnman.geotherm.brown_shankland(seis_p)
 
     def eval_material(amount_perovskite):
-#        rock = burnman.composite ( [ (minerals.Murakami_etal_2012.fe_perovskite(), amount_perovskite),
-#                             (minerals.Murakami_etal_2012.fe_periclase(), 1.0 - amount_perovskite) ] )
-        rock = burnman.Composite ( [ (minerals.SLB_2011_ZSB_2013.mg_fe_perovskite(0.07), amount_perovskite),
-                             (minerals.other.ferropericlase(0.2), 1.0 - amount_perovskite) ] )
-#        rock = burnman.composite ( [ (minerals.SLB_2011.mg_fe_perovskite(0.), amount_perovskite),
-#                             (minerals.other.ferropericlase(1.0), 1.0 - amount_perovskite) ] )
+#        rock = burnman.composite ( [minerals.Murakami_etal_2012.fe_perovskite(),\
+#                                    minerals.Murakami_etal_2012.fe_periclase()], \
+#                                   [amount_perovskite, 1.0 - amount_perovskite ] )
+        rock = burnman.Composite ( [minerals.SLB_2011_ZSB_2013.mg_fe_perovskite(0.07),
+                                    minerals.other.ferropericlase(0.2)], \
+                                   [amount_perovskite, 1.0 - amount_perovskite] )
+#        rock = burnman.composite ( [minerals.SLB_2011.mg_fe_perovskite(0.),\
+#                                   minerals.other.ferropericlase(1.0)],
+#                                  [amount_perovskite, 1.0 - amount_perovskite] )
         rock.set_method(method)
         temperature = burnman.geotherm.adiabatic(seis_p,1900,rock)
         print "Calculations are done for:"

--- a/misc/paper_uncertain.py
+++ b/misc/paper_uncertain.py
@@ -59,7 +59,7 @@ if __name__ == "__main__":
 
 
     def eval(uncertain):
-        rock = burnman.Composite ( [ (my_perovskite(uncertain), 1.0) ])
+        rock = burnman.Composite ( [my_perovskite(uncertain)], [1.0])
         rock.set_method('slb3')
 
         temperature = burnman.geotherm.adiabatic(seis_p,1900*uncertain[8],rock)

--- a/misc/paper_uncertainty.py
+++ b/misc/paper_uncertainty.py
@@ -55,7 +55,7 @@ if __name__ == "__main__":
 
 
     def eval(uncertain):
-        rock = burnman.Composite ( [ (my_perovskite(uncertain), 1.0) ])
+        rock = burnman.Composite ( [my_perovskite(uncertain)], [1.0])
         rock.set_method('slb3')
 
         temperature = burnman.geotherm.adiabatic(seis_p,1900*uncertain[8],rock)

--- a/tests/test_composite.py
+++ b/tests/test_composite.py
@@ -20,29 +20,29 @@ class composite(BurnManTest):
         min_hs = burnman.minerals.Murakami_etal_2012.fe_periclase_HS()
         min2 = minerals.SLB_2005.periclase()
 
-        c = burnman.Composite( [1.0], [min1] )
+        c = burnman.Composite( [min1], [1.0] )
         c.set_state(5e9,300)
-        (f,m) = c.unroll()
+        (m,f) = c.unroll()
         mins=",".join([a.to_string() for a in m])
         self.assertEqual(f,[1.0])
         self.assertEqual(mins,min_hs.to_string())
-        c = burnman.Composite( [0.4, 0.6], [min1, min2] )
+        c = burnman.Composite( [min1, min2], [0.4, 0.6] )
         c.set_state(5e9,300)
-        (f,m) = c.unroll()
+        (m,f) = c.unroll()
         self.assertEqual(f,[0.4,0.6])
 
-        c1 = burnman.Composite( [1.0], [min1] )
-        c2 = burnman.Composite( [1.0], [min2] )
-        c = burnman.Composite( [0.1, 0.4, 0.5], [min1, c1, c2] )
-        (f,m) = c.unroll()
+        c1 = burnman.Composite( [min1], [1.0] )
+        c2 = burnman.Composite( [min2], [1.0] )
+        c = burnman.Composite( [min1, c1, c2], [0.1, 0.4, 0.5] )
+        (m,f) = c.unroll()
         mins=",".join([a.to_string() for a in m])
         self.assertEqual(f,[0.1,0.4,0.5])
         self.assertEqual(mins,min_hs.to_string()+','+min_hs.to_string()+','+min2.to_string())
 
-        c1 = burnman.Composite( [0.1, 0.9], [min1, min2] )
-        c2 = burnman.Composite( [1.0], [min2] )
-        c = burnman.Composite( [0.3, 0.1, 0.6], [min1, c1, c2] )
-        (f,m) = c.unroll()
+        c1 = burnman.Composite( [min1, min2], [0.1, 0.9] )
+        c2 = burnman.Composite( [min2], [1.0] )
+        c = burnman.Composite( [min1, c1, c2], [0.3, 0.1, 0.6] )
+        (m,f) = c.unroll()
         mins=",".join([a.to_string() for a in m])
         self.assertArraysAlmostEqual(f,[0.3,0.01,0.09,0.6])
         self.assertEqual(mins,",".join([min_hs.to_string(),min_hs.to_string(),min2.to_string(),min2.to_string()]))
@@ -57,16 +57,16 @@ class composite(BurnManTest):
                 mins = [minerals.Murakami_etal_2012.fe_periclase(), minerals.SLB_2005.periclase()]
                 if (self.temperature>500):
                     fractions = [0.1, 0.9]
-                return (fractions, mins)
+                return (mins, fractions)
         
         c = mycomposite()
         c.set_state(5e9,300)
-        (f,m) = c.unroll()
+        (m,f) = c.unroll()
         mins=",".join([a.to_string() for a in m])
         self.assertArraysAlmostEqual(f,[0.3,0.7])
         self.assertEqual(mins,",".join([minerals.Murakami_etal_2012.fe_periclase().to_string(),minerals.SLB_2005.periclase().to_string()]))
         c.set_state(5e9,3000)
-        (f,m) = c.unroll()
+        (m,f) = c.unroll()
         self.assertArraysAlmostEqual(f,[0.1,0.9])
         self.assertEqual(mins,",".join([minerals.Murakami_etal_2012.fe_periclase().to_string(),minerals.SLB_2005.periclase().to_string()]))
 
@@ -74,19 +74,19 @@ class composite(BurnManTest):
         class mycomposite(burnman.Material):
             def unroll(self):
                 if (self.temperature>500):
-                    return ([1.0],[minerals.Murakami_etal_2012.fe_periclase()])
+                    return ([minerals.Murakami_etal_2012.fe_periclase()],[1.0])
                 fractions = [0.3, 0.7]
                 mins = [minerals.Murakami_etal_2012.fe_periclase(), minerals.SLB_2005.periclase()]
-                return (fractions, mins)
+                return (mins, fractions)
         
         c = mycomposite()
         c.set_state(5e9,1000)
-        (f,m) = c.unroll()
+        (m,f) = c.unroll()
         mins=",".join([a.to_string() for a in m])
         self.assertArraysAlmostEqual(f,[1.0])
         self.assertEqual(mins,minerals.Murakami_etal_2012.fe_periclase().to_string())
         c.set_state(5e9,300)
-        (f,m) = c.unroll()
+        (m,f) = c.unroll()
         mins=",".join([a.to_string() for a in m])
         self.assertArraysAlmostEqual(f,[0.3,0.7])
         self.assertEqual(mins,",".join([minerals.Murakami_etal_2012.fe_periclase().to_string(),minerals.SLB_2005.periclase().to_string()]))
@@ -94,23 +94,23 @@ class composite(BurnManTest):
     def test_nest(self):
         min1 = minerals.Murakami_etal_2012.fe_periclase_LS()
         min2 = minerals.SLB_2005.periclase()
-        ca = burnman.Composite( [1.0], [min1] )
-        c = burnman.Composite( [0.4, 0.6], [ca, min2] )
+        ca = burnman.Composite( [min1], [1.0] )
+        c = burnman.Composite( [ca, min2], [0.4, 0.6] )
         c.set_state(5e9,1000)
-        (f,m) = c.unroll()
+        (m,f) = c.unroll()
         mins=",".join([a.to_string() for a in m])
         self.assertArraysAlmostEqual(f,[0.4, 0.6])
         self.assertEqual(mins,",".join([min1.to_string(),min2.to_string()]))
 
     def test_density_composite(self):
-        pyrolite = burnman.Composite( [0.95, 0.05], \
-                                  [minerals.SLB_2005.mg_fe_perovskite(0.2), \
-                                       minerals.SLB_2005.ferropericlase(0.4)] )
+        pyrolite = burnman.Composite([minerals.SLB_2005.mg_fe_perovskite(0.2), \
+                                      minerals.SLB_2005.ferropericlase(0.4)], \
+                                     [0.95, 0.05] )
         pyrolite.set_method('slb3')
         pyrolite.set_state(40.e9, 2000)
         
-        d1 = int(pyrolite.children[0][1].density())
-        d2 = int(pyrolite.children[1][1].density())
+        d1 = int(pyrolite.children[0][0].density())
+        d2 = int(pyrolite.children[1][0].density())
         dmix = int(pyrolite.density())
         assert(d1<dmix)
         assert(dmix<d2)
@@ -122,30 +122,30 @@ class composite(BurnManTest):
         min1 = minerals.SLB_2005.periclase()
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            c = burnman.Composite( [0.8, 0.4], [min1, min1])
+            c = burnman.Composite( [min1, min1], [0.8, 0.4])
             assert len(w) == 1
         c.set_method("slb3")
         c.set_state(5e9,1000)
-        (f,m) = c.unroll()
+        (m,f) = c.unroll()
         self.assertArraysAlmostEqual(f, [2./3., 1./3.])
 
     def test_summing_smaller(self):
         min1 = minerals.SLB_2005.periclase()
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            c = burnman.Composite( [0.4, 0.2], [min1, min1])
+            c = burnman.Composite( [min1, min1], [0.4, 0.2])
             assert len(w) == 1
         c.set_method("slb3")
         c.set_state(5e9,1000)
-        (f,m) = c.unroll()
+        (m,f) = c.unroll()
         self.assertArraysAlmostEqual(f, [2./3., 1./3.])
 
     def test_summing_slightly_negative(self):
         min1 = minerals.SLB_2005.periclase()
-        c = burnman.Composite( [0.8, 0.2, 1.0-0.8-0.2], [min1, min1, min1])
+        c = burnman.Composite( [min1, min1, min1], [0.8, 0.2, 1.0-0.8-0.2])
         c.set_method("slb3")
         c.set_state(5e9,1000)
-        (f,m) = c.unroll()
+        (m,f) = c.unroll()
         self.assertArraysAlmostEqual(f, [0.8, 0.2, 0.0])
         self.assertTrue(f[2]>=0.0)
 

--- a/tests/test_composite.py
+++ b/tests/test_composite.py
@@ -109,8 +109,8 @@ class composite(BurnManTest):
         pyrolite.set_method('slb3')
         pyrolite.set_state(40.e9, 2000)
         
-        d1 = int(pyrolite.children[0][0].density())
-        d2 = int(pyrolite.children[1][0].density())
+        d1 = int(pyrolite.phases[0].density())
+        d2 = int(pyrolite.phases[1].density())
         dmix = int(pyrolite.density())
         assert(d1<dmix)
         assert(dmix<d2)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -48,7 +48,7 @@ class test_model(BurnManTest):
         return burnman.Model(rock, p, T, burnman.averaging_schemes.VoigtReussHill())
 
     def model12(self):
-        rock = burnman.Composite([0.2, 0.8], [min1(), min2()])
+        rock = burnman.Composite([min1(), min2()], [0.2, 0.8])
         rock.set_method('slb3')
         p = [40e9]
         T = [2000]

--- a/tests/test_spin.py
+++ b/tests/test_spin.py
@@ -20,7 +20,7 @@ class spin_transition(BurnManTest):
             p.set_state(5e9, 300)
             #print p.v_s()
          
-        f,c = mins[0].unroll()
+        c,f = mins[0].unroll()
         self.assertFloatEqual(c[0].v_s(), mins[1].v_s())
         
         #print "LS regime: (on/high/low)"
@@ -28,15 +28,15 @@ class spin_transition(BurnManTest):
             p.set_state(70e9, 300)
             #print p.v_s()
         
-        f,c = mins[0].unroll()
+        c,f = mins[0].unroll()
         self.assertFloatEqual(c[0].v_s(), mins[2].v_s())
 
     def test_no_set_state(self):
         m = minerals.Murakami_etal_2012.fe_periclase()
         m.set_state(5e9, 300)
-        self.assertIsInstance(m.unroll()[1][0], minerals.Murakami_etal_2012.fe_periclase_HS)
+        self.assertIsInstance(m.unroll()[0][0], minerals.Murakami_etal_2012.fe_periclase_HS)
         m.set_state(70e9, 300)
-        self.assertIsInstance(m.unroll()[1][0], minerals.Murakami_etal_2012.fe_periclase_LS)
+        self.assertIsInstance(m.unroll()[0][0], minerals.Murakami_etal_2012.fe_periclase_LS)
 
 
 class TestHelperSolidSolution(BurnManTest):
@@ -59,18 +59,18 @@ class TestHelperFEdep(BurnManTest):
         iron_content = lambda p,t: burnman.calculate_partition_coefficient \
                 (p,t,relative_molar_percent,Kd_0)
 
-        rock = burnman.Composite([phase_fractions['pv'], phase_fractions['fp']],
-                                 [minerals.SLB_2005.mg_fe_perovskite_pt_dependent(iron_content,0),
-                                  minerals.SLB_2005.ferropericlase_pt_dependent(iron_content,1)])
+        rock = burnman.Composite([minerals.SLB_2005.mg_fe_perovskite_pt_dependent(iron_content,0),
+                                  minerals.SLB_2005.ferropericlase_pt_dependent(iron_content,1)], \
+                                 [phase_fractions['pv'], phase_fractions['fp']])
         rock.set_state(5e9, 300)
-        fractions, mins = rock.unroll()
+        mins, fractions = rock.unroll()
         self.assertArraysAlmostEqual(fractions, [0.9428714062806316, 0.057128593719368403])
         self.assertIsInstance(mins[0], minerals.SLB_2005.mg_fe_perovskite)
         self.assertIsInstance(mins[1], minerals.SLB_2005.ferropericlase)
         self.assertFloatEqual(mins[0].molar_mass(), 0.101752790682)
 
         rock.set_state(7e9, 700)
-        fractions, mins = rock.unroll()
+        mins, fractions = rock.unroll()
         self.assertFloatEqual(mins[0].molar_mass(), 0.104161162508)
 
 

--- a/tests/test_vrh.py
+++ b/tests/test_vrh.py
@@ -46,7 +46,7 @@ class VRH_average(BurnManTest):
 
 class VRH(BurnManTest):
     def test_1(self):
-        rock = burnman.Composite ( [1.0], [mypericlase()] )
+        rock = burnman.Composite ( [mypericlase()], [1.0] )
         rock.set_method('slb3') 
         rho, v_p, v_s, v_phi, K_vrh, G_vrh = \
             burnman.velocities_from_rock(rock, [10e9,], [300,])
@@ -58,7 +58,7 @@ class VRH(BurnManTest):
         self.assertFloatEqual(150.901, G_vrh[0]/1.e9)
 
     def same(self, number):
-        rock = burnman.Composite ( [1.0/number] * number, [mypericlase()]*number )
+        rock = burnman.Composite ( [mypericlase()]*number, [1.0/number] * number )
         
         rock.set_method('slb3')
         rho, v_p, v_s, v_phi, K_vrh, G_vrh = \
@@ -76,7 +76,7 @@ class VRH(BurnManTest):
         self.same(4)
 
     def test_two_different(self):
-        rock = burnman.Composite ( [1.0, 0.0], [minerals.SLB_2005.periclase(), minerals.SLB_2005.fe_perovskite()] )
+        rock = burnman.Composite ( [minerals.SLB_2005.periclase(), minerals.SLB_2005.fe_perovskite()], [1.0, 0.0] )
         rock.set_method('slb3')
         rho, v_p, v_s, v_phi, K_vrh, G_vrh = \
             burnman.velocities_from_rock(rock,[10e9,], [300,])

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -23,9 +23,9 @@ from burnman import minerals
 class TestRock(BurnManTest):
     def test_rock(self):
         amount_perovskite = 0.3
-        rock = burnman.Composite( [amount_perovskite, 1.0-amount_perovskite], \
-            [minerals.SLB_2005.mg_fe_perovskite(0.1), minerals.SLB_2005.ferropericlase(0.2)] )
-        (fr,phases)=rock.unroll()
+        rock = burnman.Composite([minerals.SLB_2005.mg_fe_perovskite(0.1), minerals.SLB_2005.ferropericlase(0.2)], \
+                                 [amount_perovskite, 1.0-amount_perovskite])
+        (phases, fr)=rock.unroll()
         self.assertFloatEqual(fr[0], 0.3)
         self.assertFloatEqual(fr[1], 0.7)
 


### PR DESCRIPTION
The proposed Assemblage class can instead be included in the existing Composite class iff the order of phases and fractions are switched in Composite and unroll. The old way of doing things (with phase fractions being mandatory but phases being optional) seems less logical to me.

I realise that this will break all user defined composites, and may therefore meet with some resistance. We can include a two or three line try/except to catch and fix this problem, or just stick with the Exception message that I've added.

If this change meets with approval, then I can work on implementing all the other parts of Assemblage within the Composite class.