### PR TITLE
fixed solid solution constructor

### DIFF
--- a/burnman/minerals/HP_2011_ds62.py
+++ b/burnman/minerals/HP_2011_ds62.py
@@ -39,7 +39,7 @@ class CFMASO_garnet(SolidSolution):
         self.energy_interaction = [[2.5e3, 31.e3, 53.2e3],
                                    [5.e3, 37.24e3],
                                    [2.e3]]
-        SolidSolution.__init__(self, molar_fractions)
+        SolidSolution.__init__(self, molar_fractions=molar_fractions)
 
 
 """

--- a/burnman/minerals/SLB_2011.py
+++ b/burnman/minerals/SLB_2011.py
@@ -32,7 +32,7 @@ class c2c_pyroxene(SolidSolution):
         self.endmembers = [
             [hp_clinoenstatite(), '[Mg]2Si2O6'], [hp_clinoferrosilite(), '[Fe]2Si2O6']]
 
-        SolidSolution.__init__(self, molar_fractions)
+        SolidSolution.__init__(self, molar_fractions=molar_fractions)
 
 
 class ca_ferrite_structured_phase(SolidSolution):
@@ -43,7 +43,7 @@ class ca_ferrite_structured_phase(SolidSolution):
         self.endmembers = [[mg_ca_ferrite(), '[Mg]Al[Al]O4'], [
                            fe_ca_ferrite(), '[Fe]Al[Al]O4'], [na_ca_ferrite(), '[Na]Al[Si]O4']]
 
-        SolidSolution.__init__(self, molar_fractions)
+        SolidSolution.__init__(self, molar_fractions=molar_fractions)
 
 
 class clinopyroxene(SolidSolution):
@@ -56,7 +56,7 @@ class clinopyroxene(SolidSolution):
         self.energy_interaction = [
             [0., 24.74e3, 26.e3, 24.3e3], [24.74e3, 0., 0.e3], [60.53136e3, 0.0], [10.e3]]
 
-        SolidSolution.__init__(self, molar_fractions)
+        SolidSolution.__init__(self, molar_fractions=molar_fractions)
 
 
 class garnet(SolidSolution):
@@ -69,7 +69,7 @@ class garnet(SolidSolution):
         self.energy_interaction = [
             [0.0, 30.e3, 21.20278e3, 0.0], [0.0, 0.0, 0.0], [57.77596e3, 0.0], [0.0]]
 
-        SolidSolution.__init__(self, molar_fractions)
+        SolidSolution.__init__(self, molar_fractions=molar_fractions)
 
 
 class akimotoite(SolidSolution):
@@ -81,7 +81,7 @@ class akimotoite(SolidSolution):
                            fe_akimotoite(), '[Fe][Si]O3'], [corundum(), '[Al][Al]O3']]
         self.energy_interaction = [[0.0, 66.e3], [66.e3]]
 
-        SolidSolution.__init__(self, molar_fractions)
+        SolidSolution.__init__(self, molar_fractions=molar_fractions)
 
 
 class ferropericlase(SolidSolution):
@@ -92,7 +92,7 @@ class ferropericlase(SolidSolution):
         self.endmembers = [[periclase(), '[Mg]O'], [wuestite(), '[Fe]O']]
         self.energy_interaction = [[13.e3]]
 
-        SolidSolution.__init__(self, molar_fractions)
+        SolidSolution.__init__(self, molar_fractions=molar_fractions)
 
 
 class mg_fe_olivine(SolidSolution):
@@ -104,7 +104,7 @@ class mg_fe_olivine(SolidSolution):
             forsterite(), '[Mg]2SiO4'], [fayalite(), '[Fe]2SiO4']]
         self.energy_interaction = [[7.81322e3]]
 
-        SolidSolution.__init__(self, molar_fractions)
+        SolidSolution.__init__(self, molar_fractions=molar_fractions)
 
 
 class orthopyroxene(SolidSolution):
@@ -117,7 +117,7 @@ class orthopyroxene(SolidSolution):
         self.energy_interaction = [
             [0.0, 0.0, 32.11352e3], [0.0, 0.0], [48.35316e3]]
 
-        SolidSolution.__init__(self, molar_fractions)
+        SolidSolution.__init__(self, molar_fractions=molar_fractions)
 
 
 class plagioclase(SolidSolution):
@@ -129,7 +129,7 @@ class plagioclase(SolidSolution):
             [anorthite(), '[Ca][Al]2Si2O8'], [albite(), '[Na][Al1/2Si1/2]2Si2O8']]
         self.energy_interaction = [[26.0e3]]
 
-        SolidSolution.__init__(self, molar_fractions)
+        SolidSolution.__init__(self, molar_fractions=molar_fractions)
 
 
 class post_perovskite(SolidSolution):
@@ -141,7 +141,7 @@ class post_perovskite(SolidSolution):
                            fe_post_perovskite(), '[Fe][Si]O3'], [al_post_perovskite(), '[Al][Al]O3']]
         self.energy_interaction = [[0.0, 60.0e3], [0.0]]
 
-        SolidSolution.__init__(self, molar_fractions)
+        SolidSolution.__init__(self, molar_fractions=molar_fractions)
 
 
 class mg_fe_perovskite(SolidSolution):
@@ -153,7 +153,7 @@ class mg_fe_perovskite(SolidSolution):
                            fe_perovskite(), '[Fe][Si]O3'], [al_perovskite(), '[Al][Al]O3']]
         self.energy_interaction = [[0.0, 116.0e3], [0.0]]
 
-        SolidSolution.__init__(self, molar_fractions)
+        SolidSolution.__init__(self, molar_fractions=molar_fractions)
 
 
 class mg_fe_ringwoodite(SolidSolution):
@@ -165,7 +165,7 @@ class mg_fe_ringwoodite(SolidSolution):
             [mg_ringwoodite(), '[Mg]2SiO4'], [fe_ringwoodite(), '[Fe]2SiO4']]
         self.energy_interaction = [[9.34084e3]]
 
-        SolidSolution.__init__(self, molar_fractions)
+        SolidSolution.__init__(self, molar_fractions=molar_fractions)
 
 
 class mg_fe_aluminous_spinel(SolidSolution):
@@ -177,7 +177,7 @@ class mg_fe_aluminous_spinel(SolidSolution):
                                    hercynite(), '[Fe3/4Al1/4]4[Al7/8Fe1/8]8O16']]
         self.energy_interaction = [[5.87646e3]]
 
-        SolidSolution.__init__(self, molar_fractions)
+        SolidSolution.__init__(self, molar_fractions=molar_fractions)
 
 
 class mg_fe_wadsleyite(SolidSolution):
@@ -189,7 +189,7 @@ class mg_fe_wadsleyite(SolidSolution):
             [mg_wadsleyite(), '[Mg]2SiO4'], [fe_wadsleyite(), '[Fe]2SiO4']]
         self.energy_interaction = [[16.74718e3]]
 
-        SolidSolution.__init__(self, molar_fractions)
+        SolidSolution.__init__(self, molar_fractions=molar_fractions)
 
 """
 ENDMEMBERS

