### PR TITLE
remove absolute numdiff tolerance

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -6,7 +6,7 @@ fulldir=`pwd`
 which numdiff >/dev/null
 if [ $? -eq 0 ]
 then
-  diffcmd="numdiff -r 1e-5 -s ' \t\n[],' -a 1e-5"
+  diffcmd="numdiff -r 1e-5 -s ' \t\n[],'"
 else
   diffcmd="diff"
   echo "WARNING: numdiff not found, please install! Falling back to diff."


### PR DESCRIPTION
This caused the test misc/paper_onefit to pass where we swapped values a
long time ago because both numbers where ~1e-7.