### PR TITLE
Rm density from eos

### DIFF
--- a/burnman/eos/birch_murnaghan.py
+++ b/burnman/eos/birch_murnaghan.py
@@ -32,12 +32,6 @@ def birch_murnaghan(x, params):
     return 3.*params['K_0']/2. * (pow(x, 7./3.) - pow(x, 5./3.)) \
     * (1 - .75*(4-params['Kprime_0'] )*(pow(x, 2./3.) - 1)) + params['P_0']
 
-def density(pressure, params):
-    """
-    Get the birch-murnaghan density at a reference temperature for a given
-    pressure :math:`[Pa]`. Returns density in :math:`[kg/m^3]'
-    """
-    return params['molar_mass']/volume(pressure,params)
 
 def volume(pressure, params):
     """

--- a/burnman/eos/equation_of_state.py
+++ b/burnman/eos/equation_of_state.py
@@ -59,17 +59,16 @@ class EquationOfState(object):
         """
         raise NotImplementedError("")
 
-    def density(self, pressure, temperature, params):
+    def density(self, volume, params):
         """
         Calculate the density of the mineral :math:`[kg/m^3]`.  
         The params object must include a "molar_mass" field.
 
         Parameters
         ----------
-        pressure : float
-            Pressure at which to evaluate the equation of state. :math:`[Pa]`
-        temperature : float
-            Temperature at which to evaluate the equation of state. :math:`[K]`
+        volume : float
+        Molar volume of the mineral.  For consistency this should be calculated
+        using :func:`volume`. :math:`[m^3]`
         params : dictionary
             Dictionary containing material parameters required by the equation of state.
 
@@ -78,7 +77,7 @@ class EquationOfState(object):
         density : float
             Density of the mineral. :math:`[kg/m^3]`
         """
-        return params["molar_mass"] / self.volume(pressure, temperature, params)
+        return params["molar_mass"] / volume
 
     def grueneisen_parameter(self, pressure, temperature, volume, params):
         """

--- a/burnman/eos/slb.py
+++ b/burnman/eos/slb.py
@@ -55,10 +55,6 @@ class SLBBase(eos.EquationOfState):
         eta_s = - gr - (1./2. * pow(nu_o_nu0_sq,-1.) * pow((2.*f)+1.,2.)*a2_s) # EQ 46 NOTE the typo from Stixrude 2005
         return eta_s
 
-    def pressure(self, temperature, volume, params):
-        return bm.birch_murnaghan(params['V_0']/volume, params) + \
-                self.__thermal_pressure(temperature,volume, params) - \
-                self.__thermal_pressure(params['T_0'],volume, params)
 
     #calculate isotropic thermal pressure, see
     # Matas et. al. (2007) eq B4
@@ -101,6 +97,7 @@ class SLBBase(eos.EquationOfState):
                 warnings.warn("May be outside the range of validity for EOS")
                 return sol[0][0]
 
+
     def pressure( self, temperature, volume, params):
         """
         Returns the pressure of the mineral at a given temperature and volume [Pa]
@@ -117,6 +114,7 @@ class SLBBase(eos.EquationOfState):
             +(0.5*b_iikkmm*pow(f,2.))) + gr*(E_th - E_th_ref)/volume #EQ 21
 
         return P
+
 
     def grueneisen_parameter(self, pressure, temperature, volume, params):
         """

--- a/tests/test_eos.py
+++ b/tests/test_eos.py
@@ -51,7 +51,7 @@ class eos(BurnManTest):
             self.assertFloatEqual(K_test, Kt_test)
             G_test = i.shear_modulus(pressure, temperature, rock.params['V_0'], rock.params)
             self.assertFloatEqual(G_test, rock.params['G_0'])
-            Density_test = i.density(pressure, temperature, rock.params)
+            Density_test = i.density(rock.params['V_0'], rock.params)
             self.assertFloatEqual(Density_test, rock.params['molar_mass'] / rock.params['V_0'])
             alpha_test = i.thermal_expansivity(pressure, temperature, rock.params['V_0'], rock.params)
             Cp_test = i.heat_capacity_p(pressure, temperature, rock.params['V_0'], rock.params)


### PR DESCRIPTION
Cleaning up some unneeded functions.
Density is defined in the base class for eos. Here I also passed in volume, so it doesn't get computed again. However, this function currently doesn't get called (mineral, composite and solidsolution have their own equations for density).

SLB just had to functions for pressure. They gave the same solutions, I just picked the quicker one. (Still don't know if the solution is good, do you have a benchmark for this, Ian?)


 
