### PR TITLE
rework Material.name

### DIFF
--- a/burnman/composite.py
+++ b/burnman/composite.py
@@ -48,18 +48,17 @@ class Composite(Material):
             molar fraction for each phase.
         """
 
-        
+        Material.__init__(self)
+
         assert(len(phases)>0)
         self.phases = phases
-        
+
         if fractions is not None:
             self.set_fractions(fractions, fraction_type)
         else:
             self.molar_fractions=None
 
         self.set_averaging_scheme('VoigtReussHill')
-
-        Material.__init__(self)
 
 
     def set_fractions(self, fractions, fraction_type='molar'):

--- a/burnman/material.py
+++ b/burnman/material.py
@@ -128,7 +128,7 @@ class Material(object):
             The desired temperature in [K].
         """
         if not hasattr(self, "_pressure"):
-            raise Exception("Material.set_state() could not find class member _cached. "
+            raise Exception("Material.set_state() could not find class member _pressure. "
                             "Did you forget to call Material.__init__(self) in __init___?")
         self.reset()
         

--- a/burnman/material.py
+++ b/burnman/material.py
@@ -23,6 +23,9 @@ def material_property(func):
             self.varname = self.func.__name__
         
         def get(self, obj):
+            if not hasattr(obj,"_cached"):
+                raise Exception("The material_property decorator could not find class member _cached. "
+                                "Did you forget to call Material.__init__(self) in __init___?")
             cache_array = getattr(obj, "_cached")
             if self.varname not in cache_array:
                 cache_array[self.varname] = self.func(obj)
@@ -51,7 +54,25 @@ class Material(object):
     def __init__(self):
         self._pressure = None
         self._temperature = None
+        if not hasattr(self, "name"):
+            # if a derived class decides to set .name before calling this
+            # constructor (I am looking at you, SLB_2011.py!), do not
+            # overwrite the name here.
+            self.name = self.__class__.__name__
         self._cached = {}
+
+    @property
+    def name(self):
+        """ Human-readable name of this material.
+
+        By default this will return the name of the class, but it can be set
+        to an arbitrary string. Overriden in Mineral.
+        """
+        return self._name
+
+    @name.setter
+    def name(self, value):
+        self._name = value
 
     def set_method(self, method):
         """
@@ -73,7 +94,7 @@ class Material(object):
         name : string
             Name of this material.
         """
-        return "'" + self.__class__.__name__ + "'"
+        return "'" + self.name + "'"
 
     def debug_print(self, indent=""):
         """
@@ -106,6 +127,9 @@ class Material(object):
         temperature : float
             The desired temperature in [K].
         """
+        if not hasattr(self, "_pressure"):
+            raise Exception("Material.set_state() could not find class member _cached. "
+                            "Did you forget to call Material.__init__(self) in __init___?")
         self.reset()
         
         self._pressure = pressure

--- a/burnman/mineral.py
+++ b/burnman/mineral.py
@@ -41,14 +41,15 @@ class Mineral(Material):
     """
 
     def __init__(self):
+        Material.__init__(self)
         if 'params' not in self.__dict__:
             self.params = {}
         self.method = None
         if 'equation_of_state' in self.params:
             self.set_method(self.params['equation_of_state'])
         if 'name' in self.params:
-            self.name=self.params['name']
-        Material.__init__(self)
+            self.name = self.params['name']
+
 
 
 

--- a/burnman/mineral_helpers.py
+++ b/burnman/mineral_helpers.py
@@ -95,6 +95,7 @@ class HelperSpinTransition(Material):
         pressure, and the thermoelastic parameters for hs_mat
         above the transition pressure
         """
+        Material.__init__(self)
         self.transition_pressure = transition_pressure
         self.ls_mat = ls_mat
         self.hs_mat = hs_mat
@@ -141,6 +142,7 @@ class HelperFeDependent(Material):
     """
 
     def __init__(self, iron_number_with_pt, idx):
+        Material.__init__(self)
         self.iron_number_with_pt = iron_number_with_pt
         self.which_index = idx  # take input 0 or 1 from iron_number_with_pt()
         self.method = None

--- a/burnman/mineral_helpers.py
+++ b/burnman/mineral_helpers.py
@@ -38,6 +38,7 @@ class HelperSolidSolution(Mineral):
         comes up with a new mineral by doing a weighted arithmetic
         average of the end member minerals
         """
+        Mineral.__init__(self)
         self.endmembers = endmembers
         self.molar_fractions = molar_fractions
         assert(len(endmembers) == len(molar_fractions))

--- a/tests/test_composite.py
+++ b/tests/test_composite.py
@@ -53,6 +53,9 @@ class composite(BurnManTest):
 
     def test_changevalues(self):
         class mycomposite(burnman.Material):
+            def __init__(self):
+                burnman.Material.__init__(self)
+
             def unroll(self):
                 fractions = [0.3, 0.7]
                 mins = [minerals.Murakami_etal_2012.fe_periclase(), minerals.SLB_2005.periclase()]
@@ -73,6 +76,9 @@ class composite(BurnManTest):
 
     def test_number(self):
         class mycomposite(burnman.Material):
+            def __init__(self):
+                burnman.Material.__init__(self)
+
             def unroll(self):
                 if (self.temperature>500):
                     return ([minerals.Murakami_etal_2012.fe_periclase()],[1.0])

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -1,0 +1,106 @@
+from __future__ import absolute_import
+import unittest
+import inspect
+import os, sys
+sys.path.insert(1,os.path.abspath('..'))
+
+import burnman
+from burnman import minerals
+from util import BurnManTest
+
+# Instantiate every mineral in the mineral library
+class test_material_name(BurnManTest):
+
+    class min_no_name(burnman.Mineral):
+        """
+        Stixrude & Lithgow-Bertelloni 2005 and references therein
+        """
+
+        def __init__(self):
+            self.params = {
+                'equation_of_state': 'slb3',
+                'T_0': 300.,
+                'P_0': 0.,
+                'V_0': 11.24e-6,
+                'K_0': 161.0e9,
+                'Kprime_0': 3.8,
+                'G_0': 131.0e9,
+                'Gprime_0': 2.1,
+                'molar_mass': .0403,
+                'n': 2,
+                'Debye_0': 773.,
+                'grueneisen_0': 1.5,
+                'q_0': 1.5,
+                'eta_s_0': 2.8}
+            burnman.Mineral.__init__(self)
+
+    class min_with_name(burnman.Mineral):
+        """
+        Stixrude & Lithgow-Bertelloni 2005 and references therein
+        """
+
+        def __init__(self):
+            self.params = {
+                'name': 'name set in params',
+                'equation_of_state': 'slb3',
+                'T_0': 300.,
+                'P_0': 0.,
+                'V_0': 11.24e-6,
+                'K_0': 161.0e9,
+                'Kprime_0': 3.8,
+                'G_0': 131.0e9,
+                'Gprime_0': 2.1,
+                'molar_mass': .0403,
+                'n': 2,
+                'Debye_0': 773.,
+                'grueneisen_0': 1.5,
+                'q_0': 1.5,
+                'eta_s_0': 2.8}
+            burnman.Mineral.__init__(self)
+
+    class min_with_name_manually(burnman.Mineral):
+        """
+        Stixrude & Lithgow-Bertelloni 2005 and references therein
+        """
+
+        def __init__(self):
+            self.params = {
+                'equation_of_state': 'slb3',
+                'T_0': 300.,
+                'P_0': 0.,
+                'V_0': 11.24e-6,
+                'K_0': 161.0e9,
+                'Kprime_0': 3.8,
+                'G_0': 131.0e9,
+                'Gprime_0': 2.1,
+                'molar_mass': .0403,
+                'n': 2,
+                'Debye_0': 773.,
+                'grueneisen_0': 1.5,
+                'q_0': 1.5,
+                'eta_s_0': 2.8}
+            self.name = "manually set"
+            burnman.Mineral.__init__(self)
+
+    def test_mineral_without_name(self):
+        m = self.min_no_name()
+        self.assertEquals(m.name, "min_no_name")
+        m.name = "bla"
+        self.assertEquals(m.name, "bla")
+
+    def test_mineral_with_name(self):
+
+        m = self.min_with_name()
+        self.assertEquals(m.name, "name set in params")
+        m.name = "bla"
+        self.assertEquals(m.name, "bla")
+
+    def test_set_name_before_init(self):
+        m = self.min_with_name_manually()
+        self.assertEquals(m.name, "manually set")
+        m.name = "bla"
+        self.assertEquals(m.name, "bla")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -8,8 +8,8 @@ import burnman
 from burnman import minerals
 from util import BurnManTest
 
-# Instantiate every mineral in the mineral library
 class test_material_name(BurnManTest):
+    """ test Material.name and that we can edit and override it in Mineral"""
 
     class min_no_name(burnman.Mineral):
         """

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -16,6 +16,7 @@ from test_tools import *
 from test_minerals import *
 from test_seismic import *
 from test_decorators import *
+from test_material import *
 
 
 import os, sys


### PR DESCRIPTION
- create writeable property Material.name and allow overriding it in
Mineral.params
- check that Material.__init__ is called in a couple of places
- call Material.__init__ in derived classes
- rewire Material.to_string to use .name