### PR TITLE
Cleanup voigt and reuss functions

### DIFF
--- a/burnman/averaging_schemes.py
+++ b/burnman/averaging_schemes.py
@@ -572,15 +572,11 @@ def reuss_average_function(phase_volume, X):
     volumes and moduli, returns a modulus.
     """
     vol_frac = phase_volume/np.sum(phase_volume)
-    zero_exists = False
     for f,x in zip(vol_frac,X):
-        if x <= 0 and f != 0. :
-            zero_exists = True
-    if zero_exists:
-        warnings.warn("Oops, called reuss_average with Xi<=0!")
-        X_reuss = 0.0
-    else:
-        X_reuss = 1./sum( f/x for f,x in zip(vol_frac, X))
+        if x <= 0 and np.abs(f) > np.finfo(float).eps :
+            warnings.warn("Oops, called reuss_average with Xi<=0!")
+            return 0.0
+    X_reuss = 1./sum( f/x for f,x in zip(vol_frac, X))
     return X_reuss
 
 

--- a/burnman/averaging_schemes.py
+++ b/burnman/averaging_schemes.py
@@ -559,9 +559,8 @@ def voigt_average_function(phase_volume, X):
     voigt_reuss_hill classes, takes a list of
     volumes and moduli, returns a modulus.
     """
-    V_i = phase_volume
-    V_tot = sum(V_i)
-    X_voigt = sum(V_i[i]/V_tot * X[i] for i in range(len(phase_volume)))
+    vol_frac = phase_volume/np.sum(phase_volume)
+    X_voigt = sum( f*x for f,x in zip(vol_frac, X))
     return X_voigt
 
 
@@ -572,13 +571,16 @@ def reuss_average_function(phase_volume, X):
     voigt_reuss_hill classes, takes a list of
     volumes and moduli, returns a modulus.
     """
-    V_i = phase_volume
-    V_tot = sum(V_i)
-    if (min(X)<=0.0):
-        X_reuss = 0.0
+    vol_frac = phase_volume/np.sum(phase_volume)
+    zero_exists = False
+    for f,x in zip(vol_frac,X):
+        if x <= 0 and f != 0. :
+            zero_exists = True
+    if zero_exists:
         warnings.warn("Oops, called reuss_average with Xi<=0!")
+        X_reuss = 0.0
     else:
-        X_reuss = 1./sum(V_i[i]/V_tot* 1./X[i] for i in range(len(phase_volume)))
+        X_reuss = 1./sum( f/x for f,x in zip(vol_frac, X))
     return X_reuss
 
 

--- a/tests/test_averaging.py
+++ b/tests/test_averaging.py
@@ -28,6 +28,23 @@ class mypericlase (burnman.Mineral):
             'eta_s_0': 2.8 }
         burnman.Mineral.__init__(self)
 
+class my_nonrigid_mineral (burnman.Mineral):
+    def __init__(self):
+        self.params = {
+            'equation_of_state':'slb3',
+            'V_0': 11.24e-6,
+            'K_0': 161.0e9,
+            'Kprime_0': 3.8,
+            'G_0': 0.e9,
+            'Gprime_0': 0.0,
+            'molar_mass': .0403,
+            'n': 2,
+            'Debye_0': 773.,
+            'grueneisen_0': 1.5,
+            'q_0': 1.5,
+            'eta_s_0': 0.0 }
+        burnman.Mineral.__init__(self)
+
 class VRH_average(BurnManTest):
     def test_one_object(self):
         v = avg.voigt_reuss_hill_function([2.0],[0.123])
@@ -126,6 +143,12 @@ class Reuss(BurnManTest):
         self.assertFloatEqual(7473.353, v_phi[0])
         self.assertFloatEqual(272.635, K[0]/1.e9)
         self.assertFloatEqual(153.452, G[0]/1.e9)
+
+    def test_non_present_non_rigid_phase(self):
+        rock = burnman.Composite ( [1.0, 0.0], [mypericlase(), my_nonrigid_mineral()] )
+        rho, v_p, v_s, v_phi, K, G = \
+            burnman.velocities_from_rock(rock,[10e9,], [300,], averaging_scheme=avg.Reuss())
+        self.assertFloatEqual(150.901, G[0]/1.e9)
 
 class Voigt(BurnManTest):
     def test_1(self):

--- a/tests/test_averaging.py
+++ b/tests/test_averaging.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 import unittest
 import os, sys
+import warnings
 sys.path.insert(1,os.path.abspath('..'))
 
 import burnman
@@ -149,6 +150,14 @@ class Reuss(BurnManTest):
         rho, v_p, v_s, v_phi, K, G = \
             burnman.velocities_from_rock(rock,[10e9,], [300,], averaging_scheme=avg.Reuss())
         self.assertFloatEqual(150.901, G[0]/1.e9)
+
+    def test_present_non_rigid_phase(self):
+        rock = burnman.Composite ( [0.5, 0.5], [mypericlase(), my_nonrigid_mineral()] )
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("ignore")
+            rho, v_p, v_s, v_phi, K, G = \
+                burnman.velocities_from_rock(rock,[10e9,], [300,], averaging_scheme=avg.Reuss())
+            self.assertFloatEqual(0.0, G[0]/1.e9)
 
 class Voigt(BurnManTest):
     def test_1(self):


### PR DESCRIPTION
Heidi Fuqua reported a bug where the Reuss function returns zero when one of the shear moduli of the phases is zero, even when that phase is not present (has zero volume fraction). This fixes that case, as well as slightly cleans up the voigt and reuss average functions.