### PR TITLE
Changed excess_enthalpy references to excess_energy for clarity

### DIFF
--- a/burnman/data/input_raw_endmember_datasets/SLBdata_to_burnman.py
+++ b/burnman/data/input_raw_endmember_datasets/SLBdata_to_burnman.py
@@ -165,7 +165,7 @@ for idx, m in enumerate(ds):
             if landau_params.has_key(m[0].lower()):
                 print '[\'landau\', {\'Tc_0\':', landau_params[m[0].lower()][0], ', \'S_D\':', landau_params[m[0].lower()][2], ', \'V_D\':', landau_params[m[0].lower()][1], '}]',
             if configurational_entropies[m[0].lower()] != 'None':
-                print '[\'linear\', {\'G_0\':', 0., ', \'delta_S\':', configurational_entropies[m[0].lower()], ', \'delta_V\':', 0., '}]',
+                print '[\'linear\', {\'delta_E\':', 0., ', \'delta_S\':', configurational_entropies[m[0].lower()], ', \'delta_V\':', 0., '}]',
             print ']'
             print ''
         print '        self.uncertainties = {'

--- a/burnman/eos/property_modifiers.py
+++ b/burnman/eos/property_modifiers.py
@@ -153,7 +153,7 @@ def _linear_excesses(pressure, temperature, params):
     (especially in solid solution calculations)
     """
 
-    G = params['G_0'] \
+    G = params['delta_E'] \
         - (temperature) * params['delta_S'] \
         + (pressure) * params['delta_V']
     dGdT = -params['delta_S']

--- a/burnman/minerals/HP_2011_ds62.py
+++ b/burnman/minerals/HP_2011_ds62.py
@@ -36,9 +36,9 @@ class CFMASO_garnet(SolidSolution):
                            [andr(), '[Ca]3[Fe]2Si3O12']]
         self.type = 'asymmetric'
         self.alphas = [1.0, 1.0, 2.7, 2.7]
-        self.enthalpy_interaction = [[2.5e3, 31.e3, 53.2e3],
-                                    [5.e3, 37.24e3],
-                                    [2.e3]]
+        self.energy_interaction = [[2.5e3, 31.e3, 53.2e3],
+                                   [5.e3, 37.24e3],
+                                   [2.e3]]
         SolidSolution.__init__(self, molar_fractions)
 
 

--- a/burnman/minerals/SLB_2011.py
+++ b/burnman/minerals/SLB_2011.py
@@ -53,7 +53,7 @@ class clinopyroxene(SolidSolution):
         self.type = 'symmetric'
         self.endmembers = [[diopside(), '[Ca][Mg][Si]2O6'], [hedenbergite(), '[Ca][Fe][Si]2O6'], [
                            clinoenstatite(), '[Mg][Mg][Si]2O6'], [ca_tschermaks(), '[Ca][Al][Si1/2Al1/2]2O6'], [jadeite(), '[Na][Al][Si]2O6']]
-        self.enthalpy_interaction = [
+        self.energy_interaction = [
             [0., 24.74e3, 26.e3, 24.3e3], [24.74e3, 0., 0.e3], [60.53136e3, 0.0], [10.e3]]
 
         SolidSolution.__init__(self, molar_fractions)
@@ -66,7 +66,7 @@ class garnet(SolidSolution):
         self.type = 'symmetric'
         self.endmembers = [[pyrope(), '[Mg]3[Al][Al]Si3O12'], [almandine(), '[Fe]3[Al][Al]Si3O12'], [
                                    grossular(), '[Ca]3[Al][Al]Si3O12'], [mg_majorite(), '[Mg]3[Mg][Si]Si3O12'], [jd_majorite(), '[Na2/3Al1/3]3[Al][Si]Si3O12']]
-        self.enthalpy_interaction = [
+        self.energy_interaction = [
             [0.0, 30.e3, 21.20278e3, 0.0], [0.0, 0.0, 0.0], [57.77596e3, 0.0], [0.0]]
 
         SolidSolution.__init__(self, molar_fractions)
@@ -79,7 +79,7 @@ class akimotoite(SolidSolution):
         self.type = 'symmetric'
         self.endmembers = [[mg_akimotoite(), '[Mg][Si]O3'], [
                            fe_akimotoite(), '[Fe][Si]O3'], [corundum(), '[Al][Al]O3']]
-        self.enthalpy_interaction = [[0.0, 66.e3], [66.e3]]
+        self.energy_interaction = [[0.0, 66.e3], [66.e3]]
 
         SolidSolution.__init__(self, molar_fractions)
 
@@ -90,7 +90,7 @@ class ferropericlase(SolidSolution):
         self.name = 'magnesiowustite/ferropericlase'
         self.type = 'symmetric'
         self.endmembers = [[periclase(), '[Mg]O'], [wuestite(), '[Fe]O']]
-        self.enthalpy_interaction = [[13.e3]]
+        self.energy_interaction = [[13.e3]]
 
         SolidSolution.__init__(self, molar_fractions)
 
@@ -102,7 +102,7 @@ class mg_fe_olivine(SolidSolution):
         self.type = 'symmetric'
         self.endmembers = [[
             forsterite(), '[Mg]2SiO4'], [fayalite(), '[Fe]2SiO4']]
-        self.enthalpy_interaction = [[7.81322e3]]
+        self.energy_interaction = [[7.81322e3]]
 
         SolidSolution.__init__(self, molar_fractions)
 
@@ -114,7 +114,7 @@ class orthopyroxene(SolidSolution):
         self.type = 'symmetric'
         self.endmembers = [[enstatite(), '[Mg][Mg][Si]SiO6'], [ferrosilite(), '[Fe][Fe][Si]SiO6'], [
                            mg_tschermaks(), '[Mg][Al][Al]SiO6'], [ortho_diopside(), '[Ca][Mg][Si]SiO6']]
-        self.enthalpy_interaction = [
+        self.energy_interaction = [
             [0.0, 0.0, 32.11352e3], [0.0, 0.0], [48.35316e3]]
 
         SolidSolution.__init__(self, molar_fractions)
@@ -127,7 +127,7 @@ class plagioclase(SolidSolution):
         self.type = 'symmetric'
         self.endmembers = [
             [anorthite(), '[Ca][Al]2Si2O8'], [albite(), '[Na][Al1/2Si1/2]2Si2O8']]
-        self.enthalpy_interaction = [[26.0e3]]
+        self.energy_interaction = [[26.0e3]]
 
         SolidSolution.__init__(self, molar_fractions)
 
@@ -139,7 +139,7 @@ class post_perovskite(SolidSolution):
         self.type = 'symmetric'
         self.endmembers = [[mg_post_perovskite(), '[Mg][Si]O3'], [
                            fe_post_perovskite(), '[Fe][Si]O3'], [al_post_perovskite(), '[Al][Al]O3']]
-        self.enthalpy_interaction = [[0.0, 60.0e3], [0.0]]
+        self.energy_interaction = [[0.0, 60.0e3], [0.0]]
 
         SolidSolution.__init__(self, molar_fractions)
 
@@ -151,7 +151,7 @@ class mg_fe_perovskite(SolidSolution):
         self.type = 'symmetric'
         self.endmembers = [[mg_perovskite(), '[Mg][Si]O3'], [
                            fe_perovskite(), '[Fe][Si]O3'], [al_perovskite(), '[Al][Al]O3']]
-        self.enthalpy_interaction = [[0.0, 116.0e3], [0.0]]
+        self.energy_interaction = [[0.0, 116.0e3], [0.0]]
 
         SolidSolution.__init__(self, molar_fractions)
 
@@ -163,7 +163,7 @@ class mg_fe_ringwoodite(SolidSolution):
         self.type = 'symmetric'
         self.endmembers = [
             [mg_ringwoodite(), '[Mg]2SiO4'], [fe_ringwoodite(), '[Fe]2SiO4']]
-        self.enthalpy_interaction = [[9.34084e3]]
+        self.energy_interaction = [[9.34084e3]]
 
         SolidSolution.__init__(self, molar_fractions)
 
@@ -175,7 +175,7 @@ class mg_fe_aluminous_spinel(SolidSolution):
         self.type = 'symmetric'
         self.endmembers = [[spinel(), '[Mg3/4Al1/4]4[Al7/8Mg1/8]8O16'], [
                                    hercynite(), '[Fe3/4Al1/4]4[Al7/8Fe1/8]8O16']]
-        self.enthalpy_interaction = [[5.87646e3]]
+        self.energy_interaction = [[5.87646e3]]
 
         SolidSolution.__init__(self, molar_fractions)
 
@@ -187,7 +187,7 @@ class mg_fe_wadsleyite(SolidSolution):
         self.type = 'symmetric'
         self.endmembers = [
             [mg_wadsleyite(), '[Mg]2SiO4'], [fe_wadsleyite(), '[Fe]2SiO4']]
-        self.enthalpy_interaction = [[16.74718e3]]
+        self.energy_interaction = [[16.74718e3]]
 
         SolidSolution.__init__(self, molar_fractions)
 
@@ -291,7 +291,7 @@ class spinel (Mineral):
             'molar_mass': formula_mass(formula, atomic_masses)}
 
         self.property_modifiers = [
-            ['linear', {'G_0': 0.0, 'delta_S': 43.76, 'delta_V': 0.0}]]
+            ['linear', {'delta_E': 0.0, 'delta_S': 43.76, 'delta_V': 0.0}]]
 
         self.uncertainties = {
             'err_F_0': 32000.0,
@@ -330,7 +330,7 @@ class hercynite (Mineral):
             'molar_mass': formula_mass(formula, atomic_masses)}
 
         self.property_modifiers = [
-            ['linear', {'G_0': 0.0, 'delta_S': 97.28, 'delta_V': 0.0}]]
+            ['linear', {'delta_E': 0.0, 'delta_S': 97.28, 'delta_V': 0.0}]]
 
         self.uncertainties = {
             'err_F_0': 35000.0,
@@ -405,7 +405,7 @@ class fayalite (Mineral):
             'molar_mass': formula_mass(formula, atomic_masses)}
 
         self.property_modifiers = [
-            ['linear', {'G_0': 0.0, 'delta_S': 26.76, 'delta_V': 0.0}]]
+            ['linear', {'delta_E': 0.0, 'delta_S': 26.76, 'delta_V': 0.0}]]
 
         self.uncertainties = {
             'err_F_0': 1000.0,
@@ -480,7 +480,7 @@ class fe_wadsleyite (Mineral):
             'molar_mass': formula_mass(formula, atomic_masses)}
 
         self.property_modifiers = [
-            ['linear', {'G_0': 0.0, 'delta_S': 26.76, 'delta_V': 0.0}]]
+            ['linear', {'delta_E': 0.0, 'delta_S': 26.76, 'delta_V': 0.0}]]
 
         self.uncertainties = {
             'err_F_0': 7000.0,
@@ -555,7 +555,7 @@ class fe_ringwoodite (Mineral):
             'molar_mass': formula_mass(formula, atomic_masses)}
 
         self.property_modifiers = [
-            ['linear', {'G_0': 0.0, 'delta_S': 26.76, 'delta_V': 0.0}]]
+            ['linear', {'delta_E': 0.0, 'delta_S': 26.76, 'delta_V': 0.0}]]
 
         self.uncertainties = {
             'err_F_0': 2000.0,
@@ -630,7 +630,7 @@ class ferrosilite (Mineral):
             'molar_mass': formula_mass(formula, atomic_masses)}
 
         self.property_modifiers = [
-            ['linear', {'G_0': 0.0, 'delta_S': 26.76, 'delta_V': 0.0}]]
+            ['linear', {'delta_E': 0.0, 'delta_S': 26.76, 'delta_V': 0.0}]]
 
         self.uncertainties = {
             'err_F_0': 4000.0,
@@ -777,7 +777,7 @@ class hedenbergite (Mineral):
             'molar_mass': formula_mass(formula, atomic_masses)}
 
         self.property_modifiers = [
-            ['linear', {'G_0': 0.0, 'delta_S': 13.38, 'delta_V': 0.0}]]
+            ['linear', {'delta_E': 0.0, 'delta_S': 13.38, 'delta_V': 0.0}]]
 
         self.uncertainties = {
             'err_F_0': 45000.0,
@@ -852,7 +852,7 @@ class ca_tschermaks (Mineral):
             'molar_mass': formula_mass(formula, atomic_masses)}
 
         self.property_modifiers = [
-            ['linear', {'G_0': 0.0, 'delta_S': 11.525, 'delta_V': 0.0}]]
+            ['linear', {'delta_E': 0.0, 'delta_S': 11.525, 'delta_V': 0.0}]]
 
         self.uncertainties = {
             'err_F_0': 5000.0,
@@ -963,7 +963,7 @@ class hp_clinoferrosilite (Mineral):
             'molar_mass': formula_mass(formula, atomic_masses)}
 
         self.property_modifiers = [
-            ['linear', {'G_0': 0.0, 'delta_S': 26.76, 'delta_V': 0.0}]]
+            ['linear', {'delta_E': 0.0, 'delta_S': 26.76, 'delta_V': 0.0}]]
 
         self.uncertainties = {
             'err_F_0': 4000.0,
@@ -1074,7 +1074,7 @@ class fe_akimotoite (Mineral):
             'molar_mass': formula_mass(formula, atomic_masses)}
 
         self.property_modifiers = [
-            ['linear', {'G_0': 0.0, 'delta_S': 13.38, 'delta_V': 0.0}]]
+            ['linear', {'delta_E': 0.0, 'delta_S': 13.38, 'delta_V': 0.0}]]
 
         self.uncertainties = {
             'err_F_0': 21000.0,
@@ -1185,7 +1185,7 @@ class almandine (Mineral):
             'molar_mass': formula_mass(formula, atomic_masses)}
 
         self.property_modifiers = [
-            ['linear', {'G_0': 0.0, 'delta_S': 40.14, 'delta_V': 0.0}]]
+            ['linear', {'delta_E': 0.0, 'delta_S': 40.14, 'delta_V': 0.0}]]
 
         self.uncertainties = {
             'err_F_0': 29000.0,
@@ -1518,7 +1518,7 @@ class fe_perovskite (Mineral):
             'molar_mass': formula_mass(formula, atomic_masses)}
 
         self.property_modifiers = [
-            ['linear', {'G_0': 0.0, 'delta_S': 13.38, 'delta_V': 0.0}]]
+            ['linear', {'delta_E': 0.0, 'delta_S': 13.38, 'delta_V': 0.0}]]
 
         self.uncertainties = {
             'err_F_0': 6000.0,
@@ -1629,7 +1629,7 @@ class fe_post_perovskite (Mineral):
             'molar_mass': formula_mass(formula, atomic_masses)}
 
         self.property_modifiers = [
-            ['linear', {'G_0': 0.0, 'delta_S': 13.38, 'delta_V': 0.0}]]
+            ['linear', {'delta_E': 0.0, 'delta_S': 13.38, 'delta_V': 0.0}]]
 
         self.uncertainties = {
             'err_F_0': 21000.0,
@@ -1740,7 +1740,7 @@ class wuestite (Mineral):
             'molar_mass': formula_mass(formula, atomic_masses)}
 
         self.property_modifiers = [
-            ['linear', {'G_0': 0.0, 'delta_S': 13.38, 'delta_V': 0.0}]]
+            ['linear', {'delta_E': 0.0, 'delta_S': 13.38, 'delta_V': 0.0}]]
 
         self.uncertainties = {
             'err_F_0': 1000.0,
@@ -1815,7 +1815,7 @@ class fe_ca_ferrite (Mineral):
             'molar_mass': formula_mass(formula, atomic_masses)}
 
         self.property_modifiers = [
-            ['linear', {'G_0': 0.0, 'delta_S': 13.38, 'delta_V': 0.0}]]
+            ['linear', {'delta_E': 0.0, 'delta_S': 13.38, 'delta_V': 0.0}]]
 
         self.uncertainties = {
             'err_F_0': 25000.0,

--- a/burnman/solidsolution.py
+++ b/burnman/solidsolution.py
@@ -64,8 +64,8 @@ class SolidSolution(Mineral):
             if self.type == 'ideal':
                 self.solution_model = IdealSolution(self.endmembers)
             else:
-                if hasattr(self, 'enthalpy_interaction') == False:
-                    self.enthalpy_interaction = None
+                if hasattr(self, 'energy_interaction') == False:
+                    self.energy_interaction = None
                 if hasattr(self, 'volume_interaction') == False:
                     self.volume_interaction = None
                 if hasattr(self, 'entropy_interaction') == False:
@@ -73,17 +73,17 @@ class SolidSolution(Mineral):
 
                 if self.type == 'symmetric':
                     self.solution_model = SymmetricRegularSolution(
-                        self.endmembers, self.enthalpy_interaction, self.volume_interaction, self.entropy_interaction)
+                        self.endmembers, self.energy_interaction, self.volume_interaction, self.entropy_interaction)
                 elif self.type == 'asymmetric':
                     try:
                         self.solution_model = AsymmetricRegularSolution(
-                            self.endmembers, self.alphas, self.enthalpy_interaction, self.volume_interaction, self.entropy_interaction)
+                            self.endmembers, self.alphas, self.energy_interaction, self.volume_interaction, self.entropy_interaction)
                     except:
                         raise Exception(
                             "'alphas' attribute missing from solid solution")
                 elif self.type == 'subregular':
                     self.solution_model = SubregularSolution(
-                        self.endmembers, self.enthalpy_interaction, self.volume_interaction, self.entropy_interaction)
+                        self.endmembers, self.energy_interaction, self.volume_interaction, self.entropy_interaction)
                 else:
                     raise Exception(
                         "Solution model type " + self.params['type'] + "not recognised.")

--- a/burnman/solutionmodel.py
+++ b/burnman/solutionmodel.py
@@ -255,7 +255,7 @@ class AsymmetricRegularSolution (IdealSolution):
     Solution model implementing the asymmetric regular solution model formulation (Holland and Powell, 2003)
     """
 
