### PR TITLE
Add geophysical layer

### DIFF
--- a/burnman/__init__.py
+++ b/burnman/__init__.py
@@ -176,6 +176,7 @@ from .mineral import Mineral
 from .material import Material
 from .perplex import PerplexMaterial
 from .composite import Composite
+from .layer import Layer
 from .solutionmodel import SolutionModel
 from .solidsolution import SolidSolution
 from .combinedmineral import CombinedMineral

--- a/burnman/__init__.py
+++ b/burnman/__init__.py
@@ -177,6 +177,7 @@ from .material import Material
 from .perplex import PerplexMaterial
 from .composite import Composite
 from .layer import Layer
+from .planet import Planet
 from .solutionmodel import SolutionModel
 from .solidsolution import SolidSolution
 from .combinedmineral import CombinedMineral

--- a/burnman/geotherm.py
+++ b/burnman/geotherm.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import
 import numpy as np
 import scipy.integrate as integrate
+from scipy.optimize import brentq
 from . import tools
 from . import seismic
 
@@ -60,7 +61,7 @@ def adiabatic(pressures, T0, rock):
     """
     This calculates a geotherm based on an anchor temperature and a rock,
     assuming that the rock's temperature follows an adiabatic gradient with
-    pressure. This amounts to integrating:
+    pressure. A good first guess is provided by integrating:
 
     .. math::
         \\frac{\partial T}{\partial P} = \\frac{ \\gamma  T}{ K_s }
@@ -89,60 +90,24 @@ def adiabatic(pressures, T0, rock):
     temperature: list of floats
         The list of temperatures for each pressure. :math:`[K]`
     """
-    temperatures = integrate.odeint(
-        lambda t, p: dTdP(t, p, rock), T0, pressures)
-    return temperatures.ravel()
+    
+    rock.set_state(pressures[0], T0)
+    S0 = rock.S
 
+    delta_S = lambda T, P, rock, S0: S0 - rock.evaluate(['S'], [P], [T])[0]
 
-def dTdP(temperature, pressure, rock):
-    """
-    ODE to integrate temperature with depth for a composite material
-    Assumes that the minerals exist at a common pressure (Reuss bound, should be good for
-    slow deformations at high temperature), as well as an adiabatic process.  This
-    corresponds to conservation of enthalpy.
-    First consider compression of the composite to a new pressure P+dP.  They all heat up
-    different amounts dT[i], according to their thermoelastic parameters.  Then allow them
-    to equilibrate to a constant temperature dT, conserving heat within the composite.
-    This works out to the formula:
+    temperatures = np.empty_like(pressures)
+    temperatures[0] = T0
+    for i in range(1, len(pressures)):
+        args=(pressures[i], rock, S0)
+        sol = tools.bracket(fn=delta_S,
+                            x0=(temperatures[i-1] +
+                                (rock.gr*temperatures[i-1]/rock.K_S) *
+                                (pressures[i] - pressures[i-1])),
+                            dx=1., args=args)
+        temperatures[i] = brentq(delta_S, sol[0], sol[1], args=args)
 
-    .. math::
-        dT/dP = T*\\frac{\Sigma_i(X[i]*C_{p}[i]*\gamma[i]/K[i])}{\Sigma(X[i]*C_{p}[i])}
-
-    Where :math:`X[i]` is the molar fraction of phase :math:`i`, :math:`C_p` is the specific heat at constant pressure,
-    :math:`\gamma` is the Gruneisen parameter and :math:`K` is the bulk modulus.
-    This function is called by :func:`burnman.geotherm.adiabatic`, and in general
-    it will not be too useful in other contexts.
-
-    Parameters
-    ----------
-
-    pressure : float
-        The pressure at which to evaluate dT/dP. :math:`[Pa]`
-
-    temperature : float
-        The temperature at which to evaluate dT/dP. :math:`[K]`
-
-    rock : :class:`burnman.composite`
-        Material for which we compute dT/dP.
-
-    Returns
-    -------
-        dT/dP : float
-          Adiabatic temperature gradient for the composite at a given temperature and pressure. :math:`[K/Pa]`
-    """
-    top = 0
-    bottom = 0
-    rock.set_state(pressure, temperature)
-    (minerals, fractions) = rock.unroll()
-    for (mineral, fraction) in zip(minerals, fractions):
-        gr = mineral.grueneisen_parameter
-        K_s = mineral.adiabatic_bulk_modulus
-        C_p = mineral.heat_capacity_p
-
-        top += fraction * gr * C_p / K_s
-        bottom += fraction * C_p
-
-    return temperature * top / bottom
+    return temperatures
 
 
 table_brown = tools.read_table("input_geotherm/brown_81.txt")

--- a/burnman/geotherm.py
+++ b/burnman/geotherm.py
@@ -24,8 +24,8 @@ def brown_shankland(depths):
         The list of temperatures for each of the pressures. :math:`[K]`
     """
     
-    assert(min(depths) > min(table_brown_depth))
-    assert(max(depths) < max(table_brown_depth))
+    assert(min(depths) >= min(table_brown_depth))
+    assert(max(depths) <= max(table_brown_depth))
     temperature = np.empty_like(depths)
     for i,depth in enumerate(depths):
         temperature[i] = tools.lookup_and_interpolate(
@@ -47,8 +47,8 @@ def anderson(depths):
     temperature : list of floats
         The list of temperatures for each of the pressures. :math:`[K]`
     """
