### PR TITLE
Sign changes and catch warnings

### DIFF
--- a/burnman/eos/property_modifiers.py
+++ b/burnman/eos/property_modifiers.py
@@ -32,15 +32,15 @@ def _landau_excesses(pressure, temperature, params):
     entropy (and heat capacity) terms are equal to zero at 0 K.
 
     N.B. The excesses are for a *completely relaxed* mineral;
-    i.e. the seismic wave propagation is *slow* compared to the
+    for example, seismic wave propagation is *slow* compared to the
     rate of reaction.
     """
 
     Tc = params['Tc_0'] + params['V_D'] * pressure / params['S_D']
 
-    G_disordered = params['S_D'] * ((temperature - Tc) + params['Tc_0'] / 3.)
-    dGdT_disordered = params['S_D']
-    dGdP_disordered = -params['V_D']
+    G_disordered = -params['S_D'] * ((temperature - Tc) + params['Tc_0'] / 3.)
+    dGdT_disordered = -params['S_D']
+    dGdP_disordered = params['V_D']
 
     if temperature < Tc:
         # Wolfram input to check partial differentials
@@ -48,24 +48,26 @@ def _landau_excesses(pressure, temperature, params):
         # D[D[a ((x - c - d*y/a)*(1 - x/(c + d*y/a))^0.5 + c/3*(1 - x/(c +
         # d*y/a))^1.5), x], x]
         Q2 = np.sqrt(1. - temperature / Tc)
-        G = params['S_D'] * \
-            ((temperature - Tc) * Q2 +
-             params['Tc_0'] * Q2 * Q2 * Q2 / 3.) - G_disordered
-        dGdP = - \
-            params['V_D'] * Q2 * (1. + 0.5 * temperature / Tc * (
-                1. - params['Tc_0'] / Tc)) - dGdP_disordered
-        dGdT = params['S_D'] * Q2 * (1.5 - 0.5 * params['Tc_0'] / Tc) - dGdT_disordered
-        d2GdP2 = params['V_D'] * params['V_D'] * temperature / (params['S_D'] * Tc * Tc * Q2) \
-            * (temperature * (1. + params['Tc_0'] / Tc) / (4. * Tc)
-               + Q2 * Q2 * (1. - params['Tc_0'] / Tc) - 1.)
+        G = ( params['S_D'] *
+              ( (temperature - Tc) * Q2 +
+                params['Tc_0'] * Q2 * Q2 * Q2 / 3.) + G_disordered )
+        dGdP = ( -params['V_D'] * Q2 * (1. + 0.5 * temperature / Tc *
+                                        (1. - params['Tc_0'] / Tc))
+                 + dGdP_disordered )
+        dGdT = ( params['S_D'] * Q2 * (1.5 - 0.5 * params['Tc_0'] / Tc) +
+                 dGdT_disordered )
+        d2GdP2 = ( params['V_D'] * params['V_D'] * temperature /
+                   (params['S_D'] * Tc * Tc * Q2) *
+                   (temperature * (1. + params['Tc_0'] / Tc) / (4. * Tc) +
+                    Q2 * Q2 * (1. - params['Tc_0'] / Tc) - 1.) )
         d2GdT2 = -params['S_D'] / (Tc * Q2) * (0.75 - 0.25 * params['Tc_0'] / Tc)
         d2GdPdT = params['V_D'] / (2. * Tc * Q2) \
                   * (1. + (temperature / (2. * Tc) - Q2 * Q2) * (1. - params['Tc_0'] / Tc))
-
+        
     else:
-        G = -G_disordered
-        dGdT = -dGdT_disordered
-        dGdP = -dGdP_disordered
+        G = G_disordered
+        dGdT = dGdT_disordered
+        dGdP = dGdP_disordered
         d2GdT2 = 0.
         d2GdP2 = 0.
         d2GdPdT = 0.

--- a/burnman/eos/property_modifiers.py
+++ b/burnman/eos/property_modifiers.py
@@ -63,7 +63,7 @@ def _landau_excesses(pressure, temperature, params):
         d2GdT2 = -params['S_D'] / (Tc * Q2) * (0.75 - 0.25 * params['Tc_0'] / Tc)
         d2GdPdT = params['V_D'] / (2. * Tc * Q2) \
                   * (1. + (temperature / (2. * Tc) - Q2 * Q2) * (1. - params['Tc_0'] / Tc))
-        
+
     else:
         G = G_disordered
         dGdT = dGdT_disordered

--- a/tests/test_averaging.py
+++ b/tests/test_averaging.py
@@ -177,22 +177,27 @@ class Reuss(BurnManTest):
         rock = burnman.Composite(
             [mypericlase(), my_nonrigid_mineral()], [1.0, 0.0])
         rock.set_averaging_scheme(avg.Reuss())
-        rho, v_p, v_s, v_phi, K, G = \
-            rock.evaluate(
-                ['rho', 'v_p', 'v_s', 'v_phi', 'K_S', 'G'], [10.e9], [300.])
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            rho, v_p, v_s, v_phi, K, G = \
+                                         rock.evaluate(['rho', 'v_p', 'v_s',
+                                                        'v_phi', 'K_S', 'G'],
+                                                       [10.e9], [300.])
+            assert len(w) == 1 # we expect one error to be thrown when p_nonrigid = 0
         self.assertFloatEqual(150.901, G[0] / 1.e9)
 
     def test_present_non_rigid_phase(self):
         rock = burnman.Composite(
             [mypericlase(), my_nonrigid_mineral()], [0.5, 0.5])
+        rock.set_averaging_scheme(avg.Reuss())
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            rock.set_averaging_scheme(avg.Reuss())
             rho, v_p, v_s, v_phi, K, G = \
-                rock.evaluate(
-                    ['rho', 'v_p', 'v_s', 'v_phi', 'K_S', 'G'], [10.e9], [300.])
-            assert len(w) == 1
-            self.assertFloatEqual(0.0, G[0] / 1.e9)
+                                         rock.evaluate(['rho', 'v_p', 'v_s',
+                                                        'v_phi', 'K_S', 'G'],
+                                                       [10.e9], [300.])
+            assert len(w) == 2 # we expect two errors to be thrown when p_nonrigid != 0
+        self.assertFloatEqual(0.0, G[0] / 1.e9)
 
 
 class Voigt(BurnManTest):

--- a/tests/test_solidsolution.py
+++ b/tests/test_solidsolution.py
@@ -164,7 +164,6 @@ class test_solidsolution(BurnManTest):
         T = 1000.
         fo = forsterite()
         fo.set_state(P, T)
-
         fo_ss = forsterite_ss()
         fo_ss.set_composition([1.0])
         fo_ss.set_state(P, T)
@@ -175,7 +174,6 @@ class test_solidsolution(BurnManTest):
         T = 1000.
         fo = forsterite()
         fo.set_state(P, T)
-
         fo_fo_ss = forsterite_forsterite_ss()
         fo_fo_ss.set_composition([0.3, 0.7])
         fo_fo_ss.set_state(P, T)
@@ -194,24 +192,24 @@ class test_solidsolution(BurnManTest):
 
     def test_1_gibbs(self):
         fo, fo_ss = self.setup_1min_ss()
-        endmember_properties = [
-            fo.gibbs, fo.H, fo.S, fo.V, fo.C_p, fo.C_v, fo.alpha, fo.K_T, fo.K_S, fo.gr, fo.G]
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
+            endmember_properties = [fo.gibbs, fo.H, fo.S, fo.V, fo.C_p,
+                                    fo.C_v, fo.alpha, fo.K_T, fo.K_S, fo.gr, fo.G]
             ss_properties = [fo_ss.gibbs, fo_ss.H, fo_ss.S, fo_ss.V, fo_ss.C_p,
                              fo_ss.C_v, fo_ss.alpha, fo_ss.K_T, fo_ss.K_S, fo_ss.gr, fo_ss.G]
-            assert len(w) == 1  # we expect to trigger a reuss_average warning
+            assert len(w) == 3  # we expect to trigger a reuss_average warning
         self.assertArraysAlmostEqual(endmember_properties, ss_properties)
 
     def test_2_gibbs(self):
         fo, fo_ss = self.setup_2min_ss()
-        endmember_properties = [
-            fo.gibbs, fo.H, fo.S, fo.V, fo.C_p, fo.C_v, fo.alpha, fo.K_T, fo.K_S, fo.gr, fo.G]
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
+            endmember_properties = [fo.gibbs, fo.H, fo.S, fo.V, fo.C_p,
+                                    fo.C_v, fo.alpha, fo.K_T, fo.K_S, fo.gr, fo.G]
             ss_properties = [fo_ss.gibbs, fo_ss.H, fo_ss.S, fo_ss.V, fo_ss.C_p,
                              fo_ss.C_v, fo_ss.alpha, fo_ss.K_T, fo_ss.K_S, fo_ss.gr, fo_ss.G]
-            assert len(w) == 1  # we expect to trigger a reuss_average warning
+            assert len(w) == 4  # we expect to trigger a reuss_average warning
         self.assertArraysAlmostEqual(endmember_properties, ss_properties)
 
     def test_ol_gibbs(self):

--- a/tests/test_solidsolution.py
+++ b/tests/test_solidsolution.py
@@ -198,7 +198,7 @@ class test_solidsolution(BurnManTest):
                                     fo.C_v, fo.alpha, fo.K_T, fo.K_S, fo.gr, fo.G]
             ss_properties = [fo_ss.gibbs, fo_ss.H, fo_ss.S, fo_ss.V, fo_ss.C_p,
                              fo_ss.C_v, fo_ss.alpha, fo_ss.K_T, fo_ss.K_S, fo_ss.gr, fo_ss.G]
-            assert len(w) == 3  # we expect to trigger a reuss_average warning
+            assert len(w) == 3  # we expect to trigger 3 shear modulus warnings
         self.assertArraysAlmostEqual(endmember_properties, ss_properties)
 
     def test_2_gibbs(self):
@@ -209,7 +209,7 @@ class test_solidsolution(BurnManTest):
                                     fo.C_v, fo.alpha, fo.K_T, fo.K_S, fo.gr, fo.G]
             ss_properties = [fo_ss.gibbs, fo_ss.H, fo_ss.S, fo_ss.V, fo_ss.C_p,
                              fo_ss.C_v, fo_ss.alpha, fo_ss.K_T, fo_ss.K_S, fo_ss.gr, fo_ss.G]
-            assert len(w) == 4  # we expect to trigger a reuss_average warning
+            assert len(w) == 4  # we expect to trigger 4 shear modulus warnings
         self.assertArraysAlmostEqual(endmember_properties, ss_properties)
 
     def test_ol_gibbs(self):


### PR DESCRIPTION
The sign choices in the Landau model coding were unclear, with G_disordered, S_disordered and V_disordered actually corresponding to the energy/entropy/volume of *ordering*. This isn't a bug, as the values were treated appropriately in the relevant expressions. However, it was unclear.

The new shear modulus raised some warnings in the tests, which have now been caught.