### PR TITLE
Enabled combined minerals to be used in solid solutions

### DIFF
--- a/burnman/combinedmineral.py
+++ b/burnman/combinedmineral.py
@@ -35,14 +35,15 @@ class CombinedMineral(Mineral):
     This class is available as :class:`burnman.CombinedMineral`.
     """
 
-    def __init__(self, mineral_list, molar_amounts, free_energy_adjustment=[]):
+    def __init__(self, mineral_list, molar_amounts, free_energy_adjustment=[], name='User-created endmember'):
         self.mixture = SolidSolution(solution_type='mechanical',
                                      endmembers=[[m, ''] for m in mineral_list],
                                      molar_fractions = molar_amounts)
 
         self.params = {
-            'name': 'User-created endmember',
+            'name': name,
             'formula': self.mixture.formula,
+            'equation_of_state': 'combined',
             'molar_mass': self.mixture.molar_mass,
             'n': sum(self.mixture.formula.values())
         }
@@ -53,22 +54,12 @@ class CombinedMineral(Mineral):
                                                    'delta_S': free_energy_adjustment[1],
                                                    'delta_V': free_energy_adjustment[2]}]]
 
-        Mineral.__init__(self)
         
-        class MadeMemberMethod(object):
-
-            """Dummy class because SolidSolution needs a method to call
-            Mineral.set_state(), but should never have a method that
-            is used for minerals. Note that set_method() below will
-            not change self.method"""
-            pass
-        self.method = MadeMemberMethod()
-
+        Mineral.__init__(self)
 
     def set_state(self, pressure, temperature):
         self.mixture.set_state(pressure, temperature)
         Mineral.set_state(self, pressure, temperature)
-
 
     @material_property
     def molar_gibbs(self):

--- a/burnman/combinedmineral.py
+++ b/burnman/combinedmineral.py
@@ -27,7 +27,8 @@ class CombinedMineral(Mineral):
     number of moles of each mineral, and (optionally) a 
     third list containing three floats describing a 
     free energy adjustment which is linear in pressure and temperature 
-    (i.e. a constant energy, entropy and volume adjustment).
+    (i.e. a constant energy [J/mol], entropy [J/K/mol] 
+    and volume adjustment [J/Pa/mol or m^3/mol]).
 
     For example, a crude approximation to a bridgmanite model might be
     bdg = CombinedMineral([per, stv], [1.0, 1.0], [-15.e3, 0., 0.])

--- a/burnman/eos/helper.py
+++ b/burnman/eos/helper.py
@@ -20,7 +20,16 @@ from . import reciprocal_kprime
 from . import aa
 from .equation_of_state import EquationOfState
 
-
+class CombinedMineralMethod(object):
+    """Dummy class because CombinedMineral objects are derived 
+    from a mechanical SolidSolution. 
+    SolidSolution needs a method to call Mineral.set_state(), 
+    but a CombinedMineral should never have a method that
+    is used for solid solutions."""
+    def validate_parameters(self, params):
+        pass
+    pass
+            
 def create(method):
     """
     Creates an instance of an EquationOfState from a string,
@@ -59,6 +68,8 @@ def create(method):
             return dks_liquid.DKS_L()
         elif method == "dks_s":
             return dks_solid.DKS_S()
+        elif method == "combined":
+            return CombinedMineralMethod()
         else:
             raise Exception("unsupported material method " + method)
     elif isinstance(method, EquationOfState):

--- a/tests/test_solidsolution.py
+++ b/tests/test_solidsolution.py
@@ -9,6 +9,7 @@ import numpy as np
 
 import burnman
 from burnman.mineral import Mineral
+from burnman.combinedmineral import CombinedMineral
 from burnman.processchemistry import dictionarize_formula, formula_mass
 from util import BurnManTest
 
@@ -55,9 +56,10 @@ class fayalite (Mineral):
             'molar_mass': formula_mass(formula)}
         Mineral.__init__(self)
 
+
+made_forsterite = CombinedMineral([forsterite(), forsterite()], [0.5, 0.5])
+
 # One-mineral solid solution
-
-
 class forsterite_ss(burnman.SolidSolution):
 
     def __init__(self, molar_fractions=None):
@@ -69,8 +71,6 @@ class forsterite_ss(burnman.SolidSolution):
         burnman.SolidSolution.__init__(self, molar_fractions)
 
 # Two-mineral solid solution