--- a/burnman/solidsolution.py
+++ b/burnman/solidsolution.py
@@ -33,7 +33,14 @@ class SolidSolution(Mineral):
     and P derivatives in J/K/mol and m^3/mol.
     """
 
-    def __init__(self, molar_fractions=None):
+    def __init__(self,
+                 solution_type=None,
+                 endmembers=None,
+                 energy_interaction=None,
+                 volume_interaction=None,
+                 entropy_interaction=None,
+                 alphas=None,
+                 molar_fractions=None):
         """
         Set up matrices to speed up calculations for when P, T, X is defined.
 
@@ -55,6 +62,22 @@ class SolidSolution(Mineral):
             pass
         self.method = SolidSolutionMethod()
 
+
+        if solution_type is not None:
+            self.type = solution_type
+        if endmembers is not None:
+            self.endmembers = endmembers
+        if energy_interaction is not None:
+            self.energy_interaction = energy_interaction
+        if volume_interaction is not None:
+            self.volume_interaction = volume_interaction
+        if entropy_interaction is not None:
+            self.entropy_interaction = entropy_interaction
+        if alphas is not None:
+            self.alphas = alphas
+        if endmembers is not None:
+            self.endmembers = endmembers
+        
         if hasattr(self, 'endmembers') == False:
             raise Exception(
                 "'endmembers' attribute missing from solid solution")

--- a/examples/example_solid_solution.py
+++ b/examples/example_solid_solution.py
@@ -71,7 +71,7 @@ if __name__ == "__main__":
             self.endmembers = [[minerals.HP_2011_ds62.py(), '[Mg]3[Al]2Si3O12'], [
                                minerals.HP_2011_ds62.alm(), '[Fe]3[Al]2Si3O12']]
 
-            burnman.SolidSolution.__init__(self, molar_fractions)
+            burnman.SolidSolution.__init__(self, molar_fractions=molar_fractions)
 
     g1 = mg_fe_garnet()
 
@@ -158,7 +158,7 @@ if __name__ == "__main__":
                                minerals.HP_2011_ds62.alm(), '[Fe]3[Al]2Si3O12']]
             self.energy_interaction = [[2.5e3]]
 
-            burnman.SolidSolution.__init__(self, molar_fractions)
+            burnman.SolidSolution.__init__(self, molar_fractions=molar_fractions)
 
     g2 = mg_fe_garnet_2()
     g2_excess_gibbs = np.empty_like(comp)
@@ -229,7 +229,7 @@ if __name__ == "__main__":
             self.entropy_interaction = [[0.0e3, 0.0e3], [0.0e3]]
             self.volume_interaction = [[0.0e3, 0.0e3], [0.0e3]]
 
-            burnman.SolidSolution.__init__(self, molar_fractions)
+            burnman.SolidSolution.__init__(self, molar_fractions=molar_fractions)
 
     g3 = hp_mg_fe_garnet()
     g3_configurational_entropy = np.empty_like(comp)
@@ -274,7 +274,7 @@ if __name__ == "__main__":
             self.energy_interaction = [[2.5e3, 31.e3, 53.2e3],
                                         [5.e3, 37.24e3],
                                         [2.e3]]
-            burnman.SolidSolution.__init__(self, molar_fractions)
+            burnman.SolidSolution.__init__(self, molar_fractions=molar_fractions)
 
     g4 = burnman.minerals.HP_2011_ds62.CFMASO_garnet()
     g4_excess_gibbs_400 = np.empty_like(comp)
@@ -326,7 +326,7 @@ if __name__ == "__main__":
                         for k in range(len(interaction[i][j])):
                             interaction[i][j][k] *= 3.
 
-            burnman.SolidSolution.__init__(self, molar_fractions)
+            burnman.SolidSolution.__init__(self, molar_fractions=molar_fractions)
 
     g5 = mg_fe_ca_garnet_Ganguly()
     g5_excess_gibbs = np.empty_like(comp)


### PR DESCRIPTION
constructor for SolidSolution now takes all arguments required to make the implemented SolutionModels. A class is no longer required to create a new SolidSolution instance.

Almost backwards compatible. The only change is that any calls to __init__ with only the molar_fractions parameter now need to name the variable, i.e.:

`burnman.SolidSolution.__init__(self, molar_fractions)`

should now read

`burnman.SolidSolution.__init__(self, molar_fractions=molar_fractions)`