### PR TITLE
remove example_build_planet residual output for testing

### DIFF
--- a/misc/ref/example_build_planet.py.out
+++ b/misc/ref/example_build_planet.py.out
@@ -1,25 +1,14 @@
 on iteration 1
-  relative central core pressure error between iterations: 1.000000e+00
 on iteration 2
-  relative central core pressure error between iterations: 5.696704e-02
 on iteration 3
-  relative central core pressure error between iterations: 7.656556e-03
 on iteration 4
-  relative central core pressure error between iterations: 8.691833e-04
 on iteration 5
-  relative central core pressure error between iterations: 1.102989e-03
 on iteration 6
-  relative central core pressure error between iterations: 5.376599e-04
 on iteration 7
-  relative central core pressure error between iterations: 2.135243e-04
 on iteration 8
-  relative central core pressure error between iterations: 7.882636e-05
 on iteration 9
-  relative central core pressure error between iterations: 2.834042e-05
 on iteration 10
-  relative central core pressure error between iterations: 1.010033e-05
 on iteration 11
-  relative central core pressure error between iterations: 3.590789e-06
 
 mass/Earth= 1.028, moment of inertia= 0.320
 inner core mass fraction of planet 0.018

--- a/test.sh
+++ b/test.sh
@@ -57,6 +57,7 @@ else
   sed -i.bak -e '/tight_layout : falling back to Agg renderer/d' $t.tmp #remove font warning crap
   sed -i.bak -e '/cannot be converted with the encoding. Glyph may be wrong/d' $t.tmp #remove font warning crap
   sed -i.bak -e '/time old .* time new/d' $t.tmp #remove timing from tests/debye.py
+  sed -i.bak -e '/  relative central core pressure error.*/d' $t.tmp #remove residuals from examples/example_build_planet
 
   rm -f $t.tmp.bak
 


### PR DESCRIPTION
this output seems to randomly break, so remove it.