### PR TITLE
fix optimize perovskite example

### DIFF
--- a/examples/example_optimize_pv.py
+++ b/examples/example_optimize_pv.py
@@ -36,10 +36,6 @@ from burnman import minerals
 
 if __name__ == "__main__":
 
-
-### input variables ###
-    #######################
-
     # Define reference model and depth to evaluate
     seismic_model = burnman.seismic.PREM()
     number_of_points = 20
@@ -54,7 +50,7 @@ if __name__ == "__main__":
     perovskite=minerals.SLB_2011.mg_fe_perovskite()
     perovskite.set_composition([0.94,0.06,0.]) # Set molar_fraction of mg_perovskite, fe_perovskite and al_perovskite
     ferropericlase=minerals.SLB_2011.ferropericlase()
-    ferropericlase.set_composition([0.8,0.2]) # Set molar_fraction of mg_perovskite, fe_perovskite and al_perovskite
+    ferropericlase.set_composition([0.8,0.2]) # Set molar_fraction of MgO and FeO
 
     def material_error(amount_perovskite):
         #Define composite using the values

--- a/examples/example_optimize_pv.py
+++ b/examples/example_optimize_pv.py
@@ -40,39 +40,61 @@ if __name__ == "__main__":
 ### input variables ###
     #######################
 
-
-    seismic_model = burnman.seismic.PREM() # pick from .prem() .slow() .fast() (see burnman/seismic.py)
-    number_of_points = 20 #set on how many depth slices the computations should be done
+    # Define reference model and depth to evaluate
+    seismic_model = burnman.seismic.PREM()
+    number_of_points = 20
     depths = np.linspace(700e3,2800e3, number_of_points)
-    seis_p, seis_rho, seis_vp, seis_vs, seis_vphi = seismic_model.evaluate(['pressure','density','v_p','v_s','v_phi'],depths)
+    seis_p, seis_rho, seis_vp, seis_vs, seis_vphi, seis_K, seis_G = seismic_model.evaluate(['pressure','density','v_p','v_s','v_phi','K','G'],depths)
 
+    #Define geotherm
     temperature = burnman.geotherm.brown_shankland(seis_p)
+    
+    
+    #Define solid solutions
+    perovskite=minerals.SLB_2011.mg_fe_perovskite()
+    perovskite.set_composition([0.94,0.06,0.]) # Set molar_fraction of mg_perovskite, fe_perovskite and al_perovskite
+    ferropericlase=minerals.SLB_2011.ferropericlase()
+    ferropericlase.set_composition([0.8,0.2]) # Set molar_fraction of mg_perovskite, fe_perovskite and al_perovskite
 
     def material_error(amount_perovskite):
-        #Define composition using the values from Murakami et al. 2012 (Note: fe_perovskite and fe_periclase do not represent pure iron
-        #endmembers here, but contain 6% and 20% Fe respectively. 
+        #Define composite using the values
         rock = burnman.Composite([amount_perovskite, 1.0-amount_perovskite],
-                                 [minerals.Murakami_etal_2012.fe_perovskite(),
-                                  minerals.Murakami_etal_2012.fe_periclase()])
+                                 [perovskite, ferropericlase])
 
-
+        # Compute velocities
         mat_rho, mat_vp, mat_vs, mat_vphi, mat_K, mat_G = \
             burnman.velocities_from_rock(rock, seis_p, temperature, burnman.averaging_schemes.VoigtReussHill())
 
         print "Calculations are done for:"
         rock.debug_print()
+        # Calculate errors
+        [vs_err, vphi_err, rho_err, K_err, G_err] = \
+            burnman.compare_l2(depths, [mat_vs,mat_vphi,mat_rho, mat_K, mat_G], [seis_vs,seis_vphi,seis_rho, seis_K, seis_G])
+        # Normalize errors
+        vs_err = vs_err/np.mean(seis_vs)**2.
+        vphi_err = vphi_err/np.mean(seis_vphi)**2.
+        rho_err = rho_err/np.mean(seis_rho)**2.
+        K_err = K_err/np.mean(seis_K)**2.
+        G_err = G_err/np.mean(seis_G)**2.
+        return vs_err, vphi_err, rho_err, K_err, G_err
 
-        [vs_err, vphi_err, rho_err] = \
-            burnman.compare_l2(depths, [mat_vs,mat_vphi,mat_rho], [seis_vs,seis_vphi,seis_rho])
-
-        return vs_err, vphi_err
-
+    # Run through fractions of perovskite
     xx=np.linspace(0.0, 1.0, 40)
     errs=np.array([material_error(x) for x in xx])
+
+
+
+    # Plot results
     yy_vs=errs[:,0]
     yy_vphi=errs[:,1]
+    yy_rho = errs[:,2]
+    yy_K = errs[:,3]
+    yy_G = errs[:,4]
     plt.plot (xx,yy_vs,"r-x",label=("vs error"))
     plt.plot (xx,yy_vphi,"b-x",label=("vphi error"))
+    plt.plot (xx,yy_rho,"m-x",label=("rho error"))
+    plt.plot (xx,yy_K,"g-x",label=("K error"))
+    plt.plot (xx,yy_G,"y-x",label=("G error"))
     plt.yscale('log')
     plt.xlabel('% Perovskite')
     plt.ylabel('Error')


### PR DESCRIPTION
Just noticed that optimize_pv from the paper is still using the old solid solutions. While the example of optimize_pv (in the examples directory) just has a really poor choice of composition. I've tried to update that example here a bit. Please check so I can add the code to our slides. 