-    def __init__(self, endmembers, alphas, enthalpy_interaction, volume_interaction=None, entropy_interaction=None):
+    def __init__(self, endmembers, alphas, energy_interaction, volume_interaction=None, entropy_interaction=None):
 
         self.n_endmembers = len(endmembers)
 
@@ -263,14 +263,14 @@ class AsymmetricRegularSolution (IdealSolution):
         self.alpha = np.array(alphas)
 
         # Create 2D arrays of interaction parameters
-        self.Wh = np.zeros(shape=(self.n_endmembers, self.n_endmembers))
+        self.We = np.zeros(shape=(self.n_endmembers, self.n_endmembers))
         self.Ws = np.zeros(shape=(self.n_endmembers, self.n_endmembers))
         self.Wv = np.zeros(shape=(self.n_endmembers, self.n_endmembers))
 
         # setup excess enthalpy interaction matrix
         for i in range(self.n_endmembers):
             for j in range(i + 1, self.n_endmembers):
-                self.Wh[i][j] = 2. * enthalpy_interaction[
+                self.We[i][j] = 2. * energy_interaction[
                     i][j - i - 1] / (self.alpha[i] + self.alpha[j])
 
         if entropy_interaction is not None:
@@ -300,22 +300,22 @@ class AsymmetricRegularSolution (IdealSolution):
         phi = self._phi(molar_fractions)
 
         q = np.zeros(len(molar_fractions))
-        Hint = np.zeros(len(molar_fractions))
+        Eint = np.zeros(len(molar_fractions))
         Sint = np.zeros(len(molar_fractions))
         Vint = np.zeros(len(molar_fractions))
 
         for l in range(self.n_endmembers):
             q = np.array([kd(i, l) - phi[i] for i in range(self.n_endmembers)])
 
-            Hint[l] = 0. - self.alpha[l] * np.dot(q, np.dot(self.Wh, q))
+            Eint[l] = 0. - self.alpha[l] * np.dot(q, np.dot(self.We, q))
             Sint[l] = 0. - self.alpha[l] * np.dot(q, np.dot(self.Ws, q))
             Vint[l] = 0. - self.alpha[l] * np.dot(q, np.dot(self.Wv, q))
 
-        return Hint, Sint, Vint
+        return Eint, Sint, Vint
 
     def _non_ideal_excess_partial_gibbs(self, pressure, temperature, molar_fractions):
-        Hint, Sint, Vint = self._non_ideal_interactions(molar_fractions)
-        return Hint - temperature * Sint + pressure * Vint
+        Eint, Sint, Vint = self._non_ideal_interactions(molar_fractions)
+        return Eint - temperature * Sint + pressure * Vint
 
     def excess_partial_gibbs_free_energies(self, pressure, temperature, molar_fractions):
         ideal_gibbs = IdealSolution._ideal_excess_partial_gibbs(
@@ -341,9 +341,9 @@ class AsymmetricRegularSolution (IdealSolution):
 
     def excess_enthalpy(self, pressure, temperature, molar_fractions):
         phi = self._phi(molar_fractions)
-        H_excess = np.dot(self.alpha.T, molar_fractions) * np.dot(
-            phi.T, np.dot(self.Wh, phi))
-        return H_excess + pressure * self.excess_volume(pressure, temperature, molar_fractions)
+        E_excess = np.dot(self.alpha.T, molar_fractions) * np.dot(
+            phi.T, np.dot(self.We, phi))
+        return E_excess + pressure * self.excess_volume(pressure, temperature, molar_fractions)
 
     def activity_coefficients(self, pressure, temperature, molar_fractions):
         if temperature > 1.e-10:
@@ -361,10 +361,10 @@ class SymmetricRegularSolution (AsymmetricRegularSolution):
     Solution model implementing the symmetric regular solution model
     """
 
-    def __init__(self, endmembers, enthalpy_interaction, volume_interaction=None, entropy_interaction=None):
+    def __init__(self, endmembers, energy_interaction, volume_interaction=None, entropy_interaction=None):
         alphas = np.ones(len(endmembers))
         AsymmetricRegularSolution.__init__(
-            self, endmembers, alphas, enthalpy_interaction, volume_interaction, entropy_interaction)
+            self, endmembers, alphas, energy_interaction, volume_interaction, entropy_interaction)
 
 
 class SubregularSolution (IdealSolution):
@@ -373,20 +373,20 @@ class SubregularSolution (IdealSolution):
     Solution model implementing the subregular solution model formulation (Helffrich and Wood, 1989)
     """
 
-    def __init__(self, endmembers, enthalpy_interaction, volume_interaction=None, entropy_interaction=None):
+    def __init__(self, endmembers, energy_interaction, volume_interaction=None, entropy_interaction=None):
 
         self.n_endmembers = len(endmembers)
 
         # Create 2D arrays of interaction parameters
-        self.Wh = np.zeros(shape=(self.n_endmembers, self.n_endmembers))
+        self.We = np.zeros(shape=(self.n_endmembers, self.n_endmembers))
         self.Ws = np.zeros(shape=(self.n_endmembers, self.n_endmembers))
         self.Wv = np.zeros(shape=(self.n_endmembers, self.n_endmembers))
 
         # setup excess enthalpy interaction matrix
         for i in range(self.n_endmembers):
             for j in range(i + 1, self.n_endmembers):
-                self.Wh[i][j] = enthalpy_interaction[i][j - i - 1][0]
-                self.Wh[j][i] = enthalpy_interaction[i][j - i - 1][1]
+                self.We[i][j] = energy_interaction[i][j - i - 1][0]
+                self.We[j][i] = energy_interaction[i][j - i - 1][1]
 
         if entropy_interaction is not None:
             for i in range(self.n_endmembers):
@@ -422,14 +422,14 @@ class SubregularSolution (IdealSolution):
 
     def _non_ideal_interactions(self, molar_fractions):
         # equation (6') of Helffrich and Wood, 1989
-        Hint = self._non_ideal_function(self.Wh, molar_fractions)
+        Eint = self._non_ideal_function(self.We, molar_fractions)
         Sint = self._non_ideal_function(self.Ws, molar_fractions)
         Vint = self._non_ideal_function(self.Wv, molar_fractions)
-        return Hint, Sint, Vint
+        return Eint, Sint, Vint
 
     def _non_ideal_excess_partial_gibbs(self, pressure, temperature, molar_fractions):
-        Hint, Sint, Vint = self._non_ideal_interactions(molar_fractions)
-        return Hint - temperature * Sint + pressure * Vint
+        Eint, Sint, Vint = self._non_ideal_interactions(molar_fractions)
+        return Eint - temperature * Sint + pressure * Vint
 
     def excess_partial_gibbs_free_energies(self, pressure, temperature, molar_fractions):
         ideal_gibbs = IdealSolution._ideal_excess_partial_gibbs(
@@ -452,9 +452,9 @@ class SubregularSolution (IdealSolution):
         return S_conf + S_excess
 
     def excess_enthalpy(self, pressure, temperature, molar_fractions):
-        H_excess = np.dot(
-            molar_fractions, self._non_ideal_function(self.Wh, molar_fractions))
-        return H_excess + pressure * self.excess_volume(pressure, temperature, molar_fractions)
+        E_excess = np.dot(
+            molar_fractions, self._non_ideal_function(self.We, molar_fractions))
+        return E_excess + pressure * self.excess_volume(pressure, temperature, molar_fractions)
 
     def activity_coefficients(self, pressure, temperature, molar_fractions):
         if temperature > 1.e-10:

--- a/examples/example_gibbs_modifiers.py
+++ b/examples/example_gibbs_modifiers.py
@@ -16,7 +16,7 @@ These modifications currently take the forms:
   and Holland and Powell (2011)
 - Bragg-Williams corrections
   (implementation of Holland and Powell (1996))
-- Linear (a simple G_0 + deltaV*P - deltaS*T
+- Linear (a simple delta_E + delta_V*P - delta_S*T
 - Magnetic (Chin, Hertzman and Sundman (1987))
 
 *Uses:*
@@ -191,7 +191,7 @@ if __name__ == "__main__":
                 'molar_mass': formula_mass(formula, atomic_masses)}
 
             self.property_modifiers = [
-                ['linear', {'G_0': 0., 'delta_S': 12., 'delta_V': 0.}]]
+                ['linear', {'delta_E': 0., 'delta_S': 12., 'delta_V': 0.}]]
 
             self.uncertainties = {
                 'err_F_0': 1000.0,

--- a/examples/example_solid_solution.py
+++ b/examples/example_solid_solution.py
@@ -156,7 +156,7 @@ if __name__ == "__main__":
             self.type = 'symmetric'
             self.endmembers = [[minerals.HP_2011_ds62.py(), '[Mg]3[Al]2Si3O12'], [
                                minerals.HP_2011_ds62.alm(), '[Fe]3[Al]2Si3O12']]
-            self.enthalpy_interaction = [[2.5e3]]
+            self.energy_interaction = [[2.5e3]]
 
             burnman.SolidSolution.__init__(self, molar_fractions)
 
@@ -225,7 +225,7 @@ if __name__ == "__main__":
             self.type = 'symmetric'
             self.endmembers = [[minerals.HP_2011_ds62.py(), '[Mg]3[Al]2Si3O12'], [
                                minerals.HP_2011_ds62.alm(), '[Fe]3[Al]2Si3O12'], [minerals.HP_2011_ds62.maj(), '[Mg]3[Mg1/2Si1/2]2Si3O12']]
-            self.enthalpy_interaction = [[2.5e3, 0.0e3], [10.0e3]]
+            self.energy_interaction = [[2.5e3, 0.0e3], [10.0e3]]
             self.entropy_interaction = [[0.0e3, 0.0e3], [0.0e3]]
             self.volume_interaction = [[0.0e3, 0.0e3], [0.0e3]]
 
@@ -271,7 +271,7 @@ if __name__ == "__main__":
                 [minerals.HP_2011_ds62.andr(), '[Ca]3[Fe]2Si3O12']]
             self.type = 'asymmetric'
             self.alphas = [1.0, 1.0, 2.7, 2.7]
-            self.enthalpy_interaction = [[2.5e3, 31.e3, 53.2e3],
+            self.energy_interaction = [[2.5e3, 31.e3, 53.2e3],
                                         [5.e3, 37.24e3],
                                         [2.e3]]
             burnman.SolidSolution.__init__(self, molar_fractions)
@@ -312,7 +312,7 @@ if __name__ == "__main__":
             self.type = 'subregular'
             self.endmembers = [[minerals.HP_2011_ds62.py(), '[Mg]3[Al]2Si3O12'], [minerals.HP_2011_ds62.alm(), '[Fe]3[Al]2Si3O12'], [
                                minerals.HP_2011_ds62.gr(), '[Ca]3[Al]2Si3O12'], [minerals.HP_2011_ds62.spss(), '[Mn]3[Al]2Si3O12']]
-            self.enthalpy_interaction = [
+            self.energy_interaction = [
                 [[2117., 695.], [9834., 21627.], [12083., 12083.]], [[6773., 873.], [539., 539.]], [[0., 0.]]]
             self.volume_interaction = [[[0.07e-5, 0.], [0.058e-5, 0.012e-5], [0.04e-5, 0.03e-5]], [
                 [0.03e-5, 0.], [0.04e-5, 0.01e-5]], [[0., 0.]]]
@@ -320,7 +320,7 @@ if __name__ == "__main__":
                 [[0., 0.], [5.78, 5.78], [7.67, 7.67]], [[1.69, 1.69], [0., 0.]], [[0., 0.]]]
 
             # Published values are on a 4-oxygen (1-cation) basis
-            for interaction in [self.enthalpy_interaction, self.volume_interaction, self.entropy_interaction]:
+            for interaction in [self.energy_interaction, self.volume_interaction, self.entropy_interaction]:
                 for i in range(len(interaction)):
                     for j in range(len(interaction[i])):
                         for k in range(len(interaction[i][j])):
@@ -337,10 +337,10 @@ if __name__ == "__main__":
         g5_excess_gibbs[i] = g5.excess_gibbs
 
     plt.plot(comp, g5_excess_gibbs / 3., 'r-', linewidth=1.,
-             label='Py-Gr excess enthalpy (J/cation-mole)')
+             label='Py-Gr excess gibbs (J/cation-mole)')
 
     plt.title("Asymmetric py-gr join (Ganguly et al., 1996; Figure 5)")
-    plt.ylabel("Excess enthalpy of solution (J/cation-mol)")
+    plt.ylabel("Excess gibbs free energy of solution (J/cation-mol)")
     plt.xlabel("XCa")
     plt.legend(loc='lower left')
     plt.show()

--- a/misc/benchmarks/solidsolution_benchmarks.py
+++ b/misc/benchmarks/solidsolution_benchmarks.py
@@ -44,7 +44,7 @@ class o_d_spinel(burnman.SolidSolution):
         self.type = 'symmetric'
         self.endmembers = [[minerals.HP_2011_ds62.sp(), '[Mg][Al]2O4'], [
                            minerals.HP_2011_ds62.sp(), '[Al][Mg1/2Al1/2]2O4']]
-        self.enthalpy_interaction = [[0.0]]
+        self.energy_interaction = [[0.0]]
 
         burnman.SolidSolution.__init__(self)
 
@@ -82,7 +82,7 @@ class orthopyroxene_red(burnman.SolidSolution):
         self.type = 'symmetric'
         self.endmembers = [[minerals.SLB_2011.enstatite(), 'Mg[Mg][Si]SiO6'], [
             minerals.SLB_2011.mg_tschermaks(), 'Mg[Al][Al]SiO6']]
-        self.enthalpy_interaction = [[0.0]]
+        self.energy_interaction = [[0.0]]
 
         burnman.SolidSolution.__init__(self)
 
@@ -94,7 +94,7 @@ class orthopyroxene_blue(burnman.SolidSolution):
         self.type = 'symmetric'
         self.endmembers = [[minerals.SLB_2011.enstatite(), 'Mg[Mg]Si2O6'], [
             minerals.SLB_2011.mg_tschermaks(), 'Mg[Al]AlSiO6']]
-        self.enthalpy_interaction = [[0.0]]
+        self.energy_interaction = [[0.0]]
 
         burnman.SolidSolution.__init__(self)
 
@@ -106,7 +106,7 @@ class orthopyroxene_long_dashed(burnman.SolidSolution):
         self.type = 'symmetric'
         self.endmembers = [[minerals.SLB_2011.enstatite(), 'Mg[Mg]Si2O6'], [
             minerals.SLB_2011.mg_tschermaks(), '[Mg1/2Al1/2]2AlSiO6']]
-        self.enthalpy_interaction = [[10.0e3]]
+        self.energy_interaction = [[10.0e3]]
 
         burnman.SolidSolution.__init__(self)
 
@@ -118,7 +118,7 @@ class orthopyroxene_short_dashed(burnman.SolidSolution):
         self.type = 'symmetric'
         self.endmembers = [[minerals.SLB_2011.enstatite(), 'Mg[Mg][Si]2O6'], [
             minerals.SLB_2011.mg_tschermaks(), 'Mg[Al][Al1/2Si1/2]2O6']]
-        self.enthalpy_interaction = [[0.0]]
+        self.energy_interaction = [[0.0]]
 
         burnman.SolidSolution.__init__(self)
 
@@ -150,7 +150,7 @@ plt.show()
 
 # Excess volume of solution
 
-# Excess enthalpy of solution
+# Excess energy of solution
 # Figure 5 of Stixrude and Lithgow-Bertelloni, 2011
 
 
@@ -161,7 +161,7 @@ class clinopyroxene(burnman.SolidSolution):
         self.type = 'asymmetric'
         self.endmembers = [[minerals.SLB_2011.diopside(), '[Ca][Mg][Si]2O6'], [
                            minerals.SLB_2011.ca_tschermaks(), '[Ca][Al][Si1/2Al1/2]2O6']]
-        self.enthalpy_interaction = [[26.e3]]
+        self.energy_interaction = [[26.e3]]
         self.alphas = [1.0, 3.5]
 
         burnman.SolidSolution.__init__(self)
@@ -185,6 +185,6 @@ plt.imshow(fig1, extent=[0.0, 1.0, -2., 8.0], aspect='auto')
 plt.plot(comp, gibbs / 1000., 'b--', linewidth=3.)
 plt.xlim(0.0, 1.0)
 plt.ylim(-2., 8.0)
-plt.ylabel("Excess enthalpy of solution (kJ/mol)")
+plt.ylabel("Excess energy of solution (kJ/mol)")
 plt.xlabel("cats fraction")
 plt.show()

--- a/tests/test_modifiers.py
+++ b/tests/test_modifiers.py
@@ -14,7 +14,7 @@ from util import BurnManTest
 class Modifiers(BurnManTest):
 
     def test_excess_functions(self):
-        linear_params = {'G_0': 1200., 'delta_S': 5., 'delta_V': 1.e-7}
+        linear_params = {'delta_E': 1200., 'delta_S': 5., 'delta_V': 1.e-7}
         landau_params = {'Tc_0': 800., 'S_D': 5., 'V_D': 1.e-7}
         landau_params_2 = {'Tc_0': 1200., 'S_D': 5., 'V_D': 1.e-7}
         landau_hp_params = {

--- a/tests/test_solidsolution.py
+++ b/tests/test_solidsolution.py
@@ -65,7 +65,7 @@ class forsterite_ss(burnman.SolidSolution):
         self.name = 'Dummy solid solution'
         self.type = 'symmetric'
         self.endmembers = [[forsterite(), '[Mg]2SiO4']]
-        self.enthalpy_interaction = []
+        self.energy_interaction = []
 
         burnman.SolidSolution.__init__(self, molar_fractions)
 
@@ -79,7 +79,7 @@ class forsterite_forsterite_ss(burnman.SolidSolution):
         self.type = 'symmetric'
         self.endmembers = [[forsterite(), '[Mg]2SiO4'], [
                            forsterite(), '[Mg]2SiO4']]
-        self.enthalpy_interaction = [[0.]]
+        self.energy_interaction = [[0.]]
 
         burnman.SolidSolution.__init__(self, molar_fractions)
 
@@ -106,7 +106,7 @@ class olivine_ss(burnman.SolidSolution):
         self.type = 'symmetric'
         self.endmembers = [[
             forsterite(), '[Mg]2SiO4'], [fayalite(), '[Fe]2SiO4']]
-        self.enthalpy_interaction = [[8.4e3]]
+        self.energy_interaction = [[8.4e3]]
 
         burnman.SolidSolution.__init__(self, molar_fractions)
 
@@ -121,7 +121,7 @@ class orthopyroxene(burnman.SolidSolution):
         self.type = 'symmetric'
         self.endmembers = [[forsterite(), '[Mg][Mg]Si2O6'], [
                            forsterite(), '[Mg1/2Al1/2][Mg1/2Al1/2]AlSiO6']]
-        self.enthalpy_interaction = [[burnman.constants.gas_constant * 1.0e3]]
+        self.energy_interaction = [[burnman.constants.gas_constant * 1.0e3]]
 
         burnman.SolidSolution.__init__(self, molar_fractions)
 
@@ -135,7 +135,7 @@ class two_site_ss(burnman.SolidSolution):
         self.type = 'symmetric'
         self.endmembers = [[forsterite(), '[Mg]3[Al]2Si3O12'], [
                            forsterite(), '[Fe]3[Al]2Si3O12'], [forsterite(), '[Mg]3[Mg1/2Si1/2]2Si3O12']]
-        self.enthalpy_interaction = [[10.0e3, 5.0e3], [-10.0e3]]
+        self.energy_interaction = [[10.0e3, 5.0e3], [-10.0e3]]
 
         burnman.SolidSolution.__init__(self, molar_fractions)
 
@@ -151,7 +151,7 @@ class two_site_ss_subregular(burnman.SolidSolution):
         self.endmembers = [[forsterite(), '[Mg]3[Al]2Si3O12'], [
                            forsterite(), '[Fe]3[Al]2Si3O12'], [forsterite(), '[Mg]3[Mg1/2Si1/2]2Si3O12']]
         # Interaction parameters
-        self.enthalpy_interaction = [
+        self.energy_interaction = [
             [[10.e3, 10.e3], [5.e3, 5.e3]], [[-10.e3, -10.e3]]]
 
         burnman.SolidSolution.__init__(self, molar_fractions)
@@ -225,9 +225,9 @@ class test_solidsolution(BurnManTest):
     def test_ol_Wh(self):
         ol_ss = olivine_ss()
         H_excess = ol_ss.solution_model.excess_enthalpy(
-            1.e5, 1000., [0.5, 0.5])
-        Wh = ol_ss.solution_model.Wh[0][1]
-        self.assertArraysAlmostEqual([Wh / 4.0], [H_excess])
+            1.e5, 1000., [0.5, 0.5]) # Hxs = Exs if Vxs=0
+        We = ol_ss.solution_model.We[0][1]
+        self.assertArraysAlmostEqual([We / 4.0], [H_excess])
 
     def test_order_disorder(self):
         opx = orthopyroxene()


### PR DESCRIPTION
A minor cosmetic tweak for clarity...

I was reminded recently of a point of contention wrt excess properties. It is conventional to describe excess properties in terms of an excess enthalpy, so I originally formulated the models in terms of excess enthalpy, entropy and volume at 0 K, 0 Pa. This is correct, but for the case of a model where Gex = a - bT + cP, it is clearer to use energy in place of enthalpy - then there's no need to declare the reference state, as G = E - TS + PV. It also makes the code a little easier to understand. See, for example, the excess_enthalpy function in solutionmodel.py.

As this PR changes the front-end naming convention for excess properties, the change should be included in Release 1.0.