### PR TITLE
Correct landau V, changed SLB references to T_0

### DIFF
--- a/burnman/endmemberdisorder.py
+++ b/burnman/endmemberdisorder.py
@@ -75,10 +75,22 @@ def enthalpy_disorder_Landau(P, T, params):
     from Holland and Powell, 1996, corrected using
     landaunote.pdf on Tim Holland's esc web page
     """
-    # N.B. Assumes Vt==1, see above
-    Tcstar, Q_0, Q = landau_ordering(P, T, params)
     Hdisord=gibbs_disorder_Landau(P, T, params) + T*entropy_disorder_Landau(P, T, params)
     return Hdisord
+
+def volume_disorder_Landau(P, T, params):
+    """
+    Returns the volume of disordering [m^3/mol] relative 
+    to the equilibrium state of disorder (Q [unitless]) 
+    based on the landau model
+
+    from Holland and Powell, 1996, corrected using
+    landaunote.pdf on Tim Holland's esc web page
+    """
+    Tcstar, Q_0, Q = landau_ordering(P, T, params) 
+    Vt=1.
+    Vdisord=params['landau_Vmax']*(Q_0*Q_0-Q*Q)*Vt
+    return Vdisord
 
 def heat_capacity_p_disorder_Landau(P, T, params):
     """
@@ -149,3 +161,13 @@ def enthalpy_disorder_BW(P, T, params):
     nonideal=(1.-Q)*Q*W
     Hdisord=ideal+nonideal
     return Hdisord
+
+def volume_disorder_BW(P, T, params):
+    n=params['BW_n']
+    deltaS=entropydisorder(n)
+    Q=opt.fsolve(equilibrium_Q, 0.999995, args=(deltaS, P, T, params))[0]
+    W=params['BW_Wv']
+    ideal=(1.-Q)*(params['BW_deltaV'])
+    nonideal=(1.-Q)*Q*W
+    Vdisord=ideal+nonideal
+    return Vdisord

--- a/burnman/eos/slb.py
+++ b/burnman/eos/slb.py
@@ -58,7 +58,7 @@ class SLBBase(eos.EquationOfState):
     def pressure(self, temperature, volume, params):
         return bm.birch_murnaghan(params['V_0']/volume, params) + \
                 self.__thermal_pressure(temperature,volume, params) - \
-                self.__thermal_pressure(300.,volume, params)
+                self.__thermal_pressure(params['T_0'],volume, params)
 
     #calculate isotropic thermal pressure, see
     # Matas et. al. (2007) eq B4
@@ -108,7 +108,7 @@ class SLBBase(eos.EquationOfState):
         debye_T = self.__debye_temperature(params['V_0']/volume, params)
         gr = self.grueneisen_parameter(0.0, temperature, volume, params) #does not depend on pressure
         E_th = debye.thermal_energy(temperature, debye_T, params['n'])
-        E_th_ref = debye.thermal_energy(300., debye_T, params['n']) #thermal energy at reference temperature
+        E_th_ref = debye.thermal_energy(params['T_0'], debye_T, params['n']) #thermal energy at reference temperature
 
         b_iikk= 9.*params['K_0'] # EQ 28
         b_iikkmm= 27.*params['K_0']*(params['Kprime_0']-4.) # EQ 29
@@ -242,7 +242,7 @@ class SLBBase(eos.EquationOfState):
         Debye_T = self.__debye_temperature(params['V_0']/volume, params)
 
         F_quasiharmonic = debye.helmholtz_free_energy( temperature, Debye_T, params['n'] ) - \
-                          debye.helmholtz_free_energy( 300., Debye_T, params['n'] )
+                          debye.helmholtz_free_energy(params['T_0'], Debye_T, params['n'] )
 
         b_iikk= 9.*params['K_0'] # EQ 28
         b_iikkmm= 27.*params['K_0']*(params['Kprime_0']-4.) # EQ 29


### PR DESCRIPTION
This patch fixes the volume Landau contribution, removes the double counting of the enthalpy of disorder (oops), and completes the change of references to T_0 in SLB.

There are still changes to make w.r.t. Landau (w.r.t. K_T, K_S), but these can wait until our redesign of excess contributions in December. 