-
-
 class forsterite_forsterite_ss(burnman.SolidSolution):
 
     def __init__(self, molar_fractions=None):
@@ -83,8 +83,6 @@ class forsterite_forsterite_ss(burnman.SolidSolution):
         burnman.SolidSolution.__init__(self, molar_fractions)
 
 # Ideal solid solution
-
-
 class olivine_ideal_ss(burnman.SolidSolution):
 
     def __init__(self, molar_fractions=None):
@@ -96,8 +94,6 @@ class olivine_ideal_ss(burnman.SolidSolution):
         burnman.SolidSolution.__init__(self, molar_fractions)
 
 # Olivine solid solution
-
-
 class olivine_ss(burnman.SolidSolution):
 
     def __init__(self, molar_fractions=None):
@@ -109,9 +105,20 @@ class olivine_ss(burnman.SolidSolution):
 
         burnman.SolidSolution.__init__(self, molar_fractions)
 
+        
+# Olivine solid solution with combined endmember
+class olivine_ss2(burnman.SolidSolution):
+
+    def __init__(self, molar_fractions=None):
+        self.name = 'Olivine'
+        self.solution_type = 'symmetric'
+        self.endmembers = [[
+            made_forsterite, '[Mg]2SiO4'], [fayalite(), '[Fe]2SiO4']]
+        self.energy_interaction = [[8.4e3]]
+
+        burnman.SolidSolution.__init__(self, molar_fractions)
+
 # Orthopyroxene solid solution
-
-
 class orthopyroxene(burnman.SolidSolution):
 
     def __init__(self, molar_fractions=None):
@@ -125,8 +132,6 @@ class orthopyroxene(burnman.SolidSolution):
         burnman.SolidSolution.__init__(self, molar_fractions)
 
 # Three-endmember, two site solid solution
-
-
 class two_site_ss(burnman.SolidSolution):
 
     def __init__(self, molar_fractions=None):
@@ -139,8 +144,6 @@ class two_site_ss(burnman.SolidSolution):
         burnman.SolidSolution.__init__(self, molar_fractions)
 
 # Three-endmember, two site solid solution
-
-
 class two_site_ss_subregular(burnman.SolidSolution):
 
     def __init__(self, molar_fractions=None):
@@ -189,6 +192,17 @@ class test_solidsolution(BurnManTest):
         ol_ss.set_state(P, T)
         return fo, ol_ss
 
+    def setup_ol_ss2(self):
+        P = 1.e5
+        T = 1000.
+        fo = forsterite()
+        fo.set_state(P, T)
+
+        ol_ss = olivine_ss2()
+        ol_ss.set_composition([1.0, 0.0])
+        ol_ss.set_state(P, T)
+        return fo, ol_ss
+
     def test_1_gibbs(self):
         fo, fo_ss = self.setup_1min_ss()
         with warnings.catch_warnings(record=True) as w:
@@ -213,6 +227,14 @@ class test_solidsolution(BurnManTest):
 
     def test_ol_gibbs(self):
         fo, fo_ss = self.setup_ol_ss()
+        endmember_properties = [
+            fo.gibbs, fo.H, fo.S, fo.V, fo.C_p, fo.C_v, fo.alpha, fo.K_T, fo.K_S, fo.gr]
+        ss_properties = [fo_ss.gibbs, fo_ss.H, fo_ss.S, fo_ss.V,
+                         fo_ss.C_p, fo_ss.C_v, fo_ss.alpha, fo_ss.K_T, fo_ss.K_S, fo_ss.gr]
+        self.assertArraysAlmostEqual(endmember_properties, ss_properties)
+        
+    def test_ol_gibbs2(self):
+        fo, fo_ss = self.setup_ol_ss2()
         endmember_properties = [
             fo.gibbs, fo.H, fo.S, fo.V, fo.C_p, fo.C_v, fo.alpha, fo.K_T, fo.K_S, fo.gr]
         ss_properties = [fo_ss.gibbs, fo_ss.H, fo_ss.S, fo_ss.V,


### PR DESCRIPTION
The CombinedMineral class was derived in such a way that when included in a solid solution, it would lose its method. This PR makes the class more like the other minerals, with a method set using the equation_of_state param and burnman/eos/helper.py.