### PR TITLE
Fix solution potentials

### DIFF
--- a/burnman/solidsolution.py
+++ b/burnman/solidsolution.py
@@ -215,7 +215,7 @@ class SolidSolution(Mineral):
         Returns internal energy of the mineral [J]
         Aliased with self.energy
         """
-        return self.molar_helmholtz - self.pressure * self.molar_volume
+        return self.molar_helmholtz + self.temperature * self.molar_entropy
 
     @material_property
     def excess_partial_gibbs(self):
@@ -255,7 +255,7 @@ class SolidSolution(Mineral):
         Returns Helmholtz free energy of the solid solution [J]
         Aliased with self.helmholtz
         """
-        return self.molar_gibbs + self.temperature * self.molar_entropy
+        return self.molar_gibbs - self.pressure * self.molar_volume
 
     @material_property
     def molar_mass(self):

--- a/tests/test_eos_consistency.py
+++ b/tests/test_eos_consistency.py
@@ -27,6 +27,12 @@ class EosConsistency(BurnManTest):
         self.assertEqual(burnman.tools.check_eos_consistency(burnman.minerals.SLB_2011.periclase(), P, T),
                          True)
 
+    def test_solution(self):
+        P = 10.e9
+        T = 3000.
+        m = burnman.minerals.SLB_2011.garnet(molar_fractions = [0.2, 0.2, 0.2, 0.2, 0.2])
+        self.assertEqual(burnman.tools.check_eos_consistency(m, P, T),
+                         True)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Well, this is embarrassing. It seems no-one ever tried to calculate Helmholtz or internal energy for a solid solution, and both were implemented incorrectly. This PR fixes the errors and adds the appropriate test.

minerals and materials have always been implemented correctly. 