-    assert(min(depths) > min(table_anderson_depth))
-    assert(max(depths) < max(table_anderson_depth))
+    assert(min(depths) >= min(table_anderson_depth))
+    assert(max(depths) <= max(table_anderson_depth))
     temperature = np.empty_like(depths)
     for i,depth in enumerate(depths):
         temperature[i] = tools.lookup_and_interpolate(

--- a/burnman/layer.py
+++ b/burnman/layer.py
@@ -1,0 +1,140 @@
+from __future__ import print_function
+# This file is part of BurnMan - a thermoelastic and thermodynamic toolkit for the Earth and Planetary Sciences
+# Copyright (C) 2012 - 2017 by the BurnMan team, released under the GNU
+# GPL v2 or later.
+
+import numpy as np
+from scipy.integrate import odeint
+from scipy.integrate import quad
+from scipy.interpolate import UnivariateSpline
+from burnman import averaging_schemes
+from burnman import constants
+import warnings
+
+from .material import Material
+from .mineral import Mineral
+from .composite import Composite
+from .seismic import Seismic1DModel
+
+
+class Layer(object):
+    """
+    A planetary layer class
+    """
+    def __init__(self, name=None,  min_depth=None, max_depth=None, n_slices = None):
+        
+        self.name = name
+
+        self.min_depth = min_depth
+        self.max_depth = max_depth
+        self.thickness = self.max_depth-self.min_depth
+        self.n_slices = n_slices
+        self.depths = np.arange(min_depth, max_depth, n_slices)
+
+    
+        self.pressures = None
+        self.temperatures = None
+        self.composition = None
+        #planet radius
+        # mass
+        # moment_inertia
+        
+    def set_composition(self,composition):
+        assert(isinstance(composition, Material) or isinstance(composition, Composite) or isinstance(composition, Mineral)  )
+        self.composition = composition
+    
+    def set_pressures(self, seismicmodel_or_array):
+        if isinstance(seismicmodel_or_array, Seismic1DModel):
+            seismicmodel = seismicmodel_or_array
+            self.pressures = seismicmodel.get_pressures(self.depths)
+        else:
+            self.pressures = seismicmodel_or_array
+        warnings.Warn("By setting the pressures in your layer by hand, you are making the")
+
+    def set_temperature(self, temperatures)
+
+    def _evaluate_eos(self):
+        # evaluate each layer separately
+        for layer in self.layers:
+            mypressures = self.pressures[layer.n_start: layer.n_end]
+            mytemperatures = self.temperatures[layer.n_start: layer.n_end]
+
+            density = layer.rock.evaluate(['density'], mypressures, mytemperatures)
+
+            self.densities[layer.n_start: layer.n_end] = density
+
+    def _compute_gravity(self, density, radii):
+        """
+        Calculate the gravity of the planet, based on a density profile.  This integrates
+        Poisson's equation in radius, under the assumption that the planet is laterally
+        homogeneous.
+        """
+
+        start_gravity = 0.0
+        for layer in self.layers:
+            radii = self.radial_slices[layer.n_start: layer.n_end]
+            density = self.densities[layer.n_start: layer.n_end]
+            rhofunc = UnivariateSpline(radii, density)
+            #Create a spline fit of density as a function of radius
+
+            #Numerically integrate Poisson's equation
+            poisson = lambda p, x: 4.0 * np.pi * constants.G * rhofunc(x) * x * x
+            grav = np.ravel(odeint( poisson, start_gravity, radii))
+            start_gravity = grav[-1]
+            self.gravity[layer.n_start: layer.n_end] = grav
+
+        # we need to skip scaling gravity[0]
+        self.gravity[1:] = self.gravity[1:]/self.radial_slices[1:]/self.radial_slices[1:]
+
+    def _compute_pressure(self, density, gravity, radii):
+        """
+        Calculate the pressure profile based on density and gravity.  This integrates
+        the equation for hydrostatic equilibrium  P = rho g z.
+        """
+
+        start_pressure = 0.0
+        for layer in self.layers[::-1]:
+            radii = self.radial_slices[layer.n_start: layer.n_end]
+            density = self.densities[layer.n_start: layer.n_end]
+            gravity = self.gravity[layer.n_start: layer.n_end]
+
+            # convert radii to depths
+            depths = radii[-1]-radii
+
+            # Make a spline fit of density as a function of depth
+            rhofunc = UnivariateSpline(depths[::-1], density[::-1])
+            # Make a spline fit of gravity as a function of depth
+            gfunc = UnivariateSpline(depths[::-1], gravity[::-1])
+
+            # integrate the hydrostatic equation
+            pressure = np.ravel(odeint((lambda p, x : gfunc(x)* rhofunc(x)), start_pressure, depths[::-1]))
+            start_pressure = pressure[-1]
+
+            self.pressures[layer.n_start: layer.n_end] = pressure[::-1]
+
+    def _compute_mass( self):
+        """
+        calculates the mass of the entire planet [kg]
+        """
+        mass = 0.0
+        for layer in self.layers:
+            radii = self.radial_slices[layer.n_start: layer.n_end]
+            density = self.densities[layer.n_start: layer.n_end]
+            rhofunc = UnivariateSpline(radii, density)
+            layer.mass = quad(lambda r : 4*np.pi*rhofunc(r)*r*r,
+                            radii[0], radii[-1])[0]
+            mass += layer.mass
+        return mass
+
+    def _compute_moment_of_inertia( self):
+        """
+        #Returns the moment of inertia of the planet [kg m^2]
+        """
+        moment = 0.0
+        for layer in self.layers:
+            radii = self.radial_slices[layer.n_start: layer.n_end]
+            density = self.densities[layer.n_start: layer.n_end]
+            rhofunc = UnivariateSpline(radii, density)
+            moment += quad(lambda r : 8.0/3.0*np.pi*rhofunc(r)*r*r*r*r,
+                           radii[0], radii[-1])[0]
+        return moment

--- a/burnman/layer.py
+++ b/burnman/layer.py
@@ -56,12 +56,12 @@ class Layer(object):
         self._temperatures = None
         self.sublayers = None
 
-    def set_composition(self, composition):
+    def set_material(self, material):
         """
-        Set the composition of a Layer with a Material
+        Set the material of a Layer with a Material
         """
-        assert(isinstance(composition, Material))
-        self.composition = composition
+        assert(isinstance(material, Material))
+        self.material = material
         self.reset()
 
     def set_temperature_mode(self, temperature_mode='adiabat',
@@ -169,7 +169,7 @@ class Layer(object):
 
         self.sublayers = []
         for l in range(len(self.depths)):
-            self.sublayers.append(self.composition.copy())
+            self.sublayers.append(self.material.copy())
             self.sublayers[l].set_state(
                 self._pressures[l], self._temperatures[l])
 
@@ -180,7 +180,7 @@ class Layer(object):
         """
         if self.temperature_mode == 'adiabat' or self.temperature_mode == 'modified_adiabat':
             adiabat = geotherm.adiabatic(
-                pressures, temperature_top, self.composition)
+                pressures, temperature_top, self.material)
         else:
             adiabat = np.zeros_like(self.depths)
         return adiabat + self.usertemperatures
@@ -190,7 +190,7 @@ class Layer(object):
         Returns updated gravity and pressure 
         set_state() loops over this until consistency is achieved.
         """
-        [density] = self.composition.evaluate(
+        [density] = self.material.evaluate(
             ['density'], pressures, temperatures)
         grav = self._compute_gravity(density, gravity_bottom)
         press = self._compute_pressure(density, grav, pressure_top)

--- a/burnman/layer.py
+++ b/burnman/layer.py
@@ -238,10 +238,11 @@ class Layer(object):
         all = None
         if radlist is None:
             for prop in properties:
-                if hasattr(self.material,prop):
-                    oneprop = np.array([getattr(self.sublayers[i],prop) for i in range(len(self.sublayers))])
-                else:
+                if hasattr(self,prop):
                     oneprop = getattr(self,prop)
+                else:
+                    oneprop = np.array([getattr(self.sublayers[i],prop) for i in range(len(self.sublayers))])
+                
                 if all is None:
                     all = np.array(oneprop)
                 else:

--- a/burnman/layer.py
+++ b/burnman/layer.py
@@ -211,15 +211,14 @@ class Layer(object):
         def poisson(p, x): return 4.0 * np.pi * \
             constants.G * rhofunc(x) * x * x
         grav = np.ravel(
-            odeint(
-                poisson,
-                gravity_bottom *
-                radii[0] *
-                radii[0],
-                radii))
-        grav[:] = grav[:] / radii[:] / radii[:]
+            odeint( poisson, gravity_bottom *
+                radii[0] * radii[0], radii))
+        
         if radii[0] == 0:
             grav[0] = 0
+            grav[1:] = grav[1:] / radii[1:] / radii[1:]
+        else:
+            grav[:] = grav[:] / radii[:] / radii[:]
         return grav[::-1]
 
     def _compute_pressure(self, density, gravity, pressure_top):

--- a/burnman/layer.py
+++ b/burnman/layer.py
@@ -31,10 +31,7 @@ class Layer(object):
         self.n_slices = n_slices
         self.depths = np.arange(min_depth, max_depth, n_slices)
 
-    
-        self.pressures = None
-        self.temperatures = None
-        self.composition = None
+
         #planet radius
         # mass
         # moment_inertia
@@ -52,6 +49,15 @@ class Layer(object):
         warnings.Warn("By setting the pressures in your layer by hand, you are making the")
 
     def set_temperature(self, temperatures)
+    
+    def set_state(self, pressuremode = 'selfconsistent',P=None, g0=None, temperaturemode='selfconsistent',T=None)
+        if temperaturemode == 'fixed':
+            assert(len(T)==len(self.depths))
+            self.temperatures = T
+        if pressuremode == 'fixed':
+            assert(len(P)==len(self.depths))
+            self.pressures = P
+            warnings.Warn("By setting the pressures in your layer by hand, you are making the")
 
     def _evaluate_eos(self):
         # evaluate each layer separately
@@ -138,3 +144,505 @@ class Layer(object):
             moment += quad(lambda r : 8.0/3.0*np.pi*rhofunc(r)*r*r*r*r,
                            radii[0], radii[-1])[0]
         return moment
+
+
+
+    @property
+    def pressure(self):
+        """
+        Returns current pressure that was set with :func:`~burnman.material.Material.set_state`.
+
+
+        Notes
+        -----
+        - Aliased with :func:`~burnman.material.Material.P`.
+
+        Returns
+        -------
+        pressure : float
+            Pressure in [Pa].
+        """
+        return self._pressure
+
+    @property
+    def temperature(self):
+        """
+        Returns current temperature that was set with :func:`~burnman.material.Material.set_state`.
+
+        Notes
+        -----
+        - Aliased with :func:`~burnman.material.Material.T`.
+
+        Returns
+        -------
+        temperature : float
+            Temperature in [K].
+        """
+        return self._temperature
+
+    @material_property
+    def internal_energy(self):
+        """
+        Returns the internal energy of the mineral.
+
+        Notes
+        -----
+        - Needs to be implemented in derived classes.
+        - Aliased with :func:`~burnman.material.Material.energy`.
+
+        Returns
+        -------
+        internal_energy : float
+            The internal energy in [J].
+        """
+        raise NotImplementedError(
+            "need to implement internal_energy() in derived class!")
+
+    @material_property
+    def molar_gibbs(self):
+        """
+        Returns the Gibbs free energy of the mineral.
+
+        Notes
+        -----
+        - Needs to be implemented in derived classes.
+        - Aliased with :func:`~burnman.material.Material.gibbs`.
+
+        Returns
+        -------
+        molar_gibbs : float
+            Gibbs free energy in [J].
+        """
+        raise NotImplementedError(
+            "need to implement molar_gibbs() in derived class!")
+
+    @material_property
+    def molar_helmholtz(self):
+        """
+        Returns the Helmholtz free energy of the mineral.
+
+        Notes
+        -----
+        - Needs to be implemented in derived classes.
+        - Aliased with :func:`~burnman.material.Material.helmholtz`.
+
+        Returns
+        -------
+        molar_helmholtz : float
+            Helmholtz free energy in [J].
+        """
+        raise NotImplementedError(
+            "need to implement molar_helmholtz() in derived class!")
+
+    @material_property
+    def molar_mass(self):
+        """
+        Returns molar mass of the mineral.
+
+        Notes
+        -----
+        - Needs to be implemented in derived classes.
+
+        Returns
+        -------
+        molar_mass : float
+            Molar mass in [kg/mol].
+        """
+        raise NotImplementedError(
+            "need to implement molar_mass() in derived class!")
+
+    @material_property
+    def molar_volume(self):
+        """
+        Returns molar volume of the mineral.
+
+        Notes
+        -----
+        - Needs to be implemented in derived classes.
+        - Aliased with :func:`~burnman.material.Material.V`.
+
+        Returns
+        -------
+        molar_volume : float
+            Molar volume in [m^3/mol].
+        """
+        raise NotImplementedError(
+            "need to implement molar_volume() in derived class!")
+
+    @material_property
+    def density(self):
+        """
+        Returns the density of this material.
+
+        Notes
+        -----
+        - Needs to be implemented in derived classes.
+        - Aliased with :func:`~burnman.material.Material.rho`.
+
+        Returns
+        -------
+        density : float
+            The density of this material in [kg/m^3].
+        """
+        raise NotImplementedError(
+            "need to implement density() in derived class!")
+
+    @material_property
+    def molar_entropy(self):
+        """
+        Returns entropy of the mineral.
+
+        Notes
+        -----
+        - Needs to be implemented in derived classes.
+        - Aliased with :func:`~burnman.material.Material.S`.
+
+        Returns
+        -------
+        entropy : float
+            Entropy in [J].
+        """
+        raise NotImplementedError(
+            "need to implement molar_entropy() in derived class!")
+
+    @material_property
+    def molar_enthalpy(self):
+        """
+        Returns enthalpy of the mineral.
+
+        Notes
+        -----
+        - Needs to be implemented in derived classes.
+        - Aliased with :func:`~burnman.material.Material.H`.
+
+        Returns
+        -------
+        enthalpy : float
+            Enthalpy in [J].
+        """
+        raise NotImplementedError(
+            "need to implement molar_enthalpy() in derived class!")
+
+    @material_property
+    def isothermal_bulk_modulus(self):
+        """
+        Returns isothermal bulk modulus of the material.
+
+        Notes
+        -----
+        - Needs to be implemented in derived classes.
+        - Aliased with :func:`~burnman.material.Material.K_T`.
+
+        Returns
+        -------
+        isothermal_bulk_modulus : float
+            Bulk modulus in [Pa].
+        """
+        raise NotImplementedError(
+            "need to implement isothermal_bulk_moduls() in derived class!")
+
+    @material_property
+    def adiabatic_bulk_modulus(self):
+        """
+        Returns the adiabatic bulk modulus of the mineral.
+
+        Notes
+        -----
+        - Needs to be implemented in derived classes.
+        - Aliased with :func:`~burnman.material.Material.K_S`.
+
+        Returns
+        -------
+        adiabatic_bulk_modulus : float
+            Adiabatic bulk modulus in [Pa].
+        """
+        raise NotImplementedError(
+            "need to implement adiabatic_bulk_modulus() in derived class!")
+
+    @material_property
+    def isothermal_compressibility(self):
+        """
+        Returns isothermal compressibility of the mineral (or inverse isothermal bulk modulus).
+
+        Notes
+        -----
+        - Needs to be implemented in derived classes.
+        - Aliased with :func:`~burnman.material.Material.beta_T`.
+
+        Returns
+        -------
+        (K_T)^-1 : float
+            Compressibility in [1/Pa].
+        """
+        raise NotImplementedError(
+            "need to implement compressibility() in derived class!")
+
+    @material_property
+    def adiabatic_compressibility(self):
+        """
+        Returns adiabatic compressibility of the mineral (or inverse adiabatic bulk modulus).
+
+
+        Notes
+        -----
+        - Needs to be implemented in derived classes.
+        - Aliased with :func:`~burnman.material.Material.beta_S`.
+
+        Returns
+        -------
+        adiabatic_compressibility : float
+            adiabatic compressibility in [1/Pa].
+        """
+        raise NotImplementedError(
+            "need to implement compressibility() in derived class!")
+
+    @material_property
+    def shear_modulus(self):
+        """
+        Returns shear modulus of the mineral.
+
+        Notes
+        -----
+        - Needs to be implemented in derived classes.
+        - Aliased with :func:`~burnman.material.Material.beta_G`.
+
+        Returns
+        -------
+        shear_modulus : float
+            Shear modulus in [Pa].
+        """
+        raise NotImplementedError(
+            "need to implement shear_modulus() in derived class!")
+
+    @material_property
+    def p_wave_velocity(self):
+        """
+        Returns P wave speed of the mineral.
+
+        Notes
+        -----
+        - Needs to be implemented in derived classes.
+        - Aliased with :func:`~burnman.material.Material.v_p`.
+
+        Returns
+        -------
+        p_wave_velocity : float
+            P wave speed in [m/s].
+        """
+        raise NotImplementedError(
+            "need to implement p_wave_velocity() in derived class!")
+
+    @material_property
+    def bulk_sound_velocity(self):
+        """
+        Returns bulk sound speed of the mineral.
+
+        Notes
+        -----
+        - Needs to be implemented in derived classes.
+        - Aliased with :func:`~burnman.material.Material.v_phi`.
+
+        Returns
+        -------
+        bulk sound velocity: float
+            Sound velocity in [m/s].
+        """
+        raise NotImplementedError(
+            "need to implement bulk_sound_velocity() in derived class!")
+
+    @material_property
+    def shear_wave_velocity(self):
+        """
+        Returns shear wave speed of the mineral.
+
+        Notes
+        -----
+        - Needs to be implemented in derived classes.
+        - Aliased with :func:`~burnman.material.Material.v_s`.
+
+        Returns
+        -------
+        shear_wave_velocity : float
+            Wave speed in [m/s].
+        """
+        raise NotImplementedError(
+            "need to implement shear_wave_velocity() in derived class!")
+
+    @material_property
+    def grueneisen_parameter(self):
+        """
+        Returns the grueneisen parameter of the mineral.
+
+        Notes
+        -----
+        - Needs to be implemented in derived classes.
+        - Aliased with :func:`~burnman.material.Material.gr`.
+
+        Returns
+        -------
+        gr : float
+            Grueneisen parameters [unitless].
+        """
+        raise NotImplementedError(
+            "need to implement grueneisen_parameter() in derived class!")
+
+    @material_property
+    def thermal_expansivity(self):
+        """
+        Returns thermal expansion coefficient of the mineral.
+
+        Notes
+        -----
+        - Needs to be implemented in derived classes.
+        - Aliased with :func:`~burnman.material.Material.alpha`.
+
+        Returns
+        -------
+        alpha : float
+            Thermal expansivity in [1/K].
+        """
+        raise NotImplementedError(
+            "need to implement thermal_expansivity() in derived class!")
+
+    @material_property
+    def heat_capacity_v(self):
+        """
+        Returns heat capacity at constant volume of the mineral.
+
+        Notes
+        -----
+        - Needs to be implemented in derived classes.
+        - Aliased with :func:`~burnman.material.Material.C_v`.
+
+        Returns
+        -------
+        heat_capacity_v : float
+            Heat capacity in [J/K/mol].
+        """
+        raise NotImplementedError(
+            "need to implement heat_capacity_v() in derived class!")
+
+    @material_property
+    def heat_capacity_p(self):
+        """
+        Returns heat capacity at constant pressure of the mineral.
+
+        Notes
+        -----
+        - Needs to be implemented in derived classes.
+        - Aliased with :func:`~burnman.material.Material.C_p`.
+
+        Returns
+        -------
+        heat_capacity_p : float
+            Heat capacity in [J/K/mol].
+        """
+        raise NotImplementedError(
+            "need to implement heat_capacity_p() in derived class!")
+
+    #
+    # Aliased properties
+    @property
+    def P(self):
+        """Alias for :func:`~burnman.material.Material.pressure`"""
+        return self.pressure
+
+    @property
+    def T(self):
+        """Alias for :func:`~burnman.material.Material.temperature`"""
+        return self.temperature
+
+    @property
+    def energy(self):
+        """Alias for :func:`~burnman.material.Material.internal_energy`"""
+        return self.internal_energy
+
+    @property
+    def helmholtz(self):
+        """Alias for :func:`~burnman.material.Material.molar_helmholtz`"""
+        return self.molar_helmholtz
+
+    @property
+    def gibbs(self):
+        """Alias for :func:`~burnman.material.Material.molar_gibbs`"""
+        return self.molar_gibbs
+
+    @property
+    def V(self):
+        """Alias for :func:`~burnman.material.Material.molar_volume`"""
+        return self.molar_volume
+
+    @property
+    def rho(self):
+        """Alias for :func:`~burnman.material.Material.density`"""
+        return self.density
+
+    @property
+    def S(self):
+        """Alias for :func:`~burnman.material.Material.molar_entropy`"""
+        return self.molar_entropy
+
+    @property
+    def H(self):
+        """Alias for :func:`~burnman.material.Material.molar_enthalpy`"""
+        return self.molar_enthalpy
+
+    @property
+    def K_T(self):
+        """Alias for :func:`~burnman.material.Material.isothermal_bulk_modulus`"""
+        return self.isothermal_bulk_modulus
+
+    @property
+    def K_S(self):
+        """Alias for :func:`~burnman.material.Material.adiabatic_bulk_modulus`"""
+        return self.adiabatic_bulk_modulus
+
+    @property
+    def beta_T(self):
+        """Alias for :func:`~burnman.material.Material.isothermal_compressibility`"""
+        return self.isothermal_compressibility
+
+    @property
+    def beta_S(self):
+        """Alias for :func:`~burnman.material.Material.adiabatic_compressibility`"""
+        return self.adiabatic_compressibility
+
+    @property
+    def G(self):
+        """Alias for :func:`~burnman.material.Material.shear_modulus`"""
+        return self.shear_modulus
+
+    @property
+    def v_p(self):
+        """Alias for :func:`~burnman.material.Material.p_wave_velocity`"""
+        return self.p_wave_velocity
+
+    @property
+    def v_phi(self):
+        """Alias for :func:`~burnman.material.Material.bulk_sound_velocity`"""
+        return self.bulk_sound_velocity
+
+    @property
+    def v_s(self):
+        """Alias for :func:`~burnman.material.Material.shear_wave_velocity`"""
+        return self.shear_wave_velocity
+
+    @property
+    def gr(self):
+        """Alias for :func:`~burnman.material.Material.grueneisen_parameter`"""
+        return self.grueneisen_parameter
+
+    @property
+    def alpha(self):
+        """Alias for :func:`~burnman.material.Material.thermal_expansivity`"""
+        return self.thermal_expansivity
+
+    @property
+    def C_v(self):
+        """Alias for :func:`~burnman.material.Material.heat_capacity_v`"""
+        return self.heat_capacity_v
+
+    @property
+    def C_p(self):
+        """Alias for :func:`~burnman.material.Material.heat_capacity_p`"""
+        return self.heat_capacity_p

--- a/burnman/layer.py
+++ b/burnman/layer.py
@@ -201,8 +201,7 @@ class Layer(object):
                 rel_err = abs(
                     (max(ref_press) - max(new_press)) / max(new_press))
                 if self.verbose:
-                    print( "Iteration %i  maximum core pressure error between iterations: %e" %
-                        (i, rel_err))
+                    print('Iteration {0:0d} maximum relative pressure error: {1:.1f}'.format(i, rel_err))
 
                 if rel_err < self.max_delta:
                     break

--- a/burnman/layer.py
+++ b/burnman/layer.py
@@ -9,6 +9,7 @@ from scipy.integrate import quad
 from scipy.interpolate import UnivariateSpline
 from burnman import averaging_schemes
 from burnman import constants
+from burnman import geotherm
 import warnings
 
 
@@ -24,149 +25,206 @@ class Layer(Material):
     """
     A planetary layer class
     """
-    def __init__(self, name=None, radius_planet=None, min_depth=None, max_depth=None, n_slices = None):
-        Material.__init__(self)
-        self.name = name
 
+    def __init__(self, name=None, radius_planet=None,
+                 min_depth=None, max_depth=None, n_slices=None, verbose=False):
+        Material.__init__(self)
+
+        self.name = name
         self.min_depth = min_depth
         self.max_depth = max_depth
-        self.thickness = self.max_depth-self.min_depth
+        self.thickness = self.max_depth - self.min_depth
         self.n_slices = n_slices
         self.depths = np.linspace(min_depth, max_depth, n_slices)
         self.radius_planet = radius_planet
-        self.radii = self.radius_planet-self.depths
+        self.radii = self.radius_planet - self.depths
+        self.outer_radius = max(self.radii)
+        self.inner_radius = min(self.radii)
+        self.verbose = verbose
 
-        # mass
-        # moment_inertia
-        
-    def set_composition(self,composition):
-        assert(isinstance(composition, Material) or isinstance(composition, Composite) or isinstance(composition, Mineral)  )
+    def set_composition(self, composition):
+        """
+        Set the composition of a Layer with a Material
+        """
+        assert(isinstance(composition, Material))
         self.composition = composition
-
-
-
     
-    def set_state(self, pressure_mode = 'selfconsistent',temperature_mode='adiabat',pressures = None, temperatures = None, pressure_top= None, gravity_bottom=None, temperature_top=None):
+    def set_temperature_mode(self,  temperature_mode='adiabat',
+                  temperatures=None, temperature_top=None):
         """
-            temperature_mode is 'user_defined','adiabatic', or 'modified_adiabat'
-            pressure_mode is 'user_defined' or 'selfconsistent'
+        Sets temperature of the layer by user-defined values or as an (modified) adiabat.
+        temperature_mode is 'user_defined','adiabatic', or 'modified_adiabat'
         """
-        if temperature_mode == 'user_defined':
-            assert(len(temperatures)==len(self.depths))
-            self._temperatures = temperatures
-        if pressure_mode == 'user_defined':
-            assert(len(pressures)==len(self.depths))
-            self._pressures = pressures
-            warnings.Warn("By setting the pressures in Layer it is unlikely to be self-consistent")
-            if temperature_mode == 'adiabat':
-                self._temperatures = burnman.geotherm.adiabatic(pressures, T0, rock)
-            if  temperature_mode == 'modified_adiabat':
-                self._temperatures = burnman.geotherm.adiabatic(pressures, T0, rock)+temperatures
+        assert(temperature_mode == 'user_defined' or temperature_mode ==
+               'adiabat' or temperature_mode == 'modified_adiabat')
+       
+        self.temperature_mode= temperature_mode
+        
+        if temperature_mode == 'user_defined' or temperature_mode=='modified_adiabat':
+            assert(len(temperatures) == len(self.depths))
+            self.usertemperatures = temperatures
+        else:
+            self.usertemperatures = np.zeros_like(self.depths)
 
+        if temperature_mode == 'adiabat' or temperature_mode=='modified_adiabat':
+            self.temperature_top=temperature_top
+        else:
+            self.temperature_top=None
+
+
+    def set_state(self, pressure_mode='selfconsistent',  pressures=None, pressure_top=None, gravity_bottom=None,n_max_iterations=50):
+        """
+        Sets the pressure and temperature of the layer by user-defined values are in a self-consistent fashion.
+        temperature_mode is 'user_defined','adiabatic', or 'modified_adiabat'
+        pressure_mode is 'user_defined' or 'selfconsistent'
+        """
+        assert(pressure_mode == 'user_defined' or pressure_mode == 'selfconsistent')
+        assert(self.temperature_mode is not None)
+        
+        self.gravity_bottom = gravity_bottom
+
+        if pressure_mode == 'user_defined':
+            assert(len(pressures) == len(self.depths))
+            self._pressures = pressures
+            warnings.warn(
+                "By setting the pressures in Layer it is unlikely to be self-consistent")
+            self._temperatures = self._evaluate_temperature(self._pressures, self.temperature_top)
 
         if pressure_mode == 'selfconsistent':
             self.pressure_top = pressure_top
-            self.gravity_bottom = gravity_bottom
-            
-            ref_press=np.zeros_like(pressures)
-            new_press=self.pressure_top + (self.depths-min(self.depths))*1.e5 # initial pressure curve
-            i=0
+            ref_press = np.zeros_like(pressures)
+            new_press = self.pressure_top + \
+                (self.depths - min(self.depths)) * \
+                2.e5  # initial pressure curve guess
+            temperatures = self._evaluate_temperature(new_press, self.temperature_top)
             # Make it self-consistent!!!
-            while np.sum(np.abs(new_press-ref_press))>1.e6*len(self.depths):
-                i=i+1
+            i = 0
 
-                if temperature_mode == 'adiabat':
-                    temperatures = burnman.geotherm.adiabatic(new_press, T0, rock)
-                if  temperature_mode == 'modified_adiabat':
-                    temperatures = burnman.geotherm.adiabatic(new_press, T0, rock)+temperatures
-                [mat_rho] = self.composition.evaluate(['density'], new_press, temperatures)
-                grav=self._compute_gravity(mat_rho[::-1]) #values with radius
-                ref_press=new_press
-                new_press=self._compute_pressure(mat_rho[::-1],grav)#values with radius
+            while i< n_max_iterations:
+                i += 1
+                ref_press = new_press
+                new_grav, new_press = self._evaluate_eos(new_press, temperatures, gravity_bottom, pressure_top)
+                temperatures = self._evaluate_temperature(new_press, self.temperature_top)
+                rel_err = abs((max(ref_press) - max(new_press) )/ max(new_press))
+                if self.verbose:
+                    print("Iteration %i  maximum core pressure error between iterations: %e" % (i,rel_err))
 
-                if i>50:
-                    print('converged to ', str((new_press-ref_press/ref_press)*100.))
+                if rel_err < 1e-5:
                     break
-            self._pressures=new_press
-            self._temperatures=temperatures
-            self.layer = []
-            for i in range(len(self.depths)):
-                self.layer.append(self.composition.copy())
-                self.layer[i].set_state(self._pressures[i],self._temperatures[i])
+            
+            self._pressures = new_press
+            self._temperatures = temperatures
+            
+        self.layer = []
+        for l in range(len(self.depths)):
+            self.layer.append(self.composition.copy())
+            self.layer[l].set_state(
+                self._pressures[l], self._temperatures[l])
+
+    def _evaluate_temperature(self, pressures=None, temperature_top=None):
+        if self.temperature_mode == 'adiabat' or self.temperature_mode == 'modified_adiabat' :
+            adiabat = geotherm.adiabatic(
+                pressures, temperature_top, self.composition)
+        else:
+            adiabat = np.zeros_like(self.depths)
+        return adiabat + self.usertemperatures
 
 
+    def _evaluate_eos(self, pressures, temperatures, gravity_bottom, pressure_top):
+            [density] = self.composition.evaluate(['density'], pressures, temperatures)
+            grav = self._compute_gravity(density , gravity_bottom)
+            press =  self._compute_pressure( density, grav, pressure_top)
+            return grav, press
 
-    ##### Functions needed to compute self-consistent depths-pressures
-    def _compute_gravity(self,density):
-            radii=self.radii[::-1]
-            density =density[::-1]
-            # Create a spline fit of density as a function of radius
-            rhofunc = UnivariateSpline(radii, density)
-            # Numerically integrate Poisson's equation
-            poisson = lambda p, x: 4.0 * np.pi * constants.G * rhofunc(x) * x * x
-            grav = np.ravel(odeint(poisson, self.gravity_bottom*radii[0]*radii[0], radii))
-            grav[:] = grav[:] / radii[:] / radii[:]
-            return grav[::-1]
-            
-    def _compute_pressure(self,density, gravity):
-            # Calculate the pressure profile based on density and gravity.  This integrates
-            # the equation for hydrostatic equilibrium  P = rho g z.
-            
-            # convert radii to depths
-            depth = self.depths
-            # Make a spline fit of density as a function of depth
-            rhofunc = UnivariateSpline(depth, density)
-            # Make a spline fit of gravity as a function of depth
-            gfunc = UnivariateSpline(depth, gravity)
-            
-            # integrate the hydrostatic equation
-            pressure = np.ravel(
-                                odeint((lambda p, x: gfunc(x) * rhofunc(x)), self.pressure_top, depth))
-            return pressure
+
+    # Functions needed to compute self-consistent depths-pressures
+    def _compute_gravity(self, density, gravity_bottom):
+        """
+        Computes the gravity of a layer
+        """
+        radii = self.radii[::-1]
+        density = np.squeeze(density)[::-1]
+        # Create a spline fit of density as a function of radius
+        rhofunc = UnivariateSpline(radii, density)
+        # Numerically integrate Poisson's equation
+        def poisson(p, x): return 4.0 * np.pi * \
+            constants.G * rhofunc(x) * x * x
+        grav = np.ravel(odeint(poisson, gravity_bottom * radii[0] * radii[0], radii))
+        grav[:] = grav[:] / radii[:] / radii[:]
+        if radii[0] ==0:
+            grav[0]=0
+        return grav[::-1]
+
+    def _compute_pressure(self, density, gravity, pressure_top):
+        """
+        Calculate the pressure profile based on density and gravity.  This integrates
+        the equation for hydrostatic equilibrium  P = rho g z.
+        """
+        # convert radii to depths
+        depth = self.depths
+        # Make a spline fit of density as a function of depth
+        rhofunc = UnivariateSpline(depth, density)
+        # Make a spline fit of gravity as a function of depth
+        gfunc = UnivariateSpline(depth, gravity)
+
+        # integrate the hydrostatic equation
+        pressure = np.ravel(
+            odeint((lambda p, x: gfunc(x) * rhofunc(x)), pressure_top, depth))
+
+        return pressure
 
     @property
-    def mass( self):
+    def mass(self):
         """
-        calculates the mass of the layer [kg]
+        Calculates the mass of the layer [kg]
         """
         mass = 0.0
-        rhofunc = UnivariateSpline(self.radii, self.density)
-        mass = np.abs(quad(lambda r : 4*np.pi*rhofunc(r)*r*r, self.radii[0], self.radii[-1])[0])
+        radii=self.radii[::-1]
+        density=self.density[::-1]
+        rhofunc = UnivariateSpline(radii, density)
+        mass = np.abs(quad(lambda r: 4 * np.pi * rhofunc(r) *
+                           r * r, radii[0], radii[-1])[0])
         return mass
 
     @property
-    def moment_of_inertia( self):
+    def moment_of_inertia(self):
         """
         Returns the moment of inertia of the layer [kg m^2]
         """
         moment = 0.0
-        rhofunc = UnivariateSpline(self.radii, self.density)
-        moment = np.abs(quad(lambda r : 8.0/3.0*np.pi*rhofunc(r)*r*r*r*r, self.radii[0], self.radii[-1])[0])
+        radii=self.radii[::-1]
+        density=self.density[::-1]
+        rhofunc = UnivariateSpline(radii, density)
+        moment = np.abs(quad(lambda r: 8.0 / 3.0 * np.pi * rhofunc(r)
+                             * r * r * r * r, radii[0], radii[-1])[0])
         return moment
 
     @property
     def gravity(self):
         """
-        Returns gravity of the layer
+        Returns gravity of the layer [m s^(-2)]
         """
-        return self._compute_gravity(self.density)
+        return self._compute_gravity(self.density, self.gravity_bottom)
 
     @property
     def bullen(self):
-        kappa=self.bulk_sound_velocity*self.bulk_sound_velocity*self.density
-        phi = self.bulk_sound_velocity*self.bulk_sound_velocity
-        dkappadP=np.gradient(kappa)/np.gradient(self.pressure)
-        dphidz=np.gradient(phi)/np.gradient(self.depths)/self.gravity
-        bullen = dkappadP-dphidz
+        """
+        Returns the Bullen parameter
+        """
+        kappa = self.bulk_sound_velocity * self.bulk_sound_velocity * self.density
+        phi = self.bulk_sound_velocity * self.bulk_sound_velocity
+        dkappadP = np.gradient(kappa, edge_order=2) / np.gradient(self.pressure, edge_order=2)
+        dphidz = np.gradient(phi, edge_order=2) / np.gradient(self.depths, edge_order=2) / self.gravity
+        bullen = dkappadP - dphidz
         return bullen
 
     @property
     def brunt_vasala(self):
-        kappa=self.bulk_sound_velocity*self.bulk_sound_velocity*self.density
-        brunt_vasala = self.density * self.gravity * self.gravity * (self.bullen -1.)/kappa
+        kappa = self.bulk_sound_velocity * self.bulk_sound_velocity * self.density
+        brunt_vasala = self.density * self.gravity * \
+            self.gravity * (self.bullen - 1.) / kappa
         return brunt_vasala
 
-    
     @property
     def pressure(self):
         """
@@ -199,7 +257,7 @@ class Layer(Material):
             Temperature in [K].
         """
         return self._temperatures
-    
+
     @material_property
     def internal_energy(self):
         """
@@ -215,7 +273,8 @@ class Layer(Material):
         internal_energy : float
             The internal energy in [J].
         """
-        return np.array([self.layer[i].internal_energy for i in range(len(self.layer))])
+        return np.array(
+            [self.layer[i].internal_energy for i in range(len(self.layer))])
 
     @material_property
     def molar_gibbs(self):
@@ -232,7 +291,8 @@ class Layer(Material):
         molar_gibbs : float
             Gibbs free energy in [J].
         """
-        return np.array([self.layer[i].molar_gibbs for i in range(len(self.layer))])
+        return np.array(
+            [self.layer[i].molar_gibbs for i in range(len(self.layer))])
 
     @material_property
     def molar_helmholtz(self):
@@ -249,7 +309,8 @@ class Layer(Material):
         molar_helmholtz : float
             Helmholtz free energy in [J].
         """
-        return np.array([self.layer[i].molar_helmholtz for i in range(len(self.layer))])
+        return np.array(
+            [self.layer[i].molar_helmholtz for i in range(len(self.layer))])
 
     @material_property
     def molar_mass(self):
@@ -265,7 +326,8 @@ class Layer(Material):
         molar_mass : float
             Molar mass in [kg/mol].
         """
-        return np.array([self.layer[i].molar_mass for i in range(len(self.layer))])
+        return np.array(
+            [self.layer[i].molar_mass for i in range(len(self.layer))])
 
     @material_property
     def molar_volume(self):
@@ -282,7 +344,8 @@ class Layer(Material):
         molar_volume : float
             Molar volume in [m^3/mol].
         """
-        return np.array([self.layer[i].molar_volume for i in range(len(self.layer))])
+        return np.array(
+            [self.layer[i].molar_volume for i in range(len(self.layer))])
 
     @material_property
     def density(self):
@@ -299,7 +362,9 @@ class Layer(Material):
         density : float
             The density of this material in [kg/m^3].
         """
-        return np.array([self.layer[i].density for i in range(len(self.layer))])
+        return np.array(
+            [self.layer[i].density for i in range(len(self.layer))])
+
     @material_property
     def molar_entropy(self):
         """
@@ -315,7 +380,8 @@ class Layer(Material):
         entropy : float
             Entropy in [J].
         """
-        return np.array([self.layer[i].molar_entropy for i in range(len(self.layer))])
+        return np.array(
+            [self.layer[i].molar_entropy for i in range(len(self.layer))])
 
     @material_property
     def molar_enthalpy(self):
@@ -332,7 +398,8 @@ class Layer(Material):
         enthalpy : float
             Enthalpy in [J].
         """
-        return np.array([self.layer[i].molar_enthalpy for i in range(len(self.layer))])
+        return np.array(
+            [self.layer[i].molar_enthalpy for i in range(len(self.layer))])
 
     @material_property
     def isothermal_bulk_modulus(self):
@@ -349,7 +416,8 @@ class Layer(Material):
         isothermal_bulk_modulus : float
             Bulk modulus in [Pa].
         """
-        return np.array([self.layer[i].isothermal_bulk_modulus for i in range(len(self.layer))])
+        return np.array(
+            [self.layer[i].isothermal_bulk_modulus for i in range(len(self.layer))])
 
     @material_property
     def adiabatic_bulk_modulus(self):
@@ -366,7 +434,8 @@ class Layer(Material):
         adiabatic_bulk_modulus : float
             Adiabatic bulk modulus in [Pa].
         """
-        return np.array([self.layer[i].adiabatic_bulk_modulus for i in range(len(self.layer))])
+        return np.array(
+            [self.layer[i].adiabatic_bulk_modulus for i in range(len(self.layer))])
 
     @material_property
     def isothermal_compressibility(self):
@@ -383,7 +452,8 @@ class Layer(Material):
         (K_T)^-1 : float
             Compressibility in [1/Pa].
         """
-        return np.array([self.layer[i].isothermal_compressibility for i in range(len(self.layer))])
+        return np.array(
+            [self.layer[i].isothermal_compressibility for i in range(len(self.layer))])
 
     @material_property
     def adiabatic_compressibility(self):
@@ -401,7 +471,8 @@ class Layer(Material):
         adiabatic_compressibility : float
             adiabatic compressibility in [1/Pa].
         """
-        return np.array([self.layer[i].adiabatic_compressibility for i in range(len(self.layer))])
+        return np.array(
+            [self.layer[i].adiabatic_compressibility for i in range(len(self.layer))])
 
     @material_property
     def shear_modulus(self):
@@ -418,7 +489,8 @@ class Layer(Material):
         shear_modulus : float
             Shear modulus in [Pa].
         """
-        return np.array([self.layer[i].shear_modulus for i in range(len(self.layer))])
+        return np.array(
+            [self.layer[i].shear_modulus for i in range(len(self.layer))])
 
     @material_property
     def p_wave_velocity(self):
@@ -435,7 +507,8 @@ class Layer(Material):
         p_wave_velocity : float
             P wave speed in [m/s].
         """
-        return np.array([self.layer[i].p_wave_velocity for i in range(len(self.layer))])
+        return np.array(
+            [self.layer[i].p_wave_velocity for i in range(len(self.layer))])
 
     @material_property
     def bulk_sound_velocity(self):
@@ -452,7 +525,8 @@ class Layer(Material):
         bulk sound velocity: float
             Sound velocity in [m/s].
         """
-        return np.array([self.layer[i].bulk_sound_velocity for i in range(len(self.layer))])
+        return np.array(
+            [self.layer[i].bulk_sound_velocity for i in range(len(self.layer))])
 
     @material_property
     def shear_wave_velocity(self):
@@ -469,9 +543,8 @@ class Layer(Material):
         shear_wave_velocity : float
             Wave speed in [m/s].
         """
-        for i in range(len(self.layer)):
-            print(self.layer[i].pressure, self.layer[i].shear_wave_velocity)
-        return np.array([self.layer[i].shear_wave_velocity for i in range(len(self.layer))])
+        return np.array(
+            [self.layer[i].shear_wave_velocity for i in range(len(self.layer))])
 
     @material_property
     def grueneisen_parameter(self):
@@ -488,7 +561,8 @@ class Layer(Material):
         gr : float
             Grueneisen parameters [unitless].
         """
-        return np.array([self.layer[i].grueneisen_parameter for i in range(len(self.layer))])
+        return np.array(
+            [self.layer[i].grueneisen_parameter for i in range(len(self.layer))])
 
     @material_property
     def thermal_expansivity(self):
@@ -505,7 +579,8 @@ class Layer(Material):
         alpha : float
             Thermal expansivity in [1/K].
         """
-        return np.array([self.layer[i].thermal_expansivity for i in range(len(self.layer))])
+        return np.array(
+            [self.layer[i].thermal_expansivity for i in range(len(self.layer))])
 
     @material_property
     def heat_capacity_v(self):
@@ -522,7 +597,8 @@ class Layer(Material):
         heat_capacity_v : float
             Heat capacity in [J/K/mol].
         """
-        return np.array([self.layer[i].heat_capacity_v for i in range(len(self.layer))])
+        return np.array(
+            [self.layer[i].heat_capacity_v for i in range(len(self.layer))])
 
     @material_property
     def heat_capacity_p(self):
@@ -539,5 +615,5 @@ class Layer(Material):
         heat_capacity_p : float
             Heat capacity in [J/K/mol].
         """
-        return np.array([self.layer[i].heat_capacity_p for i in range(len(self.layer))])
-
+        return np.array(
+            [self.layer[i].heat_capacity_p for i in range(len(self.layer))])

--- a/burnman/material.py
+++ b/burnman/material.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 # GPL v2 or later.
 
 import numpy as np
-
+from copy import deepcopy
 
 def material_property(func):
     """
@@ -138,6 +138,9 @@ class Material(object):
         It is typically not required for the user to call this function.
         """
         self._cached = {}
+    
+    def copy(self):
+        return deepcopy(self)
 
     def unroll(self):
         """

--- a/burnman/planet.py
+++ b/burnman/planet.py
@@ -205,7 +205,7 @@ class Planet(object):
             layer._temperatures = self._temperatures[layer.n_start: layer.n_end]
             layer.gravity_bottom = self._gravity[layer.n_end - 1]
             for l in range(len(layer.depths)):
-                layer.sublayers.append(layer.composition.copy())
+                layer.sublayers.append(layer.material.copy())
                 layer.sublayers[l].set_state(
                     layer._pressures[l], layer._temperatures[l])
 
@@ -224,7 +224,7 @@ class Planet(object):
         """
         density = []
         for layer in self.layers:
-            density.append(layer.composition.evaluate(
+            density.append(layer.material.evaluate(
                 ['density'], pressures[layer.n_start:layer.n_end], temperatures[layer.n_start:layer.n_end]))
         return np.squeeze(np.hstack(density))
 

--- a/burnman/planet.py
+++ b/burnman/planet.py
@@ -227,9 +227,7 @@ class Planet(object):
                 rel_err = abs(
                     (max(ref_press) - max(new_press)) / max(new_press))
                 if self.verbose:
-                    print(
-                        "Iteration %i  maximum core pressure delta between iterations: %e" %
-                        (i, rel_err))
+                    print('Iteration {0:0d} maximum relative pressure error: {1:.1e}'.format(i, rel_err))
 
                 if rel_err < self.max_delta:
                     break

--- a/burnman/planet.py
+++ b/burnman/planet.py
@@ -131,22 +131,22 @@ class Planet(object):
             if all is None:
                 all = np.array(oneprop)
             else:
-                np.append(all, oneprop, axis=0)
+                np.append(all, np.array(oneprop), axis=0)
         return all
 
-    def set_state( self, pressure_mode='selfconsistent', pressures=None, pressure_top=0.,
+    def set_state( self, pressure_mode='self-consistent', pressures=None, pressure_top=0.,
             gravity_bottom=0., n_max_iterations=50):
         """
         Sets the pressure of the planet by user-defined values are in a self-consistent fashion.
-        pressure_mode is 'user_defined' or 'selfconsistent'.
+        pressure_mode is 'user-defined' or 'self-consistent'.
         The default for the planet is self-consistent, with zero pressure at the surface and zero pressure at the center.
         
         Parameters
         ----------
         pressure_mode : string
-        This can be set to 'user_defined' or 'selfconsistent'
+        This can be set to 'user-defined' or 'self-consistent'
         pressures : array of floats
-        Pressures (Pa) to set layer to ('user_defined'). This should be the same length as defined depths array for the layer
+        Pressures (Pa) to set layer to ('user-defined'). This should be the same length as defined depths array for the layer
         pressure_top : float
         Pressure (Pa) at the top of the layer. 
         gravity_bottom : float
@@ -155,21 +155,21 @@ class Planet(object):
         Maximum number of iterations to reach self-consistent pressures (default = 50)
         """
         
-        assert(pressure_mode == 'user_defined' or pressure_mode == 'selfconsistent')
+        assert(pressure_mode == 'user-defined' or pressure_mode == 'self-consistent')
         self.reset()
         for layer in self.layers:
             assert(layer.temperature_mode is not None)
 
         self.gravity_bottom = gravity_bottom
 
-        if pressure_mode == 'user_defined':
+        if pressure_mode == 'user-defined':
             assert(len(pressures) == len(self.depths))
             self._pressures = pressures
             warnings.warn(
                 "By setting the pressures in Planet it is unlikely to be self-consistent")
             self._temperatures = self._evaluate_temperature(self._pressures)
 
-        if pressure_mode == 'selfconsistent':
+        if pressure_mode == 'self-consistent':
             self.pressure_top = pressure_top
             ref_press = np.zeros_like(pressures)
             new_press = self.pressure_top + \
@@ -189,7 +189,7 @@ class Planet(object):
                     (max(ref_press) - max(new_press)) / max(new_press))
                 if self.verbose:
                     print(
-                        "Iteration %i  maximum core pressure error between iterations: %e" %
+                        "Iteration %i  maximum core pressure delta between iterations: %e" %
                         (i, rel_err))
 
                 if rel_err < 1e-5:

--- a/burnman/planet.py
+++ b/burnman/planet.py
@@ -167,8 +167,7 @@ class Planet(object):
             self._pressures = pressures
             warnings.warn(
                 "By setting the pressures in Planet it is unlikely to be self-consistent")
-            self._temperatures = self._evaluate_temperature(
-                self._pressures, self.potential_temperature)
+            self._temperatures = self._evaluate_temperature(self._pressures)
 
         if pressure_mode == 'selfconsistent':
             self.pressure_top = pressure_top
@@ -176,8 +175,7 @@ class Planet(object):
             new_press = self.pressure_top + \
                 (self.depths - min(self.depths)) * \
                 2.e5  # initial pressure curve guess
-            temperatures = self._evaluate_temperature(
-                new_press, self.potential_temperature)
+            temperatures = self._evaluate_temperature( new_press)
             # Make it self-consistent!!!
             i = 0
 
@@ -186,8 +184,7 @@ class Planet(object):
                 ref_press = new_press
                 new_grav, new_press = self._evaluate_eos(
                     new_press, temperatures, gravity_bottom, pressure_top)
-                temperatures = self._evaluate_temperature(
-                    new_press, self.potential_temperature)
+                temperatures = self._evaluate_temperature( new_press)
                 rel_err = abs(
                     (max(ref_press) - max(new_press)) / max(new_press))
                 if self.verbose:
@@ -231,13 +228,16 @@ class Planet(object):
                 ['density'], pressures[layer.n_start:layer.n_end], temperatures[layer.n_start:layer.n_end]))
         return np.squeeze(np.hstack(density))
 
-    def _evaluate_temperature(self, pressures, temperature_top):
+    def _evaluate_temperature(self, pressures):
         """
         Returns the temperatures of different layers for given pressures.
         Used by set_state()
         """
         temps = []
+        temperature_top = None
         for layer in self.layers:
+            if temperature_top is None:
+                temperature_top = layer.temperature_top
             temps.extend(layer._evaluate_temperature(
                 pressures[layer.n_start:layer.n_end], temperature_top))
             temperature_top = temps[-1]

--- a/burnman/seismic.py
+++ b/burnman/seismic.py
@@ -488,20 +488,8 @@ class STW105(SeismicTable):
         self.table_depth = self.earth_radius - self.table_radius
 
         # Voigt averages for Vs and Vp
-        self.table_vs = np.sqrt(
-            (2. *
-             self.table_vsv *
-             self.table_vsv +
-             self.table_vsh *
-             self.table_vsh) /
-            3.)
-        self.table_vp = np.sqrt(
-            (self.table_vpv *
-             self.table_vpv +
-             4. *
-             self.table_vph *
-             self.table_vph) /
-            5.)
+        self.table_vs = np.sqrt((2. *self.table_vsv * self.table_vsv + self.table_vsh * self.table_vsh) / 3.)
+        self.table_vp = np.sqrt((self.table_vpv * self.table_vpv + 4. * self.table_vph * self.table_vph) / 5.)
 
 
 class IASP91(SeismicTable):

--- a/burnman/seismic.py
+++ b/burnman/seismic.py
@@ -287,6 +287,20 @@ class SeismicTable(Seismic1DModel):
                 "Density has not been defined for this seismic model")
         return self._lookup(depth, self.table_density)
 
+    def bullen(self, depth):
+        """
+        Returns the Bullen parameter only for significant arrays
+        """
+        assert(len(depth)>3)
+        v_phi = self.v_phi(depth)
+        density = self.density(depth)
+        phi = v_phi * v_phi
+        kappa = phi * density
+        dkappadP = np.gradient(kappa, edge_order=2) / np.gradient(self.pressure(depth), edge_order=2)
+        dphidz = np.gradient(phi, edge_order=2) / np.gradient(depth, edge_order=2) / self.gravity(depth)
+        bullen = dkappadP - dphidz
+        return bullen
+
     def depth(self, pressure):
         if max(pressure) > max(self.table_pressure) or min(pressure) < min(self.table_pressure):
             raise ValueError("Pressure outside range of SeismicTable")

--- a/burnman/seismic.py
+++ b/burnman/seismic.py
@@ -22,7 +22,7 @@ class Seismic1DModel(object):
     def __init__(self):
         pass
 
-    def evaluate(self, vars_list, depth_list):
+    def evaluate(self, vars_list, depth_list=None):
         """
         Returns the lists of data for a Seismic1DModel for the depths provided
 
@@ -38,7 +38,8 @@ class Seismic1DModel(object):
         Array of values shapes as (len(vars_list),len(depth_list)).
 
         """
-
+        if depth_list is None:
+            depth_list = self.internal_depth_list()
         values = np.empty((len(vars_list), len(depth_list)))
         for a in range(len(vars_list)):
             values[a, :] = getattr(self, vars_list[a])(depth_list)
@@ -245,7 +246,8 @@ class SeismicTable(Seismic1DModel):
         self.earth_radius = 6371.0e3
 
     def internal_depth_list(self, mindepth=0., maxdepth=1.e10):
-        depths = np.array([self.table_depth[x] for x in range(len(self.table_depth)) if self.table_depth[x] >= mindepth and self.table_depth[x] <= maxdepth])
+        depths = np.array([self.table_depth[x] for x in range(len(
+            self.table_depth)) if self.table_depth[x] >= mindepth and self.table_depth[x] <= maxdepth])
         discontinuities = np.where(depths[1:] - depths[:-1] == 0)[0]
         # Shift values at discontinities by 1 m to simplify evaluating values
         # around these.
@@ -255,14 +257,20 @@ class SeismicTable(Seismic1DModel):
 
     def pressure(self, depth):
         if len(self.table_pressure) == 0:
-                warnings.warn("Pressure is not given in " + self.__class__.__name__ + " and is now being computed. This will only work when density is defined for the entire planet. Use at your own risk. ")
-                self._compute_pressure()
+            warnings.warn(
+                "Pressure is not given in " +
+                self.__class__.__name__ +
+                " and is now being computed. This will only work when density is defined for the entire planet. Use at your own risk. ")
+            self._compute_pressure()
         return self._lookup(depth, self.table_pressure)
 
     def gravity(self, depth):
         if len(self.table_gravity) == 0:
-                warnings.warn("Gravity is not given in " + self.__class__.__name__ + " and is now being computed. This will only work when density is defined for the entire planet.  Use at your own risk. ")
-                self._compute_gravity()
+            warnings.warn(
+                "Gravity is not given in " +
+                self.__class__.__name__ +
+                " and is now being computed. This will only work when density is defined for the entire planet.  Use at your own risk. ")
+            self._compute_gravity()
         return self._lookup(depth, self.table_gravity)
 
     def v_p(self, depth):
@@ -291,18 +299,23 @@ class SeismicTable(Seismic1DModel):
         """
         Returns the Bullen parameter only for significant arrays
         """
-        assert(len(depth)>3)
+        assert(len(depth) > 3)
         v_phi = self.v_phi(depth)
         density = self.density(depth)
         phi = v_phi * v_phi
         kappa = phi * density
-        dkappadP = np.gradient(kappa, edge_order=2) / np.gradient(self.pressure(depth), edge_order=2)
-        dphidz = np.gradient(phi, edge_order=2) / np.gradient(depth, edge_order=2) / self.gravity(depth)
+        dkappadP = np.gradient(kappa, edge_order=2) / \
+            np.gradient(self.pressure(depth), edge_order=2)
+        dphidz = np.gradient(phi,
+                             edge_order=2) / np.gradient(depth,
+                                                         edge_order=2) / self.gravity(depth)
         bullen = dkappadP - dphidz
         return bullen
 
     def depth(self, pressure):
-        if max(pressure) > max(self.table_pressure) or min(pressure) < min(self.table_pressure):
+        if max(pressure) > max(
+                self.table_pressure) or min(pressure) < min(
+                self.table_pressure):
             raise ValueError("Pressure outside range of SeismicTable")
 
         depth = np.interp(pressure, self.table_pressure, self.table_depth)
@@ -324,7 +337,15 @@ class SeismicTable(Seismic1DModel):
 
         density = self.table_density[::-1]
         radii = self.table_radius[::-1]
-        g = scipy.integrate.cumtrapz(constants.G*4.*np.pi*density*radii*radii, x=radii, initial=0)
+        g = scipy.integrate.cumtrapz(
+            constants.G *
+            4. *
+            np.pi *
+            density *
+            radii *
+            radii,
+            x=radii,
+            initial=0)
         g[1:] = g[1:] / radii[1:] / radii[1:]
 
         self.table_gravity = g[::-1]
@@ -334,11 +355,12 @@ class SeismicTable(Seismic1DModel):
         # the equation for hydrostatic equilibrium  P = rho g z.
         radii = self.table_radius
         density = self.table_density
-        gravity = self.gravity(self.earth_radius-radii)
+        gravity = self.gravity(self.earth_radius - radii)
 
         # convert radii to depths
         depth = self.earth_radius - radii
-        pressure = scipy.integrate.cumtrapz(gravity*density, x=depth, initial=0.)
+        pressure = scipy.integrate.cumtrapz(
+            gravity * density, x=depth, initial=0.)
 
         self.table_pressure = pressure
 
@@ -386,7 +408,12 @@ class Slow(SeismicTable):
         min_radius = self.earth_radius - max(table2[:, 0])
         max_radius = self.earth_radius - min(table2[:, 0])
 
-        table = np.array(list(filter(lambda x: (x[1] >= min_radius and x[1] <= max_radius), table)))
+        table = np.array(
+            list(
+                filter(
+                    lambda x: (
+                        x[1] >= min_radius and x[1] <= max_radius),
+                    table)))
 
         self.table_depth = table[:, 0]
         self.table_radius = table[:, 1]
@@ -420,7 +447,12 @@ class Fast(SeismicTable):
         min_radius = self.earth_radius - max(table2[:, 0])
         max_radius = self.earth_radius - min(table2[:, 0])
 
-        table = np.array(list(filter(lambda x: (x[1] >= min_radius and x[1] <= max_radius), table)))
+        table = np.array(
+            list(
+                filter(
+                    lambda x: (
+                        x[1] >= min_radius and x[1] <= max_radius),
+                    table)))
 
         self.table_depth = table[:, 0]
         self.table_radius = table[:, 1]
@@ -441,7 +473,8 @@ class STW105(SeismicTable):
 
     def __init__(self):
         SeismicTable.__init__(self)
-        table = tools.read_table("input_seismic/STW105.txt") # radius, pressure, density, v_p, v_s
+        # radius, pressure, density, v_p, v_s
+        table = tools.read_table("input_seismic/STW105.txt")
         table = np.array(table)
         self.table_radius = table[:, 0][::-1]
         self.table_density = table[:, 1][::-1]
@@ -452,11 +485,23 @@ class STW105(SeismicTable):
         self.table_vph = table[:, 6][::-1]
         self.table_vsh = table[:, 7][::-1]
 
-        self.table_depth = self.earth_radius-self.table_radius
+        self.table_depth = self.earth_radius - self.table_radius
 
         # Voigt averages for Vs and Vp
-        self.table_vs = np.sqrt((2.*self.table_vsv*self.table_vsv+self.table_vsh*self.table_vsh)/3.)
-        self.table_vp = np.sqrt((self.table_vpv*self.table_vpv+4.*self.table_vph*self.table_vph)/5.)
+        self.table_vs = np.sqrt(
+            (2. *
+             self.table_vsv *
+             self.table_vsv +
+             self.table_vsh *
+             self.table_vsh) /
+            3.)
+        self.table_vp = np.sqrt(
+            (self.table_vpv *
+             self.table_vpv +
+             4. *
+             self.table_vph *
+             self.table_vph) /
+            5.)
 
 
 class IASP91(SeismicTable):
@@ -525,9 +570,9 @@ def attenuation_correction(v_p, v_s, v_phi, Qs, Qphi):
         corrected Bulk sound velocity in [m/s].
     """
     beta = 0.3  # Matas et al. (2007) page 4
-    Qp  = 3. / 4.*pow((v_p/v_s), 2.)*Qs    # Matas et al. (2007) page 4
+    Qp = 3. / 4. * pow((v_p / v_s), 2.) * Qs    # Matas et al. (2007) page 4
 
-    cot = 1./np.tan(beta*np.pi/2.)
+    cot = 1. / np.tan(beta * np.pi / 2.)
     v_p *= 1. - 1. / 2. * cot * 1. / Qp  # Matas et al. (2007) page 1
     v_s *= 1. - 1. / 2. * cot * 1. / Qs
     v_phi *= 1. - 1. / 2. * cot * 1. / Qphi

--- a/burnman/seismic.py
+++ b/burnman/seismic.py
@@ -258,18 +258,14 @@ class SeismicTable(Seismic1DModel):
     def pressure(self, depth):
         if len(self.table_pressure) == 0:
             warnings.warn(
-                "Pressure is not given in " +
-                self.__class__.__name__ +
-                " and is now being computed. This will only work when density is defined for the entire planet. Use at your own risk. ")
+                "Pressure is not given in " + self.__class__.__name__ + " and is now being computed. This will only work when density is defined for the entire planet. Use at your own risk. ")
             self._compute_pressure()
         return self._lookup(depth, self.table_pressure)
 
     def gravity(self, depth):
         if len(self.table_gravity) == 0:
             warnings.warn(
-                "Gravity is not given in " +
-                self.__class__.__name__ +
-                " and is now being computed. This will only work when density is defined for the entire planet.  Use at your own risk. ")
+                "Gravity is not given in " + self.__class__.__name__ + " and is now being computed. This will only work when density is defined for the entire planet.  Use at your own risk. ")
             self._compute_gravity()
         return self._lookup(depth, self.table_gravity)
 

--- a/examples/example_build_planet.py
+++ b/examples/example_build_planet.py
@@ -126,7 +126,7 @@ if __name__ == "__main__":
 
     #Now we output the mass of the planet and moment of inertia
     print()
-    print("mass/Earth= %.3f, moment of inertia= %.3f" % (Plan.mass/5.97e24, Plan.moment_of_inertia))
+    print("mass/Earth= %.3f, moment of inertia= %.3f" % (Plan.mass/5.97e24, Plan.moment_of_inertia_factor))
 
     #And here's the mass of the individual layers:
     for layer in Plan.layers:
@@ -143,7 +143,7 @@ if __name__ == "__main__":
 
     figure = plt.figure(figsize = (12,10))
     figure.suptitle('Your planet is %.3f Earth Masses with Average Density of %.1f kg/m$^3$' %((Plan.mass/5.97e24), \
-                    (Plan.mass/(4./3.*np.pi*Plan.radial_slices[-1]*Plan.radial_slices[-1]*Plan.radial_slices[-1]))),\
+                    (Plan.mass/(4./3.*np.pi*Plan.radius_planet*Plan.radius_planet*Plan.radius_planet))),\
                      fontsize=20)
 
     ax1 = plt.subplot2grid( (6,3) , (0,0), colspan=3, rowspan=3)
@@ -151,25 +151,26 @@ if __name__ == "__main__":
     ax3 = plt.subplot2grid( (6,3) , (4,0), colspan=3, rowspan=1)
     ax4 = plt.subplot2grid( (6,3) , (5,0), colspan=3, rowspan=1)
 
-    ax1.plot(Plan.radial_slices/1.e3,Plan.densities/1.e3,'k', linewidth = 2.)
-    ax1.set_ylim(0.,(max(Plan.densities)/1.e3)+1.)
-    ax1.set_xlim(0.,max(Plan.radial_slices)/1.e3)
+    ax1.plot(Plan.radii/1.e3,Plan.density/1.e3,'k', linewidth = 2.)
+    ax1.set_ylim(0.,(max(Plan.density)/1.e3)+1.)
+    ax1.set_xlim(0.,max(Plan.radii)/1.e3)
     ax1.set_ylabel("Density ( $\cdot 10^3$ kg/m$^3$)")
+    plt.show()
 
     #Make a subplot showing the calculated pressure profile
-    ax2.plot( Plan.radial_slices/1.e3, Plan.pressures/1.e9, 'b', linewidth=2.)
+    ax2.plot( Plan.radii/1.e3, Plan.pressures/1.e9, 'b', linewidth=2.)
     ax2.set_ylim(0.,(max(Plan.pressures)/1e9)+10.)
     ax2.set_xlim(0.,max(Plan.radial_slices)/1.e3)
     ax2.set_ylabel("Pressure (GPa)")
 
     #Make a subplot showing the calculated gravity profile
-    ax3.plot( Plan.radial_slices/1.e3, Plan.gravity, 'r', linewidth=2.)
+    ax3.plot( Plan.radii/1.e3, Plan.gravity, 'r', linewidth=2.)
     ax3.set_ylabel("Gravity (m/s$^2)$")
     ax3.set_xlim(0.,max(Plan.radial_slices)/1.e3)
     ax3.set_ylim(0.,max(Plan.gravity)+0.5)
 
     #Make a subplot showing the calculated temperature profile
-    ax4.plot( Plan.radial_slices/1.e3, Plan.temperatures, 'g', linewidth=2.)
+    ax4.plot( Plan.radii/1.e3, Plan.temperatures, 'g', linewidth=2.)
     ax4.set_ylabel("Temperature ($K$)")
     ax4.set_xlabel("Radius (km)")
     ax4.set_xlim(0.,max(Plan.radial_slices)/1.e3)

--- a/examples/example_build_planet.py
+++ b/examples/example_build_planet.py
@@ -1,7 +1,47 @@
 # This file is part of BurnMan - a thermoelastic and thermodynamic toolkit for the Earth and Planetary Sciences
 # Copyright (C) 2012 - 2015 by the BurnMan team, released under the GNU
 # GPL v2 or later.
+"""
+example_build_planet
+--------------------
 
+For Earth we have well-constrained one-dimensional density models.  This allows us to
+calculate pressure as a function of depth.  Furthermore, petrologic data and assumptions
+regarding the convective state of the planet allow us to estimate the temperature.
+
+For planets other than Earth we have much less information, and in particular we
+know almost nothing about the pressure and temperature in the interior.  Instead, we tend
+to have measurements of things like mass, radius, and moment-of-inertia.  We would like
+to be able to make a model of the planet's interior that is consistent with those
+measurements.
+
+However, there is a difficulty with this.  In order to know the density of the planetary
+material, we need to know the pressure and temperature.  In order to know the pressure,
+we need to know the gravity profile.  And in order to the the gravity profile, we need
+to know the density.  This is a nonlinear problem which requires us to iterate to find
+a self-consistent solution.
+
+This example allows the user to define layers of planets of known outer radius and self-
+consistently solve for the density, pressure and gravity profiles. The calculation will
+iterate until the difference between central pressure calculations are less than 1e-5.
+The planet class in BurnMan (../burnman/planet.py) allows users to call multiple
+properties of the model planet after calculations, such as the mass of an individual layer,
+the total mass of the planet and the moment if inertia. See planets.py for information
+on each of the parameters which can be called.
+
+*Uses:*
+
+* :doc:`mineral_database`
+* :class:`burnman.planet.Planet`
+* :class: `burnman.layer.Layer`
+
+*Demonstrates:*
+
+* setting up a planet
+* computing its self-consistent state
+* computing various parameters for the planet
+* seismic comparison
+"""
 
 from __future__ import absolute_import
 from __future__ import print_function
@@ -20,47 +60,7 @@ import burnman.mineral_helpers as helpers
 
 if __name__ == "__main__":
 
-    '''
-    example_build_planet
-    --------------------
 
-    For Earth we have well-constrained one-dimensional density models.  This allows us to
-    calculate pressure as a function of depth.  Furthermore, petrologic data and assumptions
-    regarding the convective state of the planet allow us to estimate the temperature.
-
-    For planets other than Earth we have much less information, and in particular we
-    know almost nothing about the pressure and temperature in the interior.  Instead, we tend
-    to have measurements of things like mass, radius, and moment-of-inertia.  We would like
-    to be able to make a model of the planet's interior that is consistent with those
-    measurements.
-
-    However, there is a difficulty with this.  In order to know the density of the planetary
-    material, we need to know the pressure and temperature.  In order to know the pressure,
-    we need to know the gravity profile.  And in order to the the gravity profile, we need
-    to know the density.  This is a nonlinear problem which requires us to iterate to find
-    a self-consistent solution.
-
-    This example allows the user to define layers of planets of known outer radius and self-
-    consistently solve for the density, pressure and gravity profiles. The calculation will
-    iterate until the difference between central pressure calculations are less than 1e-5.
-    The planet class in BurnMan (../burnman/planet.py) allows users to call multiple
-    properties of the model planet after calculations, such as the mass of an individual layer,
-    the total mass of the planet and the moment if inertia. See planets.py for information
-    on each of the parameters which can be called.
-
-    *Uses:*
-
-    * :doc:`mineral_database`
-    * :class:`burnman.planet.Planet`
-    * :class: `burnman.layer.Layer`
-    
-    *Demonstrates:*
-    
-    * setting up a planet
-    * computing its self-consistent state
-    * computing various parameters for the planet
-    * seismic comparison
-    '''
 
     # FIRST: we must define the composition of the planet as individual layers.
     # A layer is defined by 4 parameters: Name, min_depth, max_depth,and number of slices within the layer.
@@ -71,17 +71,17 @@ if __name__ == "__main__":
         max_depth=6371.e3, min_depth=5151.e3, n_slices=10)
     inner_core.set_material(burnman.minerals.other.Fe_Dewaele())
     
-    # The minerals that make up our core do not currently implement the thermal equation of state, so we will define the temperature with the Brown & Shankland geotherm.
-    inner_core.set_temperature_mode( 'user_defined',
-        burnman.geotherm.brown_shankland(inner_core.depths))
+    # The minerals that make up our core do not currently implement the thermal equation of state, so we will set the temperature at 300 K.
+    inner_core.set_temperature_mode( 'user-defined',
+        300.*np.ones_like(inner_core.depths))
 
     # outer_core
     outer_core = burnman.Layer( "outer core", radius_planet=radius_planet,
         max_depth=5151.e3, min_depth=2891.e3, n_slices=10)
     outer_core.set_material(burnman.minerals.other.Liquid_Fe_Anderson())
-    # The minerals that make up our core do not currently implement the thermal equation of state, so we will define the temperature with the Brown & Shankland geotherm.
-    outer_core.set_temperature_mode('user_defined',
-        burnman.geotherm.brown_shankland(outer_core.depths))
+    # The minerals that make up our core do not currently implement the thermal equation of state, so we will define the temperature at 300 K.
+    outer_core.set_temperature_mode('user-defined',
+        300.*np.ones_like(outer_core.depths))
 
     # Next the Mantle.
     lower_mantle = burnman.Layer( "lower_mantle", radius_planet=radius_planet,

--- a/examples/example_build_planet.py
+++ b/examples/example_build_planet.py
@@ -91,14 +91,13 @@ if __name__ == "__main__":
     upper_mantle = burnman.Layer( "upper_mantle", radius_planet=radius_planet,
         max_depth=660e3, min_depth=0., n_slices=10)
     upper_mantle.set_composition(burnman.minerals.SLB_2011.forsterite())
-    upper_mantle.set_temperature_mode('adiabat')
+    upper_mantle.set_temperature_mode('adiabat', temperature_top =1200.)
 
 
 
     # Now we calculate the planet.
     Plan = burnman.Planet('earth_like',
-                          [inner_core, outer_core, lower_mantle, upper_mantle],
-                          potential_temperature=1200, verbose=True)
+                          [inner_core, outer_core, lower_mantle, upper_mantle], verbose=True)
     # Here we compute its state. Go BurnMan Go!
     # (If we were to change composition of one of the layers, we would have to
     # recompute the state)

--- a/examples/example_build_planet.py
+++ b/examples/example_build_planet.py
@@ -69,7 +69,7 @@ if __name__ == "__main__":
     # inner_core
     inner_core = burnman.Layer("inner core", radius_planet=radius_planet,
         max_depth=6371.e3, min_depth=5151.e3, n_slices=10)
-    inner_core.set_composition(burnman.minerals.other.Fe_Dewaele())
+    inner_core.set_material(burnman.minerals.other.Fe_Dewaele())
     
     # The minerals that make up our core do not currently implement the thermal equation of state, so we will define the temperature with the Brown & Shankland geotherm.
     inner_core.set_temperature_mode( 'user_defined',
@@ -78,7 +78,7 @@ if __name__ == "__main__":
     # outer_core
     outer_core = burnman.Layer( "outer core", radius_planet=radius_planet,
         max_depth=5151.e3, min_depth=2891.e3, n_slices=10)
-    outer_core.set_composition(burnman.minerals.other.Liquid_Fe_Anderson())
+    outer_core.set_material(burnman.minerals.other.Liquid_Fe_Anderson())
     # The minerals that make up our core do not currently implement the thermal equation of state, so we will define the temperature with the Brown & Shankland geotherm.
     outer_core.set_temperature_mode('user_defined',
         burnman.geotherm.brown_shankland(outer_core.depths))
@@ -86,11 +86,11 @@ if __name__ == "__main__":
     # Next the Mantle.
     lower_mantle = burnman.Layer( "lower_mantle", radius_planet=radius_planet,
         max_depth=2891.e3, min_depth=660.e3, n_slices=10)
-    lower_mantle.set_composition(burnman.minerals.SLB_2011.mg_bridgmanite())
+    lower_mantle.set_material(burnman.minerals.SLB_2011.mg_bridgmanite())
     lower_mantle.set_temperature_mode('adiabat')
     upper_mantle = burnman.Layer( "upper_mantle", radius_planet=radius_planet,
         max_depth=660e3, min_depth=0., n_slices=10)
-    upper_mantle.set_composition(burnman.minerals.SLB_2011.forsterite())
+    upper_mantle.set_material(burnman.minerals.SLB_2011.forsterite())
     upper_mantle.set_temperature_mode('adiabat', temperature_top =1200.)
 
 

--- a/examples/example_build_planet.py
+++ b/examples/example_build_planet.py
@@ -3,35 +3,6 @@
 # GPL v2 or later.
 
 
-'''
-example_build_planet
---------------------
-
-For Earth we have well-constrained one-dimensional density models.  This allows us to
-calculate pressure as a funcion of depth.  Furthermore, petrologic data and assumptions
-regarding the convective state of the planet allow us to estimate the temperature.
-
-For planets other than Earth we have much less information, and in particular we
-know almost nothing about the pressure and temperature in the interior.  Instead, we tend
-to have measurements of things like mass, radius, and moment-of-inertia.  We would like
-to be able to make a model of the planet's interior that is consistent with those
-measurements.
-
-However, there is a difficulty with this.  In order to know the density of the planetary
-material, we need to know the pressure and temperature.  In order to know the pressure,
-we need to know the gravity profile.  And in order to the the gravity profile, we need
-to know the density.  This is a nonlinear problem which requires us to iterate to find
-a self-consistent solution.
-
-Here we show an example that does this, using the planet Mercury as motivation.
-
-
-*Uses:*
-
-* :doc:`mineral_database`
-* :class:`burnman.composite.Composite`
-* :func:`burnman.material.Material.evaluate`
-'''
 from __future__ import absolute_import
 from __future__ import print_function
 
@@ -80,100 +51,127 @@ if __name__ == "__main__":
     *Uses:*
 
     * :doc:`mineral_database`
-    * :class:`burnman.planet`
+    * :class:`burnman.planet.Planet`
+    * :class: `burnman.layer.Layer`
+    
+    *Demonstrates:*
+    
+    * setting up a planet
+    * computing its self-consistent state
+    * computing various parameters for the planet
+    * seismic comparison
     '''
 
-    #FIRST: we must define the composition of the planet as individual layers.
-    #A layer is defined by 5 parameters: Name, mineral or rock composition, outer radius,
-    #temperature profile and number of slices within the layer.
-
-    #The minerals that make up our core do not currently implement the thermal equation of state, so we will
-    #define the temperature as None. For an isothermal profile this can be change to a singular value (e.g. 300)
-    radius_planet=6371.e3
+    # FIRST: we must define the composition of the planet as individual layers.
+    # A layer is defined by 4 parameters: Name, min_depth, max_depth,and number of slices within the layer.
+    # Separately the composition and the temperature_mode need to set.
+    radius_planet = 6371.e3
     # inner_core
-    inner_core = burnman.Layer("inner core", radius_planet=radius_planet, max_depth =radius_planet, min_depth =radius_planet-1220e3, n_slices = 10)
+    inner_core = burnman.Layer("inner core", radius_planet=radius_planet,
+        max_depth=6371.e3, min_depth=5151.e3, n_slices=10)
     inner_core.set_composition(burnman.minerals.other.Fe_Dewaele())
-    inner_core.set_temperature_mode('user_defined', burnman.geotherm.brown_shankland(inner_core.depths))
-
     
+    # The minerals that make up our core do not currently implement the thermal equation of state, so we will define the temperature with the Brown & Shankland geotherm.
+    inner_core.set_temperature_mode( 'user_defined',
+        burnman.geotherm.brown_shankland(inner_core.depths))
+
     # outer_core
-    outer_core = burnman.Layer("outer core",radius_planet=radius_planet, max_depth =radius_planet-1220e3, min_depth =radius_planet-3480.e3, n_slices = 10)
+    outer_core = burnman.Layer( "outer core", radius_planet=radius_planet,
+        max_depth=5151.e3, min_depth=2891.e3, n_slices=10)
     outer_core.set_composition(burnman.minerals.other.Liquid_Fe_Anderson())
-    outer_core.set_temperature_mode('user_defined', burnman.geotherm.brown_shankland(outer_core.depths))
+    # The minerals that make up our core do not currently implement the thermal equation of state, so we will define the temperature with the Brown & Shankland geotherm.
+    outer_core.set_temperature_mode('user_defined',
+        burnman.geotherm.brown_shankland(outer_core.depths))
 
-    #Next the Mantle.
-    mantle = burnman.Layer("mantle",radius_planet=radius_planet, max_depth =radius_planet-3480e3, min_depth =0., n_slices = 20)
-    mantle.set_composition(burnman.minerals.SLB_2011.mg_bridgmanite())
-    mantle.set_temperature_mode('adiabat')
-    
-    '''
-    Include phase transition in layer. TO BE IMPLEMENTED
-    LM = burnman.minerals.SLB_2011.mg_bridgmanite()
-    UM = burnman.minerals.SLB_2011.forsterite()
-
-    #We don't want to have an ad hoc transition from the upper mantle to lower mantle, so we'll stitch them
-    #together with a helper to switch between them at 25 GPa. So we define a class of "mantle":
-
-    class mantle_rock(helpers.HelperLowHighPressureRockTransition):
-        def __init__(self):
-            helpers.HelperLowHighPressureRockTransition.__init__(self,25.e9,UM,LM)
-    '''
+    # Next the Mantle.
+    lower_mantle = burnman.Layer( "lower_mantle", radius_planet=radius_planet,
+        max_depth=2891.e3, min_depth=660.e3, n_slices=10)
+    lower_mantle.set_composition(burnman.minerals.SLB_2011.mg_bridgmanite())
+    lower_mantle.set_temperature_mode('adiabat')
+    upper_mantle = burnman.Layer( "upper_mantle", radius_planet=radius_planet,
+        max_depth=660e3, min_depth=0., n_slices=10)
+    upper_mantle.set_composition(burnman.minerals.SLB_2011.forsterite())
+    upper_mantle.set_temperature_mode('adiabat')
 
 
-    #Now we calculate the planet. Go BurnMan Go!
-    Plan = burnman.Planet('earth_like',[inner_core, outer_core, mantle], potential_temperature = 1200, verbose=True)
+
+    # Now we calculate the planet.
+    Plan = burnman.Planet('earth_like',
+                          [inner_core, outer_core, lower_mantle, upper_mantle],
+                          potential_temperature=1200, verbose=True)
+    # Here we compute its state. Go BurnMan Go!
+    # (If we were to change composition of one of the layers, we would have to
+    # recompute the state)
     Plan.set_state()
 
-    #Now we output the mass of the planet and moment of inertia
+    # Now we output the mass of the planet and moment of inertia
     print()
-    print("mass/Earth= %.3f, moment of inertia= %.3f" % (Plan.mass/5.97e24, Plan.moment_of_inertia_factor))
+    print("mass/Earth= %.3f, moment of inertia= %.3f" %
+          (Plan.mass / 5.97e24, Plan.moment_of_inertia_factor))
 
-    #And here's the mass of the individual layers:
+    # And here's the mass of the individual layers:
     for layer in Plan.layers:
-        print("%s mass fraction of planet %.3f" %(layer.name, layer.mass/Plan.mass))
+        print("%s mass fraction of planet %.3f" %
+              (layer.name, layer.mass / Plan.mass))
     print()
 
-    #Now let's plot everything up
+    # Let's get PREM to compare everything to as we are trying
+    # to imitate Earth
+    prem = burnman.seismic.PREM()
+    premradii = 6371.e3 - prem.internal_depth_list()
+    [premdensity, prempressure, premgravity] = prem.evaluate(
+        ['density', 'pressure', 'gravity'])
+
+    # Now let's plot everything up
 
     # Do you like pretty, but slow plotting figures? Try Burnman's patented pretty_plot package.
     # otherwise this line can be commented out
     #burnman.tools.pretty_plot()
 
-    #Come up with axes for the final plot
+    # Come up with axes for the final plot
 
-    figure = plt.figure(figsize = (12,10))
-    figure.suptitle('Your planet is %.3f Earth Masses with Average Density of %.1f kg/m$^3$' %((Plan.mass/5.97e24), \
-                    (Plan.mass/(4./3.*np.pi*Plan.radius_planet*Plan.radius_planet*Plan.radius_planet))),\
-                     fontsize=20)
+    figure = plt.figure(figsize=(11, 7))
+    figure.suptitle(
+        'Your planet is %.3f Earth Masses with Average Density of %.1f kg/m$^3$' %
+        ((Plan.mass /5.97e24),(Plan.mass /(4. /3. * np.pi * Plan.radius_planet *
+              Plan.radius_planet * Plan.radius_planet))), fontsize=20)
 
-    ax1 = plt.subplot2grid( (6,3) , (0,0), colspan=3, rowspan=3)
-    ax2 = plt.subplot2grid( (6,3) , (3,0), colspan=3, rowspan=1)
-    ax3 = plt.subplot2grid( (6,3) , (4,0), colspan=3, rowspan=1)
-    ax4 = plt.subplot2grid( (6,3) , (5,0), colspan=3, rowspan=1)
+    ax1 = plt.subplot2grid((6, 3), (0, 0), colspan=3, rowspan=3)
+    ax2 = plt.subplot2grid((6, 3), (3, 0), colspan=3, rowspan=1)
+    ax3 = plt.subplot2grid((6, 3), (4, 0), colspan=3, rowspan=1)
+    ax4 = plt.subplot2grid((6, 3), (5, 0), colspan=3, rowspan=1)
 
-    ax1.plot(Plan.radii/1.e3,Plan.density/1.e3,'k', linewidth = 2.)
-    ax1.set_ylim(0.,(max(Plan.density)/1.e3)+1.)
-    ax1.set_xlim(0.,max(Plan.radii)/1.e3)
+    ax1.plot(Plan.radii / 1.e3, Plan.density / 1.e3, 'k', linewidth=2.,
+        label='your planet')
+    ax1.plot( premradii / 1.e3, premdensity / 1.e3, '--k', linewidth=1.,
+        label='PREM')
+    ax1.set_ylim(0., (max(Plan.density) / 1.e3) + 1.)
+    ax1.set_xlim(0., max(Plan.radii) / 1.e3)
+    ax1.set_xticklabels([])
     ax1.set_ylabel("Density ( $\cdot 10^3$ kg/m$^3$)")
-    plt.show()
+    ax1.legend()
 
-    #Make a subplot showing the calculated pressure profile
-    ax2.plot( Plan.radii/1.e3, Plan.pressures/1.e9, 'b', linewidth=2.)
-    ax2.set_ylim(0.,(max(Plan.pressures)/1e9)+10.)
-    ax2.set_xlim(0.,max(Plan.radial_slices)/1.e3)
+    # Make a subplot showing the calculated pressure profile
+    ax2.plot(Plan.radii / 1.e3, Plan.pressure / 1.e9, 'b', linewidth=2.)
+    ax2.plot(premradii / 1.e3, prempressure / 1.e9, '--b', linewidth=1.)
+    ax2.set_ylim(0., (max(Plan.pressure) / 1e9) + 10.)
+    ax2.set_xlim(0., max(Plan.radii) / 1.e3)
+    ax2.set_xticklabels([])
     ax2.set_ylabel("Pressure (GPa)")
 
-    #Make a subplot showing the calculated gravity profile
-    ax3.plot( Plan.radii/1.e3, Plan.gravity, 'r', linewidth=2.)
+    # Make a subplot showing the calculated gravity profile
+    ax3.plot(Plan.radii / 1.e3, Plan.gravity, 'g', linewidth=2.)
+    ax3.plot(premradii / 1.e3, premgravity, '--g', linewidth=1.)
     ax3.set_ylabel("Gravity (m/s$^2)$")
-    ax3.set_xlim(0.,max(Plan.radial_slices)/1.e3)
-    ax3.set_ylim(0.,max(Plan.gravity)+0.5)
+    ax3.set_xlim(0., max(Plan.radii) / 1.e3)
+    ax3.set_ylim(0., max(Plan.gravity) + 0.5)
+    ax3.set_xticklabels([])
 
-    #Make a subplot showing the calculated temperature profile
-    ax4.plot( Plan.radii/1.e3, Plan.temperatures, 'g', linewidth=2.)
+    # Make a subplot showing the calculated temperature profile
+    ax4.plot(Plan.radii / 1.e3, Plan.temperature, 'r', linewidth=2.)
     ax4.set_ylabel("Temperature ($K$)")
     ax4.set_xlabel("Radius (km)")
-    ax4.set_xlim(0.,max(Plan.radial_slices)/1.e3)
-    ax4.set_ylim(0.,max(Plan.temperatures)+100)
+    ax4.set_xlim(0., max(Plan.radii) / 1.e3)
+    ax4.set_ylim(0., max(Plan.temperature) + 100)
 
     plt.show()

--- a/examples/example_build_planet.py
+++ b/examples/example_build_planet.py
@@ -67,41 +67,39 @@ if __name__ == "__main__":
     # Separately the composition and the temperature_mode need to set.
     radius_planet = 6371.e3
     # inner_core
-    inner_core = burnman.Layer("inner core", radius_planet=radius_planet,
-        max_depth=6371.e3, min_depth=5151.e3, n_slices=10)
+    inner_core = burnman.Layer("inner core", radii = np.linspace(0,1220.e3,10))
     inner_core.set_material(burnman.minerals.other.Fe_Dewaele())
     
     # The minerals that make up our core do not currently implement the thermal equation of state, so we will set the temperature at 300 K.
     inner_core.set_temperature_mode( 'user-defined',
-        300.*np.ones_like(inner_core.depths))
+        300.*np.ones_like(inner_core.radii))
 
     # outer_core
-    outer_core = burnman.Layer( "outer core", radius_planet=radius_planet,
-        max_depth=5151.e3, min_depth=2891.e3, n_slices=10)
+    outer_core = burnman.Layer( "outer core", radii = np.linspace(1220.e3,3480.e3,10))
     outer_core.set_material(burnman.minerals.other.Liquid_Fe_Anderson())
     # The minerals that make up our core do not currently implement the thermal equation of state, so we will define the temperature at 300 K.
     outer_core.set_temperature_mode('user-defined',
-        300.*np.ones_like(outer_core.depths))
+        300.*np.ones_like(outer_core.radii))
 
     # Next the Mantle.
-    lower_mantle = burnman.Layer( "lower_mantle", radius_planet=radius_planet,
-        max_depth=2891.e3, min_depth=660.e3, n_slices=10)
+    lower_mantle = burnman.Layer( "lower_mantle", radii = np.linspace(3480.e3, 5711.e3, 10))
     lower_mantle.set_material(burnman.minerals.SLB_2011.mg_bridgmanite())
     lower_mantle.set_temperature_mode('adiabat')
-    upper_mantle = burnman.Layer( "upper_mantle", radius_planet=radius_planet,
-        max_depth=660e3, min_depth=0., n_slices=10)
+    upper_mantle = burnman.Layer( "upper_mantle", radii = np.linspace(5711.e3, 6371e3, 10))
     upper_mantle.set_material(burnman.minerals.SLB_2011.forsterite())
-    upper_mantle.set_temperature_mode('adiabat', temperature_top =1200.)
+    upper_mantle.set_temperature_mode('adiabat', temperature_top = 1200.)
 
 
 
     # Now we calculate the planet.
     Plan = burnman.Planet('earth_like',
                           [inner_core, outer_core, lower_mantle, upper_mantle], verbose=True)
+    print(Plan)
+    
     # Here we compute its state. Go BurnMan Go!
     # (If we were to change composition of one of the layers, we would have to
     # recompute the state)
-    Plan.set_state()
+    Plan.make()
 
     # Now we output the mass of the planet and moment of inertia
     print()
@@ -114,12 +112,13 @@ if __name__ == "__main__":
               (layer.name, layer.mass / Plan.mass))
     print()
 
+
     # Let's get PREM to compare everything to as we are trying
     # to imitate Earth
     prem = burnman.seismic.PREM()
     premradii = 6371.e3 - prem.internal_depth_list()
-    [premdensity, prempressure, premgravity] = prem.evaluate(
-        ['density', 'pressure', 'gravity'])
+    [premdensity, prempressure, premgravity,premvs,premvp] = prem.evaluate(
+        ['density', 'pressure', 'gravity', 'v_s','v_p'])
 
     # Now let's plot everything up
 

--- a/examples/example_layer.py
+++ b/examples/example_layer.py
@@ -82,13 +82,16 @@ if __name__ == "__main__":
 
 
     lower_mantle = burnman.Layer(name='Lower Mantle', radius_planet=6371.e3, min_depth =750.e3, max_depth=2800.e3, n_slices=20)
-    
+
     lower_mantle.set_composition(rock)
+ 
     # Now we get an array of temperatures at which we compute
     # the seismic properties of the rock.  Here we use the Brown+Shankland (1981)
     # geotherm for mapping pressure to temperature.
-    temperature = burnman.geotherm.brown_shankland(pressure)
-    lower_mantle.set_state(pressure_mode='selfconsistent',pressure_top= min(pressure), gravity_bottom=10.0,temperature_mode='user_defined', temperatures=temperature)
+
+    lower_mantle.set_state(pressure_mode='selfconsistent',pressure_top= min(pressure), gravity_bottom=10.0,temperature_mode='user_defined', temperatures=burnman.geotherm.brown_shankland(lower_mantle.depths))
+    plt.plot(lower_mantle.depths, lower_mantle.bullen)
+    plt.show()
 
     # All the work is done except the plotting!  Here we want to plot the seismic wave
     # speeds and the density against PREM using the matplotlib plotting tools.  We make
@@ -96,7 +99,7 @@ if __name__ == "__main__":
     # this calculation.
     # First, we plot the s-wave speed verses the PREM s-wave speed
     plt.subplot(2, 2, 1)
-    plt.plot(pressure / 1.e9, vs / 1.e3, color='b', linestyle='-',
+    plt.plot(lower_mantle.pressure / 1.e9, lower_mantle.v_s / 1.e3, color='b', linestyle='-',
              marker='o', markerfacecolor='b', markersize=4, label='computation')
     plt.plot(pressure / 1.e9, seis_vs / 1.e3, color='k', linestyle='-',
              marker='o', markerfacecolor='k', markersize=4, label='reference')
@@ -107,7 +110,7 @@ if __name__ == "__main__":
 
     # Next, we plot the p-wave speed verses the PREM p-wave speed
     plt.subplot(2, 2, 2)
-    plt.plot(pressure / 1.e9, vp / 1.e3, color='b', linestyle='-',
+    plt.plot(lower_mantle.pressure / 1.e9, lower_mantle.v_p / 1.e3, color='b', linestyle='-',
              marker='o', markerfacecolor='b', markersize=4)
     plt.plot(pressure / 1.e9, seis_vp / 1.e3, color='k',
              linestyle='-', marker='o', markerfacecolor='k', markersize=4)
@@ -117,7 +120,7 @@ if __name__ == "__main__":
 
     # Next, we plot the density verses the PREM density
     plt.subplot(2, 2, 3)
-    plt.plot(pressure / 1.e9, density / 1.e3, color='b',
+    plt.plot(lower_mantle.pressure / 1.e9, lower_mantle.density / 1.e3, color='b',
              linestyle='-', marker='o', markerfacecolor='b', markersize=4)
     plt.plot(pressure / 1.e9, seis_rho / 1.e3, color='k',
              linestyle='-', marker='o', markerfacecolor='k', markersize=4)
@@ -127,7 +130,7 @@ if __name__ == "__main__":
 
     # Finally, we plot the used geotherm
     plt.subplot(2, 2, 4)
-    plt.plot(pressure / 1e9, temperature, color='r', linestyle='-',
+    plt.plot(lower_mantle.pressure / 1e9, lower_mantle.temperature, color='r', linestyle='-',
              marker='o', markerfacecolor='r', markersize=4)
     plt.xlim(min(pressure) / 1.e9, max(pressure) / 1.e9)
     plt.xlabel("Pressure (GPa)")

--- a/examples/example_layer.py
+++ b/examples/example_layer.py
@@ -27,7 +27,7 @@ Layers can also be used to build an entire planet (see example_build_planet.py)
 *Demonstrates:*
 
 * creating basic layer
-* calculating thermoelastic properties with selfconsistent pressures
+* calculating thermoelastic properties with self-consistent pressures
 * seismic comparison
 """
 from __future__ import absolute_import
@@ -85,7 +85,7 @@ if __name__ == "__main__":
     #lower_mantle.set_temperature_mode(temperature_mode ='user_defined',
     #                                      temperatures =burnman.geotherm.brown_shankland(depths))
                            
-    lower_mantle.set_state(pressure_mode='selfconsistent',
+    lower_mantle.set_state(pressure_mode='self-consistent',
                                pressure_top=pressure[0], gravity_bottom=gravity[-1])
 
        

--- a/examples/example_layer.py
+++ b/examples/example_layer.py
@@ -73,7 +73,7 @@ if __name__ == "__main__":
     lower_mantle = burnman.Layer( name='Lower Mantle', radius_planet=6371.e3,
         min_depth=750.e3, max_depth=2800.e3,  n_slices=20)
     # Here we set the composition of the layer as the above defined 'rock'.
-    lower_mantle.set_composition(rock)
+    lower_mantle.set_material(rock)
 
     # Now we set the temperature mode of the layer. , and a
     # self-consistent pressure. The pressure at the top of the layer and

--- a/examples/example_layer.py
+++ b/examples/example_layer.py
@@ -70,8 +70,7 @@ if __name__ == "__main__":
 
     # Here we define the lower mantle as a Layer(). The layer needs various
     # parameters to set a depth array and radius array.
-    lower_mantle = burnman.Layer( name='Lower Mantle', radius_planet=6371.e3,
-        min_depth=750.e3, max_depth=2800.e3,  n_slices=20)
+    lower_mantle = burnman.Layer( name='Lower Mantle', radii=6371.e3-depths)
     # Here we set the composition of the layer as the above defined 'rock'.
     lower_mantle.set_material(rock)
 
@@ -85,15 +84,16 @@ if __name__ == "__main__":
     #lower_mantle.set_temperature_mode(temperature_mode ='user_defined',
     #                                      temperatures =burnman.geotherm.brown_shankland(depths))
                            
-    lower_mantle.set_state(pressure_mode='self-consistent',
+    lower_mantle.set_pressure_mode(pressure_mode='self-consistent',
                                pressure_top=pressure[0], gravity_bottom=gravity[-1])
 
-       
+    lower_mantle.make()
+    
     # All the work is done, now we can plot various properties!
     # First, we plot the s-wave speed verses the PREM s-wave speed
     plt.figure(figsize = (10,6))
     plt.subplot(1, 2, 1)
-    plt.plot(lower_mantle.pressure / 1.e9, lower_mantle.v_s / 1.e3, color='b', linestyle='-',
+    plt.plot(lower_mantle.pressures / 1.e9, lower_mantle.v_s / 1.e3, color='b', linestyle='-',
              marker='o', markerfacecolor='b', markersize=4, label='Vs computed')
     plt.plot(pressure / 1.e9, seis_vs / 1.e3, color='b', linestyle='--',
              marker='o', markerfacecolor='w', markersize=4, label='Vs ref')
@@ -102,25 +102,25 @@ if __name__ == "__main__":
     plt.legend(loc='lower right')
 
     # Next, we plot the p-wave speed verses the PREM p-wave speed
-    plt.plot(lower_mantle.pressure / 1.e9, lower_mantle.v_p / 1.e3, color='r', linestyle='-',
+    plt.plot(lower_mantle.pressures / 1.e9, lower_mantle.v_p / 1.e3, color='r', linestyle='-',
              marker='o', markerfacecolor='r', markersize=4, label='Vp computed')
     plt.plot(pressure / 1.e9, seis_vp / 1.e3, color='r',
              linestyle='--', marker='o', markerfacecolor='w', markersize=4, label='Vp ref')
 
 
     # Next, we plot the density verses the PREM density
-    plt.plot(lower_mantle.pressure / 1.e9, lower_mantle.density / 1.e3, color='g',
+    plt.plot(lower_mantle.pressures / 1.e9, lower_mantle.density / 1.e3, color='g',
              linestyle='-', marker='o', markerfacecolor='g', markersize=4, label='rho computed')
     plt.plot(pressure / 1.e9, seis_rho / 1.e3, color='g',
              linestyle='--', marker='o', markerfacecolor='w', markersize=4, label='rho ref')
     plt.xlim(min(pressure) / 1.e9, max(pressure) / 1.e9)
     plt.xlabel("Pressure (GPa)")
-    plt.xlim(min(lower_mantle.pressure) / 1.e9, max(lower_mantle.pressure) / 1.e9)
+    plt.xlim(min(lower_mantle.pressures) / 1.e9, max(lower_mantle.pressures) / 1.e9)
     
     plt.legend()
     
     plt.subplot(2, 2, 2)
-    plt.plot(lower_mantle.pressure / 1e9, lower_mantle.bullen, color='k', linestyle='-',
+    plt.plot(lower_mantle.pressures / 1e9, lower_mantle.bullen, color='k', linestyle='-',
              marker='o', markerfacecolor='k', markersize=4, label='bullen computed')
     plt.plot(pressure / 1.e9, seis_bullen , color='k',
                  linestyle='--', marker='o', markerfacecolor='w', markersize=4, label='bullen ref')
@@ -130,7 +130,7 @@ if __name__ == "__main__":
 
     # Finally, we plot the used geotherm
     plt.subplot(2, 2, 4)
-    plt.plot(lower_mantle.pressure / 1e9, lower_mantle.temperature, color='k', linestyle='-',
+    plt.plot(lower_mantle.pressures / 1e9, lower_mantle.temperatures, color='k', linestyle='-',
              marker='o', markerfacecolor='k', markersize=4)
     plt.xlim(min(pressure) / 1.e9, max(pressure) / 1.e9)
     plt.xlabel("Pressure (GPa)")

--- a/examples/example_layer.py
+++ b/examples/example_layer.py
@@ -4,18 +4,18 @@
 
 
 """
-example_beginner
+example_layer
 ----------------
 
-This example script is intended for absolute beginners to BurnMan.
-We cover importing BurnMan modules, creating a composite material,
-and calculating its seismic properties at lower mantle pressures and
-temperatures.  Afterwards, we plot it against a 1D seismic model
-for visual comparison.
+This example script is building on example_beginner.py.
+In this case we use the layer Class. Instead of computing properties at
+pressures defined by the seismic PREM model, we compute properties at pressures
+self-consistent to the leayr.
 
 *Uses:*
 
 * :doc:`mineral_database`
+* :class:`burnman.layer.Layer`
 * :class:`burnman.composite.Composite`
 * :class:`burnman.seismic.PREM`
 * :func:`burnman.geotherm.brown_shankland`
@@ -24,16 +24,14 @@ for visual comparison.
 
 *Demonstrates:*
 
-* creating basic composites
+* creating basic layer
 * calculating thermoelastic properties
 * seismic comparison
 """
 from __future__ import absolute_import
 
 # Here we import standard python modules that are required for
-# usage of BurnMan.  In particular, numpy is used for handling
-# numerical arrays and mathematical operations on them, and
-# matplotlib is used for generating plots of results of calculations
+# usage of BurnMan.
 import os
 import sys
 import numpy as np
@@ -44,12 +42,7 @@ if not os.path.exists('burnman') and os.path.exists('../burnman'):
     sys.path.insert(1, os.path.abspath('..'))
 
 
-# Here we import the relevant modules from BurnMan.  The burnman
-# module imports several of the most important functionalities of
-# the library, including the ability to make composites, and compute
-# thermoelastic properties of them.  The minerals module includes
-# the mineral physical parameters for the predefined minerals in
-# BurnMan
+# Here we import the relevant modules from BurnMan.
 import burnman
 from burnman import minerals
 
@@ -57,13 +50,7 @@ from burnman import minerals
 if __name__ == "__main__":
 
     # This is the first actual work done in this example.  We define
-    # composite object and name it "rock".  A composite is made by
-    # giving burnman.composite a list of minerals and their molar fractions.
-    # Here "rock" has two constituent minerals: it is 80% Mg perovskite
-    # and 20% periclase.  More minerals may be added by simply extending
-    # the list given to burnman.composite
-    # For the preset minerals from the SLB_2011, the equation of state
-    # formulation from Stixrude and Lithgow-Bertolloni (2005) will be used.
+    # composite object and name it "rock".
     rock = burnman.Composite([minerals.SLB_2011.mg_perovskite(),
                               minerals.SLB_2011.periclase()],
                              [0.8, 0.2])
@@ -76,65 +63,84 @@ if __name__ == "__main__":
     # query the seismic model for the pressure, density, P wave speed, S wave
     # speed, and bulk sound velocity at those depths
     depths = np.linspace(750e3, 2800e3, 20)
-    pressure, seis_rho, seis_vp, seis_vs, seis_vphi = seismic_model.evaluate(
-        ['pressure', 'density', 'v_p', 'v_s', 'v_phi'], depths)
+    pressure, gravity, seis_rho, seis_vp, seis_vs, seis_bullen = seismic_model.evaluate(
+        ['pressure', 'gravity', 'density', 'v_p', 'v_s', 'bullen'], depths)
 
-
-
-    lower_mantle = burnman.Layer(name='Lower Mantle', radius_planet=6371.e3, min_depth =750.e3, max_depth=2800.e3, n_slices=20)
-
+    # Here we define the lower mantle as a Layer(). The layer needs various
+    # parameters to set a depth array and radius array.
+    lower_mantle = burnman.Layer(
+        name='Lower Mantle',
+        radius_planet=6371.e3,
+        min_depth=750.e3,
+        max_depth=2800.e3,
+        n_slices=20)
+    # Here we set the composition of the layer as the above defined 'rock'.
     lower_mantle.set_composition(rock)
- 
-    # Now we get an array of temperatures at which we compute
-    # the seismic properties of the rock.  Here we use the Brown+Shankland (1981)
-    # geotherm for mapping pressure to temperature.
 
-    lower_mantle.set_state(pressure_mode='selfconsistent',pressure_top= min(pressure), gravity_bottom=10.0,temperature_mode='user_defined', temperatures=burnman.geotherm.brown_shankland(lower_mantle.depths))
-    plt.plot(lower_mantle.depths, lower_mantle.bullen)
-    plt.show()
+    # Now we set the temperature mode of the layer. , and a
+    # self-consistent pressure. The pressure at the top of the layer and
+    # gravity at the bottom of the layer are given by the PREM.
+    
+    # Here we use an adiabatic temperature and set the temperature at the top of the layer
+    #lower_mantle.set_temperature_mode(temperature_mode='adiabat',
+    #                       temperature_top=1900.)
+    
+    #Here we choose a user-defined
+    # temperature, given by the Brown & Shankland geotherm
+    lower_mantle.set_temperature_mode(temperature_mode ='user_defined',
+                                          temperatures =burnman.geotherm.brown_shankland(depths))
+                           
+    lower_mantle.set_state(pressure_mode='selfconsistent',
+                               pressure_top=pressure[0],
+                               gravity_bottom=gravity[-1])
 
-    # All the work is done except the plotting!  Here we want to plot the seismic wave
-    # speeds and the density against PREM using the matplotlib plotting tools.  We make
-    # a 2x2 array of plots.  The fourth subplot plots the geotherm used for
-    # this calculation.
+       
+    # All the work is done except the plotting!
     # First, we plot the s-wave speed verses the PREM s-wave speed
-    plt.subplot(2, 2, 1)
+    plt.figure(figsize = (10,6))
+    plt.subplot(1, 2, 1)
     plt.plot(lower_mantle.pressure / 1.e9, lower_mantle.v_s / 1.e3, color='b', linestyle='-',
-             marker='o', markerfacecolor='b', markersize=4, label='computation')
-    plt.plot(pressure / 1.e9, seis_vs / 1.e3, color='k', linestyle='-',
-             marker='o', markerfacecolor='k', markersize=4, label='reference')
-    plt.title("S wave speed (km/s)")
+             marker='o', markerfacecolor='b', markersize=4, label='Vs computed')
+    plt.plot(pressure / 1.e9, seis_vs / 1.e3, color='b', linestyle='--',
+             marker='o', markerfacecolor='w', markersize=4, label='Vs ref')
+    plt.ylabel("Wave speeds (km/s)  and density (g/cm^3)")
     plt.xlim(min(pressure) / 1.e9, max(pressure) / 1.e9)
     plt.legend(loc='lower right')
-    plt.ylim(5, 8.0)
 
     # Next, we plot the p-wave speed verses the PREM p-wave speed
-    plt.subplot(2, 2, 2)
-    plt.plot(lower_mantle.pressure / 1.e9, lower_mantle.v_p / 1.e3, color='b', linestyle='-',
-             marker='o', markerfacecolor='b', markersize=4)
-    plt.plot(pressure / 1.e9, seis_vp / 1.e3, color='k',
-             linestyle='-', marker='o', markerfacecolor='k', markersize=4)
-    plt.title("P wave speed (km/s)")
-    plt.xlim(min(pressure) / 1.e9, max(pressure) / 1.e9)
-    plt.ylim(10, 16)
+    plt.plot(lower_mantle.pressure / 1.e9, lower_mantle.v_p / 1.e3, color='r', linestyle='-',
+             marker='o', markerfacecolor='r', markersize=4, label='Vp computed')
+    plt.plot(pressure / 1.e9, seis_vp / 1.e3, color='r',
+             linestyle='--', marker='o', markerfacecolor='w', markersize=4, label='Vp ref')
+
 
     # Next, we plot the density verses the PREM density
-    plt.subplot(2, 2, 3)
-    plt.plot(lower_mantle.pressure / 1.e9, lower_mantle.density / 1.e3, color='b',
-             linestyle='-', marker='o', markerfacecolor='b', markersize=4)
-    plt.plot(pressure / 1.e9, seis_rho / 1.e3, color='k',
-             linestyle='-', marker='o', markerfacecolor='k', markersize=4)
+    plt.plot(lower_mantle.pressure / 1.e9, lower_mantle.density / 1.e3, color='g',
+             linestyle='-', marker='o', markerfacecolor='g', markersize=4, label='rho computed')
+    plt.plot(pressure / 1.e9, seis_rho / 1.e3, color='g',
+             linestyle='--', marker='o', markerfacecolor='w', markersize=4, label='rho ref')
     plt.xlim(min(pressure) / 1.e9, max(pressure) / 1.e9)
     plt.xlabel("Pressure (GPa)")
-    plt.title("density (kg/m^3)")
+    plt.xlim(min(lower_mantle.pressure) / 1.e9, max(lower_mantle.pressure) / 1.e9)
+    
+    plt.legend()
+    
+    plt.subplot(2, 2, 2)
+    plt.plot(lower_mantle.pressure / 1e9, lower_mantle.bullen, color='k', linestyle='-',
+             marker='o', markerfacecolor='k', markersize=4, label='bullen computed')
+    plt.plot(pressure / 1.e9, seis_bullen , color='k',
+                 linestyle='--', marker='o', markerfacecolor='w', markersize=4, label='bullen ref')
+    plt.xlim(min(pressure) / 1.e9, max(pressure) / 1.e9)
+    plt.legend()
+    plt.ylabel("Bullen parameter")
 
     # Finally, we plot the used geotherm
     plt.subplot(2, 2, 4)
-    plt.plot(lower_mantle.pressure / 1e9, lower_mantle.temperature, color='r', linestyle='-',
-             marker='o', markerfacecolor='r', markersize=4)
+    plt.plot(lower_mantle.pressure / 1e9, lower_mantle.temperature, color='k', linestyle='-',
+             marker='o', markerfacecolor='k', markersize=4)
     plt.xlim(min(pressure) / 1.e9, max(pressure) / 1.e9)
     plt.xlabel("Pressure (GPa)")
-    plt.title("temperature (K)")
+    plt.ylabel("temperature (K)")
 
     # At long last, we show the results!  We are done!
     plt.show()

--- a/examples/example_layer.py
+++ b/examples/example_layer.py
@@ -83,7 +83,7 @@ if __name__ == "__main__":
     lower_mantle.set_temperature_mode(temperature_mode='adiabat', temperature_top=1900.)
     #Alternatively, we choose a user-defined temperature, given by the Brown & Shankland geotherm
     #lower_mantle.set_temperature_mode(temperature_mode ='user_defined',
-                                          temperatures =burnman.geotherm.brown_shankland(depths))
+    #                                      temperatures =burnman.geotherm.brown_shankland(depths))
                            
     lower_mantle.set_state(pressure_mode='selfconsistent',
                                pressure_top=pressure[0], gravity_bottom=gravity[-1])

--- a/examples/example_layer.py
+++ b/examples/example_layer.py
@@ -74,16 +74,15 @@ if __name__ == "__main__":
     # Here we set the composition of the layer as the above defined 'rock'.
     lower_mantle.set_material(rock)
 
-    # Now we set the temperature mode of the layer. , and a
-    # self-consistent pressure. The pressure at the top of the layer and
-    # gravity at the bottom of the layer are given by the PREM.
-    
+    # Now we set the temperature mode of the layer.
     # Here we use an adiabatic temperature and set the temperature at the top of the layer
     lower_mantle.set_temperature_mode(temperature_mode='adiabat', temperature_top=1900.)
     #Alternatively, we choose a user-defined temperature, given by the Brown & Shankland geotherm
     #lower_mantle.set_temperature_mode(temperature_mode ='user_defined',
     #                                      temperatures =burnman.geotherm.brown_shankland(depths))
-                           
+
+    # And we set a self-consistent pressure. The pressure at the top of the layer and
+    # gravity at the bottom of the layer are given by the PREM.
     lower_mantle.set_pressure_mode(pressure_mode='self-consistent',
                                pressure_top=pressure[0], gravity_bottom=gravity[-1])
 

--- a/examples/example_layer.py
+++ b/examples/example_layer.py
@@ -1,0 +1,137 @@
+# This file is part of BurnMan - a thermoelastic and thermodynamic toolkit for the Earth and Planetary Sciences
+# Copyright (C) 2012 - 2015 by the BurnMan team, released under the GNU
+# GPL v2 or later.
+
+
+"""
+example_beginner
+----------------
+
+This example script is intended for absolute beginners to BurnMan.
+We cover importing BurnMan modules, creating a composite material,
+and calculating its seismic properties at lower mantle pressures and
+temperatures.  Afterwards, we plot it against a 1D seismic model
+for visual comparison.
+
+*Uses:*
+
+* :doc:`mineral_database`
+* :class:`burnman.composite.Composite`
+* :class:`burnman.seismic.PREM`
+* :func:`burnman.geotherm.brown_shankland`
+* :func:`burnman.material.Material.evaluate`
+
+
+*Demonstrates:*
+
+* creating basic composites
+* calculating thermoelastic properties
+* seismic comparison
+"""
+from __future__ import absolute_import
+
+# Here we import standard python modules that are required for
+# usage of BurnMan.  In particular, numpy is used for handling
+# numerical arrays and mathematical operations on them, and
+# matplotlib is used for generating plots of results of calculations
+import os
+import sys
+import numpy as np
+import matplotlib.pyplot as plt
+
+# hack to allow scripts to be placed in subdirectories next to burnman:
+if not os.path.exists('burnman') and os.path.exists('../burnman'):
+    sys.path.insert(1, os.path.abspath('..'))
+
+
+# Here we import the relevant modules from BurnMan.  The burnman
+# module imports several of the most important functionalities of
+# the library, including the ability to make composites, and compute
+# thermoelastic properties of them.  The minerals module includes
+# the mineral physical parameters for the predefined minerals in
+# BurnMan
+import burnman
+from burnman import minerals
+
+
+if __name__ == "__main__":
+
+    # This is the first actual work done in this example.  We define
+    # composite object and name it "rock".  A composite is made by
+    # giving burnman.composite a list of minerals and their molar fractions.
+    # Here "rock" has two constituent minerals: it is 80% Mg perovskite
+    # and 20% periclase.  More minerals may be added by simply extending
+    # the list given to burnman.composite
+    # For the preset minerals from the SLB_2011, the equation of state
+    # formulation from Stixrude and Lithgow-Bertolloni (2005) will be used.
+    rock = burnman.Composite([minerals.SLB_2011.mg_perovskite(),
+                              minerals.SLB_2011.periclase()],
+                             [0.8, 0.2])
+
+    # Here we create and load the PREM seismic velocity model, which will be
+    # used for comparison with the seismic velocities of the "rock" composite
+    seismic_model = burnman.seismic.PREM()
+
+    # We create an array of 20 depths at which we want to evaluate PREM, and then
+    # query the seismic model for the pressure, density, P wave speed, S wave
+    # speed, and bulk sound velocity at those depths
+    depths = np.linspace(750e3, 2800e3, 20)
+    pressure, seis_rho, seis_vp, seis_vs, seis_vphi = seismic_model.evaluate(
+        ['pressure', 'density', 'v_p', 'v_s', 'v_phi'], depths)
+
+
+
+    lower_mantle = burnman.Layer(name='Lower Mantle', radius_planet=6371.e3, min_depth =750.e3, max_depth=2800.e3, n_slices=20)
+    
+    lower_mantle.set_composition(rock)
+    # Now we get an array of temperatures at which we compute
+    # the seismic properties of the rock.  Here we use the Brown+Shankland (1981)
+    # geotherm for mapping pressure to temperature.
+    temperature = burnman.geotherm.brown_shankland(pressure)
+    lower_mantle.set_state(pressure_mode='selfconsistent',pressure_top= min(pressure), gravity_bottom=10.0,temperature_mode='user_defined', temperatures=temperature)
+
+    # All the work is done except the plotting!  Here we want to plot the seismic wave
+    # speeds and the density against PREM using the matplotlib plotting tools.  We make
+    # a 2x2 array of plots.  The fourth subplot plots the geotherm used for
+    # this calculation.
+    # First, we plot the s-wave speed verses the PREM s-wave speed
+    plt.subplot(2, 2, 1)
+    plt.plot(pressure / 1.e9, vs / 1.e3, color='b', linestyle='-',
+             marker='o', markerfacecolor='b', markersize=4, label='computation')
+    plt.plot(pressure / 1.e9, seis_vs / 1.e3, color='k', linestyle='-',
+             marker='o', markerfacecolor='k', markersize=4, label='reference')
+    plt.title("S wave speed (km/s)")
+    plt.xlim(min(pressure) / 1.e9, max(pressure) / 1.e9)
+    plt.legend(loc='lower right')
+    plt.ylim(5, 8.0)
+
+    # Next, we plot the p-wave speed verses the PREM p-wave speed
+    plt.subplot(2, 2, 2)
+    plt.plot(pressure / 1.e9, vp / 1.e3, color='b', linestyle='-',
+             marker='o', markerfacecolor='b', markersize=4)
+    plt.plot(pressure / 1.e9, seis_vp / 1.e3, color='k',
+             linestyle='-', marker='o', markerfacecolor='k', markersize=4)
+    plt.title("P wave speed (km/s)")
+    plt.xlim(min(pressure) / 1.e9, max(pressure) / 1.e9)
+    plt.ylim(10, 16)
+
+    # Next, we plot the density verses the PREM density
+    plt.subplot(2, 2, 3)
+    plt.plot(pressure / 1.e9, density / 1.e3, color='b',
+             linestyle='-', marker='o', markerfacecolor='b', markersize=4)
+    plt.plot(pressure / 1.e9, seis_rho / 1.e3, color='k',
+             linestyle='-', marker='o', markerfacecolor='k', markersize=4)
+    plt.xlim(min(pressure) / 1.e9, max(pressure) / 1.e9)
+    plt.xlabel("Pressure (GPa)")
+    plt.title("density (kg/m^3)")
+
+    # Finally, we plot the used geotherm
+    plt.subplot(2, 2, 4)
+    plt.plot(pressure / 1e9, temperature, color='r', linestyle='-',
+             marker='o', markerfacecolor='r', markersize=4)
+    plt.xlim(min(pressure) / 1.e9, max(pressure) / 1.e9)
+    plt.xlabel("Pressure (GPa)")
+    plt.title("temperature (K)")
+
+    # At long last, we show the results!  We are done!
+    plt.show()

--- a/examples/example_layer.py
+++ b/examples/example_layer.py
@@ -9,8 +9,12 @@ example_layer
 
 This example script is building on example_beginner.py.
 In this case we use the layer Class. Instead of computing properties at
-pressures defined by the seismic PREM model, we compute properties at pressures
-self-consistent to the leayr.
+pressures defined by the seismic PREM model (as is done in many examples), 
+we compute properties at pressures self-consistent to the layer.
+Layer can be used to evaluate geophysical parameter, such as
+the Bullen parameter or the Brunt_vasala frequency. Through the 'modified_adiabat'
+temperature setting it allows for inclusions of thermal boundary layers. 
+Layers can also be used to build an entire planet (see example_build_planet.py)
 
 *Uses:*
 
@@ -18,14 +22,12 @@ self-consistent to the leayr.
 * :class:`burnman.layer.Layer`
 * :class:`burnman.composite.Composite`
 * :class:`burnman.seismic.PREM`
-* :func:`burnman.geotherm.brown_shankland`
-* :func:`burnman.material.Material.evaluate`
 
 
 *Demonstrates:*
 
 * creating basic layer
-* calculating thermoelastic properties
+* calculating thermoelastic properties with selfconsistent pressures
 * seismic comparison
 """
 from __future__ import absolute_import
@@ -68,12 +70,8 @@ if __name__ == "__main__":
 
     # Here we define the lower mantle as a Layer(). The layer needs various
     # parameters to set a depth array and radius array.
-    lower_mantle = burnman.Layer(
-        name='Lower Mantle',
-        radius_planet=6371.e3,
-        min_depth=750.e3,
-        max_depth=2800.e3,
-        n_slices=20)
+    lower_mantle = burnman.Layer( name='Lower Mantle', radius_planet=6371.e3,
+        min_depth=750.e3, max_depth=2800.e3,  n_slices=20)
     # Here we set the composition of the layer as the above defined 'rock'.
     lower_mantle.set_composition(rock)
 
@@ -82,20 +80,16 @@ if __name__ == "__main__":
     # gravity at the bottom of the layer are given by the PREM.
     
     # Here we use an adiabatic temperature and set the temperature at the top of the layer
-    #lower_mantle.set_temperature_mode(temperature_mode='adiabat',
-    #                       temperature_top=1900.)
-    
-    #Here we choose a user-defined
-    # temperature, given by the Brown & Shankland geotherm
-    lower_mantle.set_temperature_mode(temperature_mode ='user_defined',
+    lower_mantle.set_temperature_mode(temperature_mode='adiabat', temperature_top=1900.)
+    #Alternatively, we choose a user-defined temperature, given by the Brown & Shankland geotherm
+    #lower_mantle.set_temperature_mode(temperature_mode ='user_defined',
                                           temperatures =burnman.geotherm.brown_shankland(depths))
                            
     lower_mantle.set_state(pressure_mode='selfconsistent',
-                               pressure_top=pressure[0],
-                               gravity_bottom=gravity[-1])
+                               pressure_top=pressure[0], gravity_bottom=gravity[-1])
 
        
-    # All the work is done except the plotting!
+    # All the work is done, now we can plot various properties!
     # First, we plot the s-wave speed verses the PREM s-wave speed
     plt.figure(figsize = (10,6))
     plt.subplot(1, 2, 1)

--- a/misc/ref/example_build_planet.py.out
+++ b/misc/ref/example_build_planet.py.out
@@ -1,17 +1,22 @@
-on iteration 1
-on iteration 2
-on iteration 3
-on iteration 4
-on iteration 5
-on iteration 6
-on iteration 7
-on iteration 8
-on iteration 9
-on iteration 10
-on iteration 11
+Iteration 1  maximum core pressure error between iterations: 6.689277e-01
+Iteration 2  maximum core pressure error between iterations: 3.429670e-01
+Iteration 3  maximum core pressure error between iterations: 1.676346e-01
+Iteration 4  maximum core pressure error between iterations: 6.843174e-02
+Iteration 5  maximum core pressure error between iterations: 2.556444e-02
+Iteration 6  maximum core pressure error between iterations: 9.184659e-03
+Iteration 7  maximum core pressure error between iterations: 3.248780e-03
+Iteration 8  maximum core pressure error between iterations: 1.142705e-03
+Iteration 9  maximum core pressure error between iterations: 4.011601e-04
+Iteration 10  maximum core pressure error between iterations: 1.407470e-04
+Iteration 11  maximum core pressure error between iterations: 4.937207e-05
+Iteration 12  maximum core pressure error between iterations: 1.731808e-05
+Iteration 13  maximum core pressure error between iterations: 6.074510e-06
 
 mass/Earth= 1.028, moment of inertia= 0.320
+upper_mantle mass fraction of planet 0.167
+lower_mantle mass fraction of planet 0.476
+outer core mass fraction of planet 0.338
 inner core mass fraction of planet 0.018
-outer core mass fraction of planet 0.339
-mantle mass fraction of planet 0.642
 
+BURNMAN/burnman/seismic.py: UserWarning: Gravity is not given in PREM and is now being computed. This will only work when density is defined for the entire planet.  Use at your own risk. 
+  " and is now being computed. This will only work when density is defined for the entire planet.  Use at your own risk. ")

--- a/misc/ref/example_build_planet.py.out
+++ b/misc/ref/example_build_planet.py.out
@@ -4,19 +4,19 @@ Planet earth_like consists of 4 layers:
  Layer lower_mantle made out of Mg_Perovskite with adiabat temperatures 
  Layer upper_mantle made out of Forsterite with adiabat temperatures 
 
-Iteration 1  maximum core pressure delta between iterations: 6.689276e-01
-Iteration 2  maximum core pressure delta between iterations: 3.429670e-01
-Iteration 3  maximum core pressure delta between iterations: 1.676346e-01
-Iteration 4  maximum core pressure delta between iterations: 6.843174e-02
-Iteration 5  maximum core pressure delta between iterations: 2.556444e-02
-Iteration 6  maximum core pressure delta between iterations: 9.184659e-03
-Iteration 7  maximum core pressure delta between iterations: 3.248780e-03
-Iteration 8  maximum core pressure delta between iterations: 1.142704e-03
-Iteration 9  maximum core pressure delta between iterations: 4.011601e-04
-Iteration 10  maximum core pressure delta between iterations: 1.407470e-04
-Iteration 11  maximum core pressure delta between iterations: 4.937206e-05
-Iteration 12  maximum core pressure delta between iterations: 1.731808e-05
-Iteration 13  maximum core pressure delta between iterations: 6.074510e-06
+Iteration 1 maximum relative pressure error: 6.7e-01
+Iteration 2 maximum relative pressure error: 3.4e-01
+Iteration 3 maximum relative pressure error: 1.7e-01
+Iteration 4 maximum relative pressure error: 6.8e-02
+Iteration 5 maximum relative pressure error: 2.6e-02
+Iteration 6 maximum relative pressure error: 9.2e-03
+Iteration 7 maximum relative pressure error: 3.2e-03
+Iteration 8 maximum relative pressure error: 1.1e-03
+Iteration 9 maximum relative pressure error: 4.0e-04
+Iteration 10 maximum relative pressure error: 1.4e-04
+Iteration 11 maximum relative pressure error: 4.9e-05
+Iteration 12 maximum relative pressure error: 1.7e-05
+Iteration 13 maximum relative pressure error: 6.1e-06
 
 mass/Earth= 1.028, moment of inertia= 0.320
 inner core mass fraction of planet 0.018

--- a/misc/ref/example_build_planet.py.out
+++ b/misc/ref/example_build_planet.py.out
@@ -25,4 +25,4 @@ lower_mantle mass fraction of planet 0.476
 upper_mantle mass fraction of planet 0.167
 
 BURNMAN/burnman/seismic.py: UserWarning: Gravity is not given in PREM and is now being computed. This will only work when density is defined for the entire planet.  Use at your own risk. 
-  warnings.warn("Gravity is not given in " + self.__class__.__name__ + " and is now being computed. This will only work when density is defined for the entire planet.  Use at your own risk. ")
+  "Gravity is not given in " + self.__class__.__name__ + " and is now being computed. This will only work when density is defined for the entire planet.  Use at your own risk.  ") 

--- a/misc/ref/example_build_planet.py.out
+++ b/misc/ref/example_build_planet.py.out
@@ -1,22 +1,28 @@
-Iteration 1  maximum core pressure delta between iterations: 6.689277e-01
+Planet earth_like consists of 4 layers: 
+ Layer inner core made out of Fe_Dewaele with user-defined temperatures 
+ Layer outer core made out of Liquid_Fe_Anderson with user-defined temperatures 
+ Layer lower_mantle made out of Mg_Perovskite with adiabat temperatures 
+ Layer upper_mantle made out of Forsterite with adiabat temperatures 
+
+Iteration 1  maximum core pressure delta between iterations: 6.689276e-01
 Iteration 2  maximum core pressure delta between iterations: 3.429670e-01
 Iteration 3  maximum core pressure delta between iterations: 1.676346e-01
 Iteration 4  maximum core pressure delta between iterations: 6.843174e-02
 Iteration 5  maximum core pressure delta between iterations: 2.556444e-02
 Iteration 6  maximum core pressure delta between iterations: 9.184659e-03
 Iteration 7  maximum core pressure delta between iterations: 3.248780e-03
-Iteration 8  maximum core pressure delta between iterations: 1.142705e-03
+Iteration 8  maximum core pressure delta between iterations: 1.142704e-03
 Iteration 9  maximum core pressure delta between iterations: 4.011601e-04
 Iteration 10  maximum core pressure delta between iterations: 1.407470e-04
-Iteration 11  maximum core pressure delta between iterations: 4.937207e-05
+Iteration 11  maximum core pressure delta between iterations: 4.937206e-05
 Iteration 12  maximum core pressure delta between iterations: 1.731808e-05
 Iteration 13  maximum core pressure delta between iterations: 6.074510e-06
 
 mass/Earth= 1.028, moment of inertia= 0.320
-upper_mantle mass fraction of planet 0.167
-lower_mantle mass fraction of planet 0.476
-outer core mass fraction of planet 0.338
 inner core mass fraction of planet 0.018
+outer core mass fraction of planet 0.338
+lower_mantle mass fraction of planet 0.476
+upper_mantle mass fraction of planet 0.167
 
 BURNMAN/burnman/seismic.py: UserWarning: Gravity is not given in PREM and is now being computed. This will only work when density is defined for the entire planet.  Use at your own risk. 
-  " and is now being computed. This will only work when density is defined for the entire planet.  Use at your own risk. ")
+  warnings.warn("Gravity is not given in " + self.__class__.__name__ + " and is now being computed. This will only work when density is defined for the entire planet.  Use at your own risk. ")

--- a/misc/ref/example_build_planet.py.out
+++ b/misc/ref/example_build_planet.py.out
@@ -1,16 +1,16 @@
-Iteration 1  maximum core pressure error between iterations: 6.689277e-01
-Iteration 2  maximum core pressure error between iterations: 3.429670e-01
-Iteration 3  maximum core pressure error between iterations: 1.676346e-01
-Iteration 4  maximum core pressure error between iterations: 6.843174e-02
-Iteration 5  maximum core pressure error between iterations: 2.556444e-02
-Iteration 6  maximum core pressure error between iterations: 9.184659e-03
-Iteration 7  maximum core pressure error between iterations: 3.248780e-03
-Iteration 8  maximum core pressure error between iterations: 1.142705e-03
-Iteration 9  maximum core pressure error between iterations: 4.011601e-04
-Iteration 10  maximum core pressure error between iterations: 1.407470e-04
-Iteration 11  maximum core pressure error between iterations: 4.937207e-05
-Iteration 12  maximum core pressure error between iterations: 1.731808e-05
-Iteration 13  maximum core pressure error between iterations: 6.074510e-06
+Iteration 1  maximum core pressure delta between iterations: 6.689277e-01
+Iteration 2  maximum core pressure delta between iterations: 3.429670e-01
+Iteration 3  maximum core pressure delta between iterations: 1.676346e-01
+Iteration 4  maximum core pressure delta between iterations: 6.843174e-02
+Iteration 5  maximum core pressure delta between iterations: 2.556444e-02
+Iteration 6  maximum core pressure delta between iterations: 9.184659e-03
+Iteration 7  maximum core pressure delta between iterations: 3.248780e-03
+Iteration 8  maximum core pressure delta between iterations: 1.142705e-03
+Iteration 9  maximum core pressure delta between iterations: 4.011601e-04
+Iteration 10  maximum core pressure delta between iterations: 1.407470e-04
+Iteration 11  maximum core pressure delta between iterations: 4.937207e-05
+Iteration 12  maximum core pressure delta between iterations: 1.731808e-05
+Iteration 13  maximum core pressure delta between iterations: 6.074510e-06
 
 mass/Earth= 1.028, moment of inertia= 0.320
 upper_mantle mass fraction of planet 0.167

--- a/misc/ref/example_layer.py.out
+++ b/misc/ref/example_layer.py.out
@@ -1,0 +1,2 @@
+BURNMAN/burnman/seismic.py: UserWarning: Gravity is not given in PREM and is now being computed. This will only work when density is defined for the entire planet.  Use at your own risk. 
+  " and is now being computed. This will only work when density is defined for the entire planet.  Use at your own risk. ")

--- a/misc/ref/example_seismic.py.out
+++ b/misc/ref/example_seismic.py.out
@@ -2,16 +2,16 @@ pressure is not defined for IASP91
 gravity is not defined for IASP91
 density is not defined for IASP91
 BURNMAN/burnman/seismic.py: UserWarning: Pressure is not given in STW105 and is now being computed. This will only work when density is defined for the entire planet. Use at your own risk. 
-  warnings.warn("Pressure is not given in " + self.__class__.__name__ + " and is now being computed. This will only work when density is defined for the entire planet. Use at your own risk. ")
+  "Pressure is not given in " + self.__class__.__name__ + " and is now being computed. This will only work when density is defined for the entire planet. Use at your own risk. ")
 BURNMAN/burnman/seismic.py: UserWarning: Gravity is not given in STW105 and is now being computed. This will only work when density is defined for the entire planet.  Use at your own risk. 
-  warnings.warn("Gravity is not given in " + self.__class__.__name__ + " and is now being computed. This will only work when density is defined for the entire planet.  Use at your own risk. ")
+  "Gravity is not given in " + self.__class__.__name__ + " and is now being computed. This will only work when density is defined for the entire planet.  Use at your own risk. ")
 BURNMAN/burnman/seismic.py: UserWarning: Pressure is not given in AK135 and is now being computed. This will only work when density is defined for the entire planet. Use at your own risk. 
-  warnings.warn("Pressure is not given in " + self.__class__.__name__ + " and is now being computed. This will only work when density is defined for the entire planet. Use at your own risk. ")
+  "Pressure is not given in " + self.__class__.__name__ + " and is now being computed. This will only work when density is defined for the entire planet. Use at your own risk. ")
 BURNMAN/burnman/seismic.py: UserWarning: Gravity is not given in AK135 and is now being computed. This will only work when density is defined for the entire planet.  Use at your own risk. 
-  warnings.warn("Gravity is not given in " + self.__class__.__name__ + " and is now being computed. This will only work when density is defined for the entire planet.  Use at your own risk. ")
+  "Gravity is not given in " + self.__class__.__name__ + " and is now being computed. This will only work when density is defined for the entire planet.  Use at your own risk. ")
 BURNMAN/burnman/seismic.py: UserWarning: Pressure is not given in IASP91 and is now being computed. This will only work when density is defined for the entire planet. Use at your own risk. 
-  warnings.warn("Pressure is not given in " + self.__class__.__name__ + " and is now being computed. This will only work when density is defined for the entire planet. Use at your own risk. ")
+  "Pressure is not given in " + self.__class__.__name__ + " and is now being computed. This will only work when density is defined for the entire planet. Use at your own risk. ")
 BURNMAN/burnman/seismic.py: UserWarning: Gravity is not given in IASP91 and is now being computed. This will only work when density is defined for the entire planet.  Use at your own risk. 
-  warnings.warn("Gravity is not given in " + self.__class__.__name__ + " and is now being computed. This will only work when density is defined for the entire planet.  Use at your own risk. ")
+  "Gravity is not given in " + self.__class__.__name__ + " and is now being computed. This will only work when density is defined for the entire planet.  Use at your own risk. ")
 BURNMAN/burnman/seismic.py: UserWarning: Gravity is not given in PREM and is now being computed. This will only work when density is defined for the entire planet.  Use at your own risk. 
-  warnings.warn("Gravity is not given in " + self.__class__.__name__ + " and is now being computed. This will only work when density is defined for the entire planet.  Use at your own risk. ")
+  "Gravity is not given in " + self.__class__.__name__ + " and is now being computed. This will only work when density is defined for the entire planet.  Use at your own risk. ")

--- a/tests/test_planet.py
+++ b/tests/test_planet.py
@@ -21,52 +21,50 @@ class test_planet(BurnManTest):
 
     def test_planet_1(self):
 
-        core = Layer("core", radius_planet= 6371.e3, min_depth=2890.e3, max_depth =6371.e3, n_slices= 10)
+        core = Layer("core", np.linspace(0.e3,3480.e3,10))
         core.set_material(burnman.minerals.other.Liquid_Fe_Anderson())
-        core.set_temperature_mode('user_defined', temperatures= 300.*np.ones_like(core.depths))
+        core.set_temperature_mode('user-defined', temperatures= 300.*np.ones_like(core.radii))
         
-        mantle = Layer("mantle", radius_planet= 6371.e3, min_depth=0e3, max_depth =2890.e3,  n_slices= 10)
+        mantle = Layer("mantle", np.linspace(3480.e3, 6371.e3, 10))
         mantle.set_material(burnman.minerals.SLB_2011.mg_bridgmanite())
         mantle.set_temperature_mode('adiabat', temperature_top = 1200)
         myplanet = Planet('earth_like',[core, mantle])
-        myplanet.set_state()
+        myplanet.make()
         
         assert(myplanet.get_layer("core") == core)
         assert(myplanet.get_layer_by_radius(2000.e3) == core)
         assert(myplanet.get_layer_by_radius(4000.e3) == mantle)
         assert(myplanet.get_layer_by_radius(5000.e3) == mantle)
-
-        self.assertFloatEqual(myplanet.pressure[-1], 445428905300.0, tol=1.e-4)
+        
+        self.assertFloatEqual(myplanet.pressure[0], 445219931774.84, tol=1.e-4)
 
 
     def test_sort_layers(self):
-        core = Layer("core", radius_planet= 6371.e3, min_depth=2890.e3, max_depth =6371.e3, n_slices= 10)
+        core = Layer("core", np.linspace(0.e3,3480.e3,10))
         core.set_material(burnman.minerals.other.Liquid_Fe_Anderson())
-        core.set_temperature_mode('user_defined', temperatures= 300.*np.ones_like(core.depths))
+        core.set_temperature_mode('user-defined', temperatures= 300.*np.ones_like(core.radii))
         
-        mantle = Layer("mantle", radius_planet= 6371.e3, min_depth=0e3, max_depth =2890.e3,  n_slices= 10)
+        mantle = Layer("mantle", np.linspace(3480.e3, 6371.e3, 10))
         mantle.set_material(burnman.minerals.SLB_2011.mg_bridgmanite())
         mantle.set_temperature_mode('adiabat', temperature_top = 1200)
         myplanet = Planet('earth_like',[core, mantle])
-        assert(myplanet.layers == [mantle,core])
+        assert(myplanet.layers == [core, mantle])
 
     def test_temperature(self):
-        core = Layer("core", radius_planet= 6371.e3, min_depth=2890.e3, max_depth =6371.e3, n_slices= 10)
+        core = Layer("core", np.linspace(0.e3,3480.e3,10))
         core.set_material(burnman.minerals.other.Liquid_Fe_Anderson())
-        core.set_temperature_mode('user-defined', temperatures= burnman.geotherm.brown_shankland(core.depths))
+        core.set_temperature_mode('user-defined', temperatures= np.zeros_like(core.radii))
         
-        mantle = Layer("mantle", radius_planet= 6371.e3, min_depth=0e3, max_depth =2890.e3,  n_slices= 10)
+        mantle = Layer("mantle",  np.linspace(3480.e3, 6371.e3, 10))
         mantle.set_material(burnman.minerals.SLB_2011.mg_bridgmanite())
         mantle.set_temperature_mode('adiabat', temperature_top = 1200)
         myplanet = Planet('earth_like',[core, mantle])
-        myplanet.set_state()
+        myplanet.make()
         
-        ref = [ 1200.,          1304.56273992,  1397.12842763,  1480.88446903,  1557.96838056,
-           1629.98958458,  1698.27053255,  1763.96944242,  1828.14624527,  1891.79862543,
-           2452.25581395,  2694.29333333,  2902.27777778,  3073.52666667,  3207.49444444,
-           3305.10666667,  3369.93333333,  3433.17333333,  3470.79333333,  3484.        ]
-        print(myplanet.temperature)
-        print(ref)
+        ref = [ 0.,             0.,             0.,             0.,             0. ,            0.,
+                0.,             0.,             0.,             0. ,         1891.81949144,
+               1828.16862831,  1763.99394829,  1698.29707386 , 1630.01741059,  1557.99610591,
+               1480.9100882,   1397.14929092,  1304.57543674,  1200.        ]
         self.assertArraysAlmostEqual(myplanet.temperature, ref)
 
 

--- a/tests/test_planet.py
+++ b/tests/test_planet.py
@@ -60,12 +60,8 @@ class test_planet(BurnManTest):
         mantle.set_temperature_mode('adiabat', temperature_top = 1200)
         myplanet = Planet('earth_like',[core, mantle])
         myplanet.make()
-        
-        ref = [ 0.,             0.,             0.,             0.,             0. ,            0.,
-                0.,             0.,             0.,             0. ,         1891.81949144,
-               1828.16862831,  1763.99394829,  1698.29707386 , 1630.01741059,  1557.99610591,
-               1480.9100882,   1397.14929092,  1304.57543674,  1200.        ]
-        self.assertArraysAlmostEqual(myplanet.temperature, ref)
+
+        self.assertArraysAlmostEqual(mantle.S, [mantle.S[-1] for S in mantle.S])
 
 
 if __name__ == '__main__':

--- a/tests/test_planet.py
+++ b/tests/test_planet.py
@@ -53,7 +53,7 @@ class test_planet(BurnManTest):
     def test_temperature(self):
         core = Layer("core", radius_planet= 6371.e3, min_depth=2890.e3, max_depth =6371.e3, n_slices= 10)
         core.set_material(burnman.minerals.other.Liquid_Fe_Anderson())
-        core.set_temperature_mode('user_defined', temperatures= burnman.geotherm.brown_shankland(core.depths))
+        core.set_temperature_mode('user-defined', temperatures= burnman.geotherm.brown_shankland(core.depths))
         
         mantle = Layer("mantle", radius_planet= 6371.e3, min_depth=0e3, max_depth =2890.e3,  n_slices= 10)
         mantle.set_material(burnman.minerals.SLB_2011.mg_bridgmanite())
@@ -65,7 +65,8 @@ class test_planet(BurnManTest):
            1629.98958458,  1698.27053255,  1763.96944242,  1828.14624527,  1891.79862543,
            2452.25581395,  2694.29333333,  2902.27777778,  3073.52666667,  3207.49444444,
            3305.10666667,  3369.93333333,  3433.17333333,  3470.79333333,  3484.        ]
-
+        print(myplanet.temperature)
+        print(ref)
         self.assertArraysAlmostEqual(myplanet.temperature, ref)
 
 

--- a/tests/test_planet.py
+++ b/tests/test_planet.py
@@ -22,11 +22,11 @@ class test_planet(BurnManTest):
     def test_planet_1(self):
 
         core = Layer("core", radius_planet= 6371.e3, min_depth=2890.e3, max_depth =6371.e3, n_slices= 10)
-        core.set_composition(burnman.minerals.other.Liquid_Fe_Anderson())
+        core.set_material(burnman.minerals.other.Liquid_Fe_Anderson())
         core.set_temperature_mode('user_defined', temperatures= 300.*np.ones_like(core.depths))
         
         mantle = Layer("mantle", radius_planet= 6371.e3, min_depth=0e3, max_depth =2890.e3,  n_slices= 10)
-        mantle.set_composition(burnman.minerals.SLB_2011.mg_bridgmanite())
+        mantle.set_material(burnman.minerals.SLB_2011.mg_bridgmanite())
         mantle.set_temperature_mode('adiabat', temperature_top = 1200)
         myplanet = Planet('earth_like',[core, mantle])
         myplanet.set_state()
@@ -41,22 +41,22 @@ class test_planet(BurnManTest):
 
     def test_sort_layers(self):
         core = Layer("core", radius_planet= 6371.e3, min_depth=2890.e3, max_depth =6371.e3, n_slices= 10)
-        core.set_composition(burnman.minerals.other.Liquid_Fe_Anderson())
+        core.set_material(burnman.minerals.other.Liquid_Fe_Anderson())
         core.set_temperature_mode('user_defined', temperatures= 300.*np.ones_like(core.depths))
         
         mantle = Layer("mantle", radius_planet= 6371.e3, min_depth=0e3, max_depth =2890.e3,  n_slices= 10)
-        mantle.set_composition(burnman.minerals.SLB_2011.mg_bridgmanite())
+        mantle.set_material(burnman.minerals.SLB_2011.mg_bridgmanite())
         mantle.set_temperature_mode('adiabat', temperature_top = 1200)
         myplanet = Planet('earth_like',[core, mantle])
         assert(myplanet.layers == [mantle,core])
 
     def test_temperature(self):
         core = Layer("core", radius_planet= 6371.e3, min_depth=2890.e3, max_depth =6371.e3, n_slices= 10)
-        core.set_composition(burnman.minerals.other.Liquid_Fe_Anderson())
+        core.set_material(burnman.minerals.other.Liquid_Fe_Anderson())
         core.set_temperature_mode('user_defined', temperatures= burnman.geotherm.brown_shankland(core.depths))
         
         mantle = Layer("mantle", radius_planet= 6371.e3, min_depth=0e3, max_depth =2890.e3,  n_slices= 10)
-        mantle.set_composition(burnman.minerals.SLB_2011.mg_bridgmanite())
+        mantle.set_material(burnman.minerals.SLB_2011.mg_bridgmanite())
         mantle.set_temperature_mode('adiabat', temperature_top = 1200)
         myplanet = Planet('earth_like',[core, mantle])
         myplanet.set_state()


### PR DESCRIPTION
In this pull request I've split up Layer and Planet, for the following reasons:
- We often use a layer kind of setup to evaluate properties in many of our examples. Now these constantly reset the P and T of a Material() and recompute. In Layer, these properties can be cached across the Layer. 
- More importantly, the properties in the layer can be computed with self-consistent pressures. This can be used for a single layer if the pressure at the top and gravity at the bottom are set (the planet as a whole is not self-consistent, but there are applications for this). 
- Geophysical parameters that depend on gradients (e.g. Bullen parameter and brunt-vasala frequency) can be evaluated for layer. 
- Unlike the Layer originally in Planet, adiabats can be used. 
- Both Layer and Planet can evaluate all the properties that are also in a Material (before this was very limited to density, gravity, pressure, and temperature). 

Things that can be implemented going forward:
- I've implemented a modified_adiabat setup for the Layer. This means the temperature of the adiabat can be perturbed, e.g. to add a boundary layer. We could implement functions in geotherm to approximate boundary layers. 
- I can rewrite the seismic output routines for Mineos and AxiSEM to ask for a Layer or Planet, and produce appropriate output file. Similarly I can see Layer being used to produce the input for Aspect. 

You might find that the examples run slower, I think this is mostly due to adiabats being included. 
Let me know your thoughts, and things that can be done better. 
