### PR TITLE
standardised use of molar_ across all properties

### DIFF
--- a/burnman/combinedmineral.py
+++ b/burnman/combinedmineral.py
@@ -119,12 +119,12 @@ class CombinedMineral(Mineral):
                 + self._property_modifiers['d2GdPdT']) / self.molar_volume
     
     @material_property
-    def heat_capacity_p(self):
+    def molar_heat_capacity_p(self):
         """
         Returns heat capacity at constant pressure of the solid solution [J/K/mol]
         Aliased with self.C_p
         """
-        return self.mixture.heat_capacity_p - self.temperature * self._property_modifiers['d2GdT2']
+        return self.mixture.molar_heat_capacity_p - self.temperature * self._property_modifiers['d2GdT2']
 
 
     """
@@ -143,7 +143,7 @@ class CombinedMineral(Mineral):
     @material_property
     def formula(self):
         """
-        Returns chemical formula of the solid solution
+        Returns molar chemical formula of the solid solution
         """
         return self.mixture.formula
 
@@ -156,9 +156,9 @@ class CombinedMineral(Mineral):
         return self.molar_mass / self.molar_volume
 
     @material_property
-    def internal_energy(self):
+    def molar_internal_energy(self):
         """
-        Returns internal energy of the mineral [J]
+        Returns molar internal energy of the mineral [J/mol]
         Aliased with self.energy
         """
         return self.molar_gibbs - self.pressure * self.molar_volume + self.temperature * self.molar_entropy
@@ -166,7 +166,7 @@ class CombinedMineral(Mineral):
     @material_property
     def molar_helmholtz(self):
         """
-        Returns Helmholtz free energy of the solid solution [J]
+        Returns molar Helmholtz free energy of the solid solution [J/mol]
         Aliased with self.helmholtz
         """
         return self.molar_gibbs - self.pressure * self.molar_volume
@@ -175,7 +175,7 @@ class CombinedMineral(Mineral):
     @material_property
     def molar_enthalpy(self):
         """
-        Returns enthalpy of the solid solution [J]
+        Returns molar enthalpy of the solid solution [J/mol]
         Aliased with self.H
         """
         return self.molar_gibbs + self.temperature * self.molar_entropy
@@ -190,7 +190,7 @@ class CombinedMineral(Mineral):
         if self.temperature < 1.e-10:
             return self.isothermal_bulk_modulus
         else:
-            return self.isothermal_bulk_modulus * self.heat_capacity_p / self.heat_capacity_v
+            return self.isothermal_bulk_modulus * self.molar_heat_capacity_p / self.molar_heat_capacity_v
         
     @material_property
     def isothermal_compressibility(self):
@@ -243,15 +243,15 @@ class CombinedMineral(Mineral):
             return 0.
         else:
             return self.thermal_expansivity * self.isothermal_bulk_modulus \
-                * self.molar_volume / self.heat_capacity_v
+                * self.molar_volume / self.molar_heat_capacity_v
 
     @material_property
-    def heat_capacity_v(self):
+    def molar_heat_capacity_v(self):
         """
-        Returns heat capacity at constant volume of the solid solution [J/K/mol]
+        Returns molar heat capacity at constant volume of the solid solution [J/K/mol]
         Aliased with self.C_v
         """
-        return self.heat_capacity_p - self.molar_volume * self.temperature \
+        return self.molar_heat_capacity_p - self.molar_volume * self.temperature \
             * self.thermal_expansivity * self.thermal_expansivity \
             * self.isothermal_bulk_modulus
 

--- a/burnman/composite.py
+++ b/burnman/composite.py
@@ -176,19 +176,19 @@ class Composite(Material):
         return "'" + self.__class__.__name__ + "'"
 
     @material_property
-    def internal_energy(self):
+    def molar_internal_energy(self):
         """
-        Returns internal energy of the mineral [J]
+        Returns molar internal energy of the mineral [J/mol]
         Aliased with self.energy
         """
-        U = sum(phase.internal_energy * molar_fraction for (
+        U = sum(phase.molar_internal_energy * molar_fraction for (
                 phase, molar_fraction) in zip(self.phases, self.molar_fractions))
         return U
 
     @material_property
     def molar_gibbs(self):
         """
-        Returns Gibbs free energy of the composite [J]
+        Returns molar Gibbs free energy of the composite [J/mol]
         Aliased with self.gibbs
         """
         G = sum(phase.molar_gibbs * molar_fraction for (phase, molar_fraction)
@@ -198,7 +198,7 @@ class Composite(Material):
     @material_property
     def molar_helmholtz(self):
         """
-        Returns Helmholtz free energy of the mineral [J]
+        Returns molar Helmholtz free energy of the mineral [J/mol]
         Aliased with self.helmholtz
         """
         F = sum(phase.molar_helmholtz * molar_fraction for (
@@ -342,7 +342,7 @@ class Composite(Material):
         Returns grueneisen parameter of the composite [unitless]
         Aliased with self.gr
         """
-        return self.thermal_expansivity * self.isothermal_bulk_modulus * self.molar_volume / self.heat_capacity_v
+        return self.thermal_expansivity * self.isothermal_bulk_modulus * self.molar_volume / self.molar_heat_capacity_v
 
     @material_property
     def thermal_expansivity(self):
@@ -356,21 +356,21 @@ class Composite(Material):
         return self.averaging_scheme.average_thermal_expansivity(volumes, alphas)
 
     @material_property
-    def heat_capacity_v(self):
+    def molar_heat_capacity_v(self):
         """
-        Returns heat capacity at constant volume of the composite [J/K/mol]
+        Returns molar_heat capacity at constant volume of the composite [J/K/mol]
         Aliased with self.C_v
         """
-        c_v = np.array([phase.heat_capacity_v for phase in self.phases])
+        c_v = np.array([phase.molar_heat_capacity_v for phase in self.phases])
         return self.averaging_scheme.average_heat_capacity_v(self.molar_fractions, c_v)
 
     @material_property
-    def heat_capacity_p(self):
+    def molar_heat_capacity_p(self):
         """
-        Returns heat capacity at constant pressure of the composite [J/K/mol]
+        Returns molar heat capacity at constant pressure of the composite [J/K/mol]
         Aliased with self.C_p
         """
-        c_p = np.array([phase.heat_capacity_p for phase in self.phases])
+        c_p = np.array([phase.molar_heat_capacity_p for phase in self.phases])
         return self.averaging_scheme.average_heat_capacity_p(self.molar_fractions, c_p)
 
     def _mass_to_molar_fractions(self, phases, mass_fractions):

--- a/burnman/eos/aa.py
+++ b/burnman/eos/aa.py
@@ -227,8 +227,8 @@ class AA(eos.EquationOfState):
         T0 = brentq(delta_S, temperature*0.97, temperature*1.03, args=(S, volume - 0.5*dV))
         T1 = brentq(delta_S, temperature*0.97, temperature*1.03, args=(S, volume + 0.5*dV))
 
-        E0 = self.internal_energy(0., T0, volume - 0.5*dV, params)
-        E1 = self.internal_energy(0., T1, volume + 0.5*dV, params)
+        E0 = self.molar_internal_energy(0., T0, volume - 0.5*dV, params)
+        E1 = self.molar_internal_energy(0., T1, volume + 0.5*dV, params)
 
         P = -(E1 - E0)/dV # |S
         
@@ -244,12 +244,12 @@ class AA(eos.EquationOfState):
         gr = (params['grueneisen_0'] +
               params['grueneisen_prime'] *
               (np.power(params['V_0']/volume, params['grueneisen_n']) *
-               (self.internal_energy(pressure, temperature, volume, params) -
+               (self.molar_internal_energy(pressure, temperature, volume, params) -
                 params['E_0'])))
         '''
         dT = 1.
-        dE = (self.internal_energy(0., temperature + 0.5*dT, volume, params) -
-              self.internal_energy(0., temperature - 0.5*dT, volume, params))
+        dE = (self.molar_internal_energy(0., temperature + 0.5*dT, volume, params) -
+              self.molar_internal_energy(0., temperature - 0.5*dT, volume, params))
         dP = (self.pressure(temperature + 0.5*dT, volume, params) -
               self.pressure(temperature - 0.5*dT, volume, params))
         gr = volume*dP/dE
@@ -285,7 +285,7 @@ class AA(eos.EquationOfState):
         """
         return 0.
 
-    def heat_capacity_v(self, pressure, temperature, volume, params):
+    def molar_heat_capacity_v(self, pressure, temperature, volume, params):
         """
         Returns heat capacity at constant volume. :math:`[J/K/mol]` 
         """
@@ -300,14 +300,14 @@ class AA(eos.EquationOfState):
         return C_kin + C_e + C_pot
 
     
-    def heat_capacity_p(self, pressure, temperature, volume, params):
+    def molar_heat_capacity_p(self, pressure, temperature, volume, params):
         """
         Returns heat capacity at constant pressure. :math:`[J/K/mol]` 
         """
         
         alpha = self.thermal_expansivity(pressure, temperature, volume, params)
         gr = self.grueneisen_parameter(pressure, temperature, volume, params)
-        C_v = self.heat_capacity_v(pressure, temperature, volume, params)
+        C_v = self.molar_heat_capacity_v(pressure, temperature, volume, params)
         C_p = C_v*(1. + gr * alpha * temperature)
         
         return C_p
@@ -333,7 +333,7 @@ class AA(eos.EquationOfState):
         return self.helmholtz_free_energy( pressure, temperature, volume, params) + \
             pressure * self.volume( pressure, temperature, params)
 
-    def internal_energy( self, pressure, temperature, volume, params):
+    def molar_internal_energy( self, pressure, temperature, volume, params):
         """
         Returns the internal energy at the pressure and temperature of the mineral [J/mol]
         """
@@ -369,7 +369,7 @@ class AA(eos.EquationOfState):
         E + PV
         """
         
-        return self.internal_energy(pressure, temperature, volume, params) + \
+        return self.molar_internal_energy(pressure, temperature, volume, params) + \
             pressure * self.volume( pressure, temperature, params)
 
     def helmholtz_free_energy( self, pressure, temperature, volume, params):
@@ -377,7 +377,7 @@ class AA(eos.EquationOfState):
         Returns the Helmholtz free energy at the pressure and temperature of the mineral [J/mol]
         E - TS
         """
-        return self.internal_energy(pressure, temperature, volume, params) - temperature*self.entropy(pressure, temperature, volume, params)
+        return self.molar_internal_energy(pressure, temperature, volume, params) - temperature*self.entropy(pressure, temperature, volume, params)
 
 
     def validate_parameters(self, params):

--- a/burnman/eos/birch_murnaghan.py
+++ b/burnman/eos/birch_murnaghan.py
@@ -124,7 +124,7 @@ class BirchMurnaghanBase(eos.EquationOfState):
         """
         return 0.
     
-    def internal_energy(self, pressure, temperature, volume, params):
+    def molar_internal_energy(self, pressure, temperature, volume, params):
         """
         Returns the internal energy :math:`\mathcal{E}` of the mineral. :math:`[J/mol]`
         """
@@ -148,15 +148,15 @@ class BirchMurnaghanBase(eos.EquationOfState):
         """
         # G = int VdP = [PV] - int PdV = E + PV
                   
-        return self.internal_energy(pressure, temperature, volume, params) + volume*pressure
+        return self.molar_internal_energy(pressure, temperature, volume, params) + volume*pressure
         
-    def heat_capacity_v(self, pressure, temperature, volume, params):
+    def molar_heat_capacity_v(self, pressure, temperature, volume, params):
         """
         Since this equation of state does not contain temperature effects, simply return a very large number. :math:`[J/K/mol]`
         """
         return 1.e99
 
-    def heat_capacity_p(self, pressure, temperature, volume, params):
+    def molar_heat_capacity_p(self, pressure, temperature, volume, params):
         """
         Since this equation of state does not contain temperature effects, simply return a very large number. :math:`[J/K/mol]`
         """

--- a/burnman/eos/birch_murnaghan_4th.py
+++ b/burnman/eos/birch_murnaghan_4th.py
@@ -99,7 +99,7 @@ class BM4(eos.EquationOfState):
         """
         return 0.
     
-    def internal_energy(self, pressure, temperature, volume, params):
+    def molar_internal_energy(self, pressure, temperature, volume, params):
         """
         Returns the internal energy :math:`\mathcal{E}` of the mineral. :math:`[J/mol]`
         """
@@ -128,15 +128,15 @@ class BM4(eos.EquationOfState):
         """
         # G = int VdP = [PV] - int PdV = E + PV
                   
-        return self.internal_energy(pressure, temperature, volume, params) + volume*pressure
+        return self.molar_internal_energy(pressure, temperature, volume, params) + volume*pressure
     
-    def heat_capacity_v(self, pressure, temperature, volume, params):
+    def molar_heat_capacity_v(self, pressure, temperature, volume, params):
         """
         Since this equation of state does not contain temperature effects, simply return a very large number. :math:`[J/K/mol]`
         """
         return 1.e99
 
-    def heat_capacity_p(self, pressure, temperature, volume, params):
+    def molar_heat_capacity_p(self, pressure, temperature, volume, params):
         """
         Since this equation of state does not contain temperature effects, simply return a very large number. :math:`[J/K/mol]`
         """

--- a/burnman/eos/cork.py
+++ b/burnman/eos/cork.py
@@ -72,7 +72,7 @@ class CORK(eos.EquationOfState):
         return 0.
 
     # Cv, heat capacity at constant volume
-    def heat_capacity_v(self, pressure, temperature, volume, params):
+    def molar_heat_capacity_v(self, pressure, temperature, volume, params):
         """
         Returns heat capacity at constant volume at the pressure, temperature, and volume [J/K/mol].
         """
@@ -86,7 +86,7 @@ class CORK(eos.EquationOfState):
         return 0.
 
     # Heat capacity at ambient pressure
-    def heat_capacity_p0(self, temperature, params):
+    def molar_heat_capacity_p0(self, temperature, params):
         """
         Returns heat capacity at ambient pressure as a function of temperature [J/K/mol]
         Cp = a + bT + cT^-2 + dT^-0.5 in Holland and Powell, 2011
@@ -96,7 +96,7 @@ class CORK(eos.EquationOfState):
                 'Cp'][3] * np.power(temperature, -0.5)
         return Cp
 
-    def heat_capacity_p(self, pressure, temperature, volume, params):
+    def molar_heat_capacity_p(self, pressure, temperature, volume, params):
         """
         Returns heat capacity at constant pressure at the pressure, temperature, and volume [J/K/mol]
         """
@@ -179,7 +179,7 @@ class CORK(eos.EquationOfState):
         if params['cork_P'] < 1.e4 or params['cork_P'] > 1.e8:
             warnings.warn('Unusual value for cork_P', stacklevel=2)
 
-        if self.heat_capacity_p0(params['T_0'], params) < 0.:
+        if self.molar_heat_capacity_p0(params['T_0'], params) < 0.:
             warnings.warn('Negative heat capacity at T_0', stacklevel=2)
-        if self.heat_capacity_p0(2000., params) < 0.:
+        if self.molar_heat_capacity_p0(2000., params) < 0.:
             warnings.warn('Negative heat capacity at 2000K', stacklevel=2)

--- a/burnman/eos/debye.py
+++ b/burnman/eos/debye.py
@@ -134,7 +134,7 @@ def thermal_energy(T, debye_T, n):
 
 
 @jit
-def heat_capacity_v(T, debye_T, n):
+def molar_heat_capacity_v(T, debye_T, n):
     """
     Heat capacity at constant volume.  In J/K/mol
     """

--- a/burnman/eos/dks_liquid.py
+++ b/burnman/eos/dks_liquid.py
@@ -480,7 +480,7 @@ class DKS_L(eos.EquationOfState):
         """
         gamma = (self._aK_T(temperature, volume, params)
                  * volume
-                 / self.heat_capacity_v(pressure, temperature, volume, params))
+                 / self.molar_heat_capacity_v(pressure, temperature, volume, params))
         return gamma
 
     def shear_modulus(self, pressure, temperature, volume, params):
@@ -490,7 +490,7 @@ class DKS_L(eos.EquationOfState):
         """
         return 0.
 
-    def heat_capacity_v(self, pressure, temperature, volume, params):
+    def molar_heat_capacity_v(self, pressure, temperature, volume, params):
         """
         Returns heat capacity at constant volume. :math:`[J/K/mol]` 
         """
@@ -500,11 +500,11 @@ class DKS_L(eos.EquationOfState):
                + self._C_v_mag(temperature, volume, params))
         return C_v
 
-    def heat_capacity_p(self, pressure, temperature, volume, params):
+    def molar_heat_capacity_p(self, pressure, temperature, volume, params):
         """
         Returns heat capacity at constant pressure. :math:`[J/K/mol]` 
         """
-        C_p = (self.heat_capacity_v(pressure,temperature, volume, params)
+        C_p = (self.molar_heat_capacity_v(pressure,temperature, volume, params)
                * ( 1. + temperature 
                    * self.thermal_expansivity(pressure, temperature, volume, params)
                    * self.grueneisen_parameter(pressure, temperature, volume, params) ))
@@ -554,7 +554,7 @@ class DKS_L(eos.EquationOfState):
              + self._F_mag(temperature, volume, params))
         return F
 
-    def internal_energy(self, pressure, temperature, volume, params):
+    def molar_internal_energy(self, pressure, temperature, volume, params):
         E = self.helmholtz_free_energy(pressure, temperature, volume, params) + \
             temperature*self.entropy(pressure, temperature, volume, params)
         return E

--- a/burnman/eos/dks_solid.py
+++ b/burnman/eos/dks_solid.py
@@ -184,19 +184,19 @@ class DKS_S(eos.EquationOfState):
         E_th_diff = params['Cv'] * (temperature - params['T_0'])
         return bm.shear_modulus_third_order(volume, params) - eta_s * (E_th_diff) / volume
 
-    def heat_capacity_v(self, pressure, temperature, volume, params):
+    def molar_heat_capacity_v(self, pressure, temperature, volume, params):
         """
         Returns heat capacity at constant volume. :math:`[J/K/mol]`
         """
         return params['Cv']
 
-    def heat_capacity_p(self, pressure, temperature, volume, params):
+    def molar_heat_capacity_p(self, pressure, temperature, volume, params):
         """
         Returns heat capacity at constant pressure. :math:`[J/K/mol]`
         """
         alpha = self.thermal_expansivity(pressure, temperature, volume, params)
         gr = self.grueneisen_parameter(pressure, temperature, volume, params)
-        C_v = self.heat_capacity_v(pressure, temperature, volume, params)
+        C_v = self.molar_heat_capacity_v(pressure, temperature, volume, params)
         C_p = C_v * (1. + gr * alpha * temperature)
         return C_p
 
@@ -204,7 +204,7 @@ class DKS_S(eos.EquationOfState):
         """
         Returns thermal expansivity. :math:`[1/K]`
         """
-        C_v = self.heat_capacity_v(pressure, temperature, volume, params)
+        C_v = self.molar_heat_capacity_v(pressure, temperature, volume, params)
         gr = self.grueneisen_parameter(pressure, temperature, volume, params)
         K = self.isothermal_bulk_modulus(pressure, temperature, volume, params)
         alpha = gr * C_v / K / volume
@@ -218,7 +218,7 @@ class DKS_S(eos.EquationOfState):
             pressure, temperature, volume, params) + pressure * volume
         return G
 
-    def internal_energy(self, pressure, temperature, volume, params):
+    def molar_internal_energy(self, pressure, temperature, volume, params):
         """
         Returns the internal energy at the pressure and temperature of the mineral [J/mol]
         """

--- a/burnman/eos/einstein.py
+++ b/burnman/eos/einstein.py
@@ -28,7 +28,7 @@ def thermal_energy(T, einstein_T, n):
     return E_th
 
 
-def heat_capacity_v(T, einstein_T, n):
+def molar_heat_capacity_v(T, einstein_T, n):
     """
     Heat capacity at constant volume.  In J/K/mol
     """

--- a/burnman/eos/equation_of_state.py
+++ b/burnman/eos/equation_of_state.py
@@ -164,7 +164,7 @@ class EquationOfState(object):
         """
         raise NotImplementedError("")
 
-    def heat_capacity_v(self, pressure, temperature, volume, params):
+    def molar_heat_capacity_v(self, pressure, temperature, volume, params):
         """
         Parameters
         ----------
@@ -185,7 +185,7 @@ class EquationOfState(object):
         """
         raise NotImplementedError("")
 
-    def heat_capacity_p(self, pressure, temperature, volume, params):
+    def molar_heat_capacity_p(self, pressure, temperature, volume, params):
         """
         Parameters
         ----------
@@ -292,7 +292,7 @@ class EquationOfState(object):
         """
         raise NotImplementedError("")
 
-    def internal_energy(self, pressure, temperature, volume, params):
+    def molar_internal_energy(self, pressure, temperature, volume, params):
         """
         Parameters
         ----------

--- a/burnman/eos/hp.py
+++ b/burnman/eos/hp.py
@@ -51,7 +51,7 @@ class HP_TMT(eos.EquationOfState):
             pressure, temperature, volume, params)
         K_T = self.isothermal_bulk_modulus(
             pressure, temperature, volume, params)
-        C_V = self.heat_capacity_v(pressure, temperature, volume, params)
+        C_V = self.molar_heat_capacity_v(pressure, temperature, volume, params)
         return alpha * K_T * volume / C_V
 
     def isothermal_bulk_modulus(self, pressure, temperature, volume, params):
@@ -72,11 +72,11 @@ class HP_TMT(eos.EquationOfState):
         return 0.
 
     # Cv, heat capacity at constant volume
-    def heat_capacity_v(self, pressure, temperature, volume, params):
+    def molar_heat_capacity_v(self, pressure, temperature, volume, params):
         """
         Returns heat capacity at constant volume at the pressure, temperature, and volume [J/K/mol].
         """
-        C_p = self.heat_capacity_p(pressure, temperature, volume, params)
+        C_p = self.molar_heat_capacity_p(pressure, temperature, volume, params)
         V = self.volume(pressure, temperature, params)
         alpha = self.thermal_expansivity(pressure, temperature, volume, params)
         K_T = self.isothermal_bulk_modulus(
@@ -92,15 +92,15 @@ class HP_TMT(eos.EquationOfState):
         Pth = self.__relative_thermal_pressure(temperature, params)
         psubpth = pressure - params['P_0'] - Pth
 
-        C_V0 = einstein.heat_capacity_v(
+        C_V0 = einstein.molar_heat_capacity_v(
             params['T_0'], params['T_einstein'], params['n'])
-        C_V = einstein.heat_capacity_v(
+        C_V = einstein.molar_heat_capacity_v(
             temperature, params['T_einstein'], params['n'])
         alpha = params['a_0'] * (C_V / C_V0) * 1. / (
             (1. + b * psubpth) * (a + (1. - a) * np.power((1 + b * psubpth), c)))
         return alpha
 
-    def heat_capacity_p0(self, temperature, params):
+    def molar_heat_capacity_p0(self, temperature, params):
         """
         Returns heat capacity at ambient pressure as a function of temperature [J/K/mol]
         Cp = a + bT + cT^-2 + dT^-0.5 in Holland and Powell, 2011
@@ -110,14 +110,14 @@ class HP_TMT(eos.EquationOfState):
                 'Cp'][3] * np.power(temperature, -0.5)
         return Cp
 
-    def heat_capacity_p_einstein(self, pressure, temperature, volume, params):
+    def molar_heat_capacity_p_einstein(self, pressure, temperature, volume, params):
         """
         Returns heat capacity at constant pressure at the pressure, temperature, and volume, using the C_v and Einstein model [J/K/mol]
         WARNING: Only for comparison with internally self-consistent C_p
         """
         alpha = self.thermal_expansivity(pressure, temperature, volume, params)
         gr = self.grueneisen_parameter(pressure, temperature, volume, params)
-        C_v = self.heat_capacity_v(pressure, temperature, volume, params)
+        C_v = self.molar_heat_capacity_v(pressure, temperature, volume, params)
         C_p = C_v * (1. + gr * alpha * temperature)
         return C_p
 
@@ -127,8 +127,8 @@ class HP_TMT(eos.EquationOfState):
         temperature [K], and volume [m^3].
         """
         K_T = self.isothermal_bulk_modulus(pressure, temperature, volume, params)
-        C_p = self.heat_capacity_p(pressure, temperature, volume, params)
-        C_v = self.heat_capacity_v(pressure, temperature, volume, params)
+        C_p = self.molar_heat_capacity_p(pressure, temperature, volume, params)
+        C_v = self.molar_heat_capacity_v(pressure, temperature, volume, params)
         K_S = K_T * C_p / C_v
         return K_S
 
@@ -162,8 +162,8 @@ class HP_TMT(eos.EquationOfState):
         a, b, c = mt.tait_constants(params)
         Pth = self.__relative_thermal_pressure(temperature, params)
 
-        ksi_over_ksi_0 = einstein.heat_capacity_v(temperature, params['T_einstein'], params[
-                                                  'n']) / einstein.heat_capacity_v(params['T_0'], params['T_einstein'], params['n'])
+        ksi_over_ksi_0 = einstein.molar_heat_capacity_v(temperature, params['T_einstein'], params[
+                                                  'n']) / einstein.molar_heat_capacity_v(params['T_0'], params['T_einstein'], params['n'])
 
         dintVdpdT = (params['V_0'] * params['a_0'] * params['K_0'] * a * ksi_over_ksi_0) * (
             np.power((1. + b * (pressure - params['P_0'] - Pth)), 0. - c) - np.power((1. - b * Pth), 0. - c))
@@ -178,7 +178,7 @@ class HP_TMT(eos.EquationOfState):
         entropy = self.entropy(pressure, temperature, volume, params)
         return gibbs + temperature * entropy
 
-    def heat_capacity_p(self, pressure, temperature, volume, params):
+    def molar_heat_capacity_p(self, pressure, temperature, volume, params):
         """
         Returns the heat capacity [J/K/mol] as a function of pressure [Pa]
         and temperature [K].
@@ -189,8 +189,8 @@ class HP_TMT(eos.EquationOfState):
         n = params['n']
         Pth = self.__relative_thermal_pressure(T, params)
 
-        ksi_over_ksi_0 = einstein.heat_capacity_v(T, T_e, n) \
-                         / einstein.heat_capacity_v(params['T_0'], T_e, n)
+        ksi_over_ksi_0 = einstein.molar_heat_capacity_v(T, T_e, n) \
+                         / einstein.molar_heat_capacity_v(params['T_0'], T_e, n)
 
         dintVdpdT = (params['V_0'] * params['a_0'] * params['K_0'] * a * ksi_over_ksi_0) * (
             np.power((1. + b * (pressure - params['P_0'] - Pth)), 0. - c) - np.power((1. - b * Pth), 0. - c))
@@ -200,14 +200,14 @@ class HP_TMT(eos.EquationOfState):
                  np.power((1. + b * (-Pth)), -1. - c))
 
         x = T_e/T
-        dCv_einstdT = -(einstein.heat_capacity_v(T, T_e, n) *
+        dCv_einstdT = -(einstein.molar_heat_capacity_v(T, T_e, n) *
                         ( 1 - 2./x + 2./(np.exp(x) - 1.) ) * x/T)
 
         dSdT1 = -dintVdpdT * dCv_einstdT \
-                / einstein.heat_capacity_v(T, T_e, n)
+                / einstein.molar_heat_capacity_v(T, T_e, n)
 
         dSdT = dSdT0 + dSdT1
-        return self.heat_capacity_p0(temperature, params) + temperature * dSdT
+        return self.molar_heat_capacity_p0(temperature, params) + temperature * dSdT
 
     def __thermal_pressure(self, T, params):
         """
@@ -226,7 +226,7 @@ class HP_TMT(eos.EquationOfState):
         # freedom provided by their polynomial expression.
 
         E_th = einstein.thermal_energy(T, params['T_einstein'], params['n'])
-        C_V0 = einstein.heat_capacity_v(
+        C_V0 = einstein.molar_heat_capacity_v(
             params['T_0'], params['T_einstein'], params['n'])
         P_th = params['a_0'] * params['K_0'] / C_V0 * E_th
         return P_th
@@ -300,9 +300,9 @@ class HP_TMT(eos.EquationOfState):
         if params['V_0'] < 1.e-7 or params['V_0'] > 1.e-2:
             warnings.warn('Unusual value for V_0', stacklevel=2)
 
-        if self.heat_capacity_p0(params['T_0'], params) < 0.:
+        if self.molar_heat_capacity_p0(params['T_0'], params) < 0.:
             warnings.warn('Negative heat capacity at T_0', stacklevel=2)
-        if self.heat_capacity_p0(2000., params) < 0.:
+        if self.molar_heat_capacity_p0(2000., params) < 0.:
             warnings.warn('Negative heat capacity at 2000K', stacklevel=2)
 
         if params['a_0'] < 0. or params['a_0'] > 1.e-3:

--- a/burnman/eos/mie_grueneisen_debye.py
+++ b/burnman/eos/mie_grueneisen_debye.py
@@ -79,32 +79,32 @@ class MGDBase(eos.EquationOfState):
             raise NotImplementedError("")
 
     # heat capacity at constant volume
-    def heat_capacity_v(self, pressure, temperature, volume, params):
+    def molar_heat_capacity_v(self, pressure, temperature, volume, params):
         """
         Returns heat capacity at constant volume at the pressure, temperature, and volume [J/K/mol]
         """
         Debye_T = self._debye_temperature(params['V_0'] / volume, params)
-        C_v = debye.heat_capacity_v(temperature, Debye_T, params['n'])
+        C_v = debye.molar_heat_capacity_v(temperature, Debye_T, params['n'])
         return C_v
 
     def thermal_expansivity(self, pressure, temperature, volume, params):
         """
         Returns thermal expansivity at the pressure, temperature, and volume [1/K]
         """
-        C_v = self.heat_capacity_v(pressure, temperature, volume, params)
+        C_v = self.molar_heat_capacity_v(pressure, temperature, volume, params)
         gr = self._grueneisen_parameter(params['V_0'] / volume, params)
         K = self.isothermal_bulk_modulus(pressure, temperature, volume, params)
         alpha = gr * C_v / K / volume
         return alpha
 
     # heat capacity at constant pressure
-    def heat_capacity_p(self, pressure, temperature, volume, params):
+    def molar_heat_capacity_p(self, pressure, temperature, volume, params):
         """
         Returns heat capacity at constant pressure at the pressure, temperature, and volume [J/K/mol]
         """
         alpha = self.thermal_expansivity(pressure, temperature, volume, params)
         gr = self._grueneisen_parameter(params['V_0'] / volume, params)
-        C_v = self.heat_capacity_v(pressure, temperature, volume, params)
+        C_v = self.molar_heat_capacity_v(pressure, temperature, volume, params)
         C_p = C_v * (1. + gr * alpha * temperature)
         return C_p
 
@@ -138,7 +138,7 @@ class MGDBase(eos.EquationOfState):
             pressure, temperature, volume, params) + pressure * volume
         return G
 
-    def internal_energy(self, pressure, temperature, volume, params):
+    def molar_internal_energy(self, pressure, temperature, volume, params):
         """
         Returns the internal energy at the pressure and temperature of the mineral [J/mol]
         """

--- a/burnman/eos/modified_tait.py
+++ b/burnman/eos/modified_tait.py
@@ -107,7 +107,7 @@ class MT(eos.EquationOfState):
         """
         return 0.
     
-    def internal_energy(self, pressure, temperature, volume, params):
+    def molar_internal_energy(self, pressure, temperature, volume, params):
         """
         Returns the internal energy :math:`\mathcal{E}` of the mineral. :math:`[J/mol]`
         """
@@ -128,13 +128,13 @@ class MT(eos.EquationOfState):
         
         return intVdP + params['E_0'] + params['V_0']*params['P_0']
     
-    def heat_capacity_v(self, pressure, temperature, volume, params):
+    def molar_heat_capacity_v(self, pressure, temperature, volume, params):
         """
         Since this equation of state does not contain temperature effects, simply return a very large number. :math:`[J/K/mol]`
         """
         return 1.e99
 
-    def heat_capacity_p(self, pressure, temperature, volume, params):
+    def molar_heat_capacity_p(self, pressure, temperature, volume, params):
         """
         Since this equation of state does not contain temperature effects, simply return a very large number. :math:`[J/K/mol]`
         """

--- a/burnman/eos/morse_potential.py
+++ b/burnman/eos/morse_potential.py
@@ -103,7 +103,7 @@ class Morse(eos.EquationOfState):
         """
         return 0.
     
-    def internal_energy(self, pressure, temperature, volume, params):
+    def molar_internal_energy(self, pressure, temperature, volume, params):
         """
         Returns the internal energy :math:`\mathcal{E}` of the mineral. :math:`[J/mol]`
         """
@@ -119,15 +119,15 @@ class Morse(eos.EquationOfState):
         """
         Returns the Gibbs free energy :math:`\mathcal{G}` of the mineral. :math:`[J/mol]`
         """
-        return self.internal_energy(pressure, temperature, volume, params) + volume*pressure
+        return self.molar_internal_energy(pressure, temperature, volume, params) + volume*pressure
     
-    def heat_capacity_v(self, pressure, temperature, volume, params):
+    def molar_heat_capacity_v(self, pressure, temperature, volume, params):
         """
         Since this equation of state does not contain temperature effects, simply return a very large number. :math:`[J/K/mol]`
         """
         return 1.e99
 
-    def heat_capacity_p(self, pressure, temperature, volume, params):
+    def molar_heat_capacity_p(self, pressure, temperature, volume, params):
         """
         Since this equation of state does not contain temperature effects, simply return a very large number. :math:`[J/K/mol]`
         """

--- a/burnman/eos/reciprocal_kprime.py
+++ b/burnman/eos/reciprocal_kprime.py
@@ -188,20 +188,20 @@ class RKprime(eos.EquationOfState):
         K = self.isothermal_bulk_modulus(pressure, temperature, volume, params)
         return params['E_0'] + params['P_0']*params['V_0'] + self._intVdP((pressure - params['P_0'])/K, params) - self._intVdP(0., params) 
     
-    def internal_energy(self, pressure, temperature, volume, params):
+    def molar_internal_energy(self, pressure, temperature, volume, params):
         """
         Returns the internal energy :math:`\mathcal{E}` of the mineral. :math:`[J/mol]`
         """
         # E = G - PV (+ TS)
         return ( self.gibbs_free_energy(pressure, temperature, volume, params) - pressure*volume)
         
-    def heat_capacity_v(self, pressure, temperature, volume, params):
+    def molar_heat_capacity_v(self, pressure, temperature, volume, params):
         """
         Since this equation of state does not contain temperature effects, simply return a very large number. :math:`[J/K/mol]`
         """
         return 1.e99
 
-    def heat_capacity_p(self, pressure, temperature, volume, params):
+    def molar_heat_capacity_p(self, pressure, temperature, volume, params):
         """
         Since this equation of state does not contain temperature effects, simply return a very large number. :math:`[J/K/mol]`
         """

--- a/burnman/eos/slb.py
+++ b/burnman/eos/slb.py
@@ -185,9 +185,9 @@ class SLBBase(eos.EquationOfState):
         E_th_ref = debye.thermal_energy(
             T_0, debye_T, params['n'])  # thermal energy at reference temperature
 
-        C_v = debye.heat_capacity_v(
+        C_v = debye.molar_heat_capacity_v(
             temperature, debye_T, params['n'])  # heat capacity at temperature T
-        C_v_ref = debye.heat_capacity_v(
+        C_v_ref = debye.molar_heat_capacity_v(
             T_0, debye_T, params['n'])  # heat capacity at reference temperature
 
         q = self.volume_dependent_q(params['V_0'] / volume, params)
@@ -227,20 +227,20 @@ class SLBBase(eos.EquationOfState):
         else:
             raise NotImplementedError("")
 
-    def heat_capacity_v(self, pressure, temperature, volume, params):
+    def molar_heat_capacity_v(self, pressure, temperature, volume, params):
         """
         Returns heat capacity at constant volume. :math:`[J/K/mol]`
         """
         debye_T = self._debye_temperature(params['V_0'] / volume, params)
-        return debye.heat_capacity_v(temperature, debye_T, params['n'])
+        return debye.molar_heat_capacity_v(temperature, debye_T, params['n'])
 
-    def heat_capacity_p(self, pressure, temperature, volume, params):
+    def molar_heat_capacity_p(self, pressure, temperature, volume, params):
         """
         Returns heat capacity at constant pressure. :math:`[J/K/mol]`
         """
         alpha = self.thermal_expansivity(pressure, temperature, volume, params)
         gr = self.grueneisen_parameter(pressure, temperature, volume, params)
-        C_v = self.heat_capacity_v(pressure, temperature, volume, params)
+        C_v = self.molar_heat_capacity_v(pressure, temperature, volume, params)
         C_p = C_v * (1. + gr * alpha * temperature)
         return C_p
 
@@ -248,7 +248,7 @@ class SLBBase(eos.EquationOfState):
         """
         Returns thermal expansivity. :math:`[1/K]`
         """
-        C_v = self.heat_capacity_v(pressure, temperature, volume, params)
+        C_v = self.molar_heat_capacity_v(pressure, temperature, volume, params)
         gr = self.grueneisen_parameter(pressure, temperature, volume, params)
         K = self.isothermal_bulk_modulus(pressure, temperature, volume, params)
         alpha = gr * C_v / K / volume
@@ -262,7 +262,7 @@ class SLBBase(eos.EquationOfState):
             pressure, temperature, volume, params) + pressure * volume
         return G
 
-    def internal_energy(self, pressure, temperature, volume, params):
+    def molar_internal_energy(self, pressure, temperature, volume, params):
         """
         Returns the internal energy at the pressure and temperature of the mineral [J/mol]
         """

--- a/burnman/eos/vinet.py
+++ b/burnman/eos/vinet.py
@@ -92,7 +92,7 @@ class Vinet(eos.EquationOfState):
         """
         return 0.
     
-    def internal_energy(self, pressure, temperature, volume, params):
+    def molar_internal_energy(self, pressure, temperature, volume, params):
         """
         Returns the internal energy :math:`\mathcal{E}` of the mineral. :math:`[J/mol]`
         """
@@ -112,15 +112,15 @@ class Vinet(eos.EquationOfState):
         """
         # G = int VdP = [PV] - int PdV = E + PV
                   
-        return self.internal_energy(pressure, temperature, volume, params) + volume*pressure
+        return self.molar_internal_energy(pressure, temperature, volume, params) + volume*pressure
     
-    def heat_capacity_v(self, pressure, temperature, volume, params):
+    def molar_heat_capacity_v(self, pressure, temperature, volume, params):
         """
         Since this equation of state does not contain temperature effects, simply return a very large number. :math:`[J/K/mol]`
         """
         return 1.e99
 
-    def heat_capacity_p(self, pressure, temperature, volume, params):
+    def molar_heat_capacity_p(self, pressure, temperature, volume, params):
         """
         Since this equation of state does not contain temperature effects, simply return a very large number. :math:`[J/K/mol]`
         """

--- a/burnman/eos_fitting.py
+++ b/burnman/eos_fitting.py
@@ -109,11 +109,11 @@ def fit_PTp_data(mineral, fit_params, flags, data, data_covariances=[], mle_tole
             elif flag == 'H':
                 self.m.set_state(P, T)
                 dPdp = 1./((1.-T*self.m.alpha)*self.m.V)
-                dpdT = self.m.heat_capacity_p
+                dpdT = self.m.molar_heat_capacity_p
             elif flag == 'S':
                 self.m.set_state(P, T)
                 dPdp = -1./(self.m.alpha*self.m.V)
-                dpdT = self.m.heat_capacity_p/T
+                dpdT = self.m.molar_heat_capacity_p/T
             elif flag == 'gibbs':
                 self.m.set_state(P, T)
                 dPdp = 1./self.m.V

--- a/burnman/layer.py
+++ b/burnman/layer.py
@@ -451,9 +451,9 @@ class Layer(object):
 
 
     @material_property
-    def internal_energy(self):
+    def molar_internal_energy(self):
         """
-        Returns the internal energies across the layer.
+        Returns the molar internal energies across the layer.
 
         Notes
         -----
@@ -462,16 +462,16 @@ class Layer(object):
 
         Returns
         -------
-        internal_energy : array of floats
-            The internal energies in [J] at the predefined radii.
+        molar_internal_energy : array of floats
+            The internal energies in [J/mol] at the predefined radii.
         """
         return np.array(
-            [self.sublayers[i].internal_energy for i in range(len(self.sublayers))])
+            [self.sublayers[i].molar_internal_energy for i in range(len(self.sublayers))])
 
     @material_property
     def molar_gibbs(self):
         """
-        Returns the Gibbs free energies across the layer.
+        Returns the molar Gibbs free energies across the layer.
 
         Notes
         -----
@@ -481,7 +481,7 @@ class Layer(object):
         Returns
         -------
         molar_gibbs : array of floats
-            Gibbs free energies in [J] at the predefined radii.
+            Gibbs free energies in [J/mol] at the predefined radii.
         """
         return np.array(
             [self.sublayers[i].molar_gibbs for i in range(len(self.sublayers))])
@@ -489,7 +489,7 @@ class Layer(object):
     @material_property
     def molar_helmholtz(self):
         """
-        Returns the Helmholtz free energies across the layer.
+        Returns the molar Helmholtz free energies across the layer.
 
         Notes
         -----
@@ -499,7 +499,7 @@ class Layer(object):
         Returns
         -------
         molar_helmholtz : array of floats
-            Helmholtz free energies in [J] at the predefined radii.
+            Helmholtz free energies in [J/mol] at the predefined radii.
         """
         return np.array(
             [self.sublayers[i].molar_helmholtz for i in range(len(self.sublayers))])
@@ -560,7 +560,7 @@ class Layer(object):
     @material_property
     def molar_entropy(self):
         """
-        Returns entropies acroos the layer.
+        Returns molar entropies acroos the layer.
 
         Notes
         -----
@@ -569,8 +569,8 @@ class Layer(object):
 
         Returns
         -------
-        entropy : array of floats
-            Entropies in [J] at the predefined radii.
+        molar_entropy : array of floats
+            Entropies in [J/K/mol] at the predefined radii.
         """
         return np.array(
             [self.sublayers[i].molar_entropy for i in range(len(self.sublayers))])
@@ -578,7 +578,7 @@ class Layer(object):
     @material_property
     def molar_enthalpy(self):
         """
-        Returns enthalpies across the layer.
+        Returns molar enthalpies across the layer.
 
         Notes
         -----
@@ -587,8 +587,8 @@ class Layer(object):
 
         Returns
         -------
-        enthalpy : array of floats
-            Enthalpies in [J] at the predefined radii.
+        molar_enthalpy : array of floats
+            Enthalpies in [J/mol] at the predefined radii.
         """
         return np.array(
             [self.sublayers[i].molar_enthalpy for i in range(len(self.sublayers))])
@@ -775,9 +775,9 @@ class Layer(object):
             [self.sublayers[i].thermal_expansivity for i in range(len(self.sublayers))])
 
     @material_property
-    def heat_capacity_v(self):
+    def molar_heat_capacity_v(self):
         """
-        Returns heat capacity at constant volumes across the layer.
+        Returns molar heat capacity at constant volumes across the layer.
 
         Notes
         -----
@@ -786,16 +786,16 @@ class Layer(object):
 
         Returns
         -------
-        heat_capacity_v : array of floats
+        molar_heat_capacity_v : array of floats
             Heat capacities in [J/K/mol] at the predefined radii.
         """
         return np.array(
-            [self.sublayers[i].heat_capacity_v for i in range(len(self.sublayers))])
+            [self.sublayers[i].molar_heat_capacity_v for i in range(len(self.sublayers))])
 
     @material_property
-    def heat_capacity_p(self):
+    def molar_heat_capacity_p(self):
         """
-        Returns heat capacity at constant pressures across the layer.
+        Returns molar_heat capacity at constant pressures across the layer.
 
         Notes
         -----
@@ -804,11 +804,11 @@ class Layer(object):
 
         Returns
         -------
-        heat_capacity_p : array of floats
+        molar_heat_capacity_p : array of floats
             Heat capacities in [J/K/mol] at the predefined radii.
         """
         return np.array(
-            [self.sublayers[i].heat_capacity_p for i in range(len(self.sublayers))])
+            [self.sublayers[i].molar_heat_capacity_p for i in range(len(self.sublayers))])
 
 #
 # Aliased properties
@@ -824,8 +824,8 @@ class Layer(object):
     
     @property
     def energy(self):
-        """Alias for :func:`~burnman.layer.Layer.internal_energy`"""
-        return self.internal_energy
+        """Alias for :func:`~burnman.layer.Layer.molar_internal_energy`"""
+        return self.molar_internal_energy
     
     @property
     def helmholtz(self):
@@ -909,11 +909,11 @@ class Layer(object):
     
     @property
     def C_v(self):
-        """Alias for :func:`~burnman.material.Material.heat_capacity_v`"""
-        return self.heat_capacity_v
+        """Alias for :func:`~burnman.material.Material.molar_heat_capacity_v`"""
+        return self.molar_heat_capacity_v
     
     @property
     def C_p(self):
-        """Alias for :func:`~burnman.material.Material.heat_capacity_p`"""
-        return self.heat_capacity_p
+        """Alias for :func:`~burnman.material.Material.molar_heat_capacity_p`"""
+        return self.molar_heat_capacity_p
 

--- a/burnman/material.py
+++ b/burnman/material.py
@@ -240,9 +240,9 @@ class Material(object):
         return self._temperature
 
     @material_property
-    def internal_energy(self):
+    def molar_internal_energy(self):
         """
-        Returns the internal energy of the mineral.
+        Returns the molar internal energy of the mineral.
 
         Notes
         -----
@@ -251,16 +251,16 @@ class Material(object):
 
         Returns
         -------
-        internal_energy : float
-            The internal energy in [J].
+        molar_internal_energy : float
+            The internal energy in [J/mol].
         """
         raise NotImplementedError(
-            "need to implement internal_energy() in derived class!")
+            "need to implement molar_internal_energy() in derived class!")
 
     @material_property
     def molar_gibbs(self):
         """
-        Returns the Gibbs free energy of the mineral.
+        Returns the molar Gibbs free energy of the mineral.
 
         Notes
         -----
@@ -270,7 +270,7 @@ class Material(object):
         Returns
         -------
         molar_gibbs : float
-            Gibbs free energy in [J].
+            Gibbs free energy in [J/mol].
         """
         raise NotImplementedError(
             "need to implement molar_gibbs() in derived class!")
@@ -278,7 +278,7 @@ class Material(object):
     @material_property
     def molar_helmholtz(self):
         """
-        Returns the Helmholtz free energy of the mineral.
+        Returns the molar Helmholtz free energy of the mineral.
 
         Notes
         -----
@@ -288,7 +288,7 @@ class Material(object):
         Returns
         -------
         molar_helmholtz : float
-            Helmholtz free energy in [J].
+            Helmholtz free energy in [J/mol].
         """
         raise NotImplementedError(
             "need to implement molar_helmholtz() in derived class!")
@@ -349,7 +349,7 @@ class Material(object):
     @material_property
     def molar_entropy(self):
         """
-        Returns entropy of the mineral.
+        Returns molar entropy of the mineral.
 
         Notes
         -----
@@ -358,8 +358,8 @@ class Material(object):
 
         Returns
         -------
-        entropy : float
-            Entropy in [J].
+        molar_entropy : float
+            Entropy in [J/K/mol].
         """
         raise NotImplementedError(
             "need to implement molar_entropy() in derived class!")
@@ -367,7 +367,7 @@ class Material(object):
     @material_property
     def molar_enthalpy(self):
         """
-        Returns enthalpy of the mineral.
+        Returns molar enthalpy of the mineral.
 
         Notes
         -----
@@ -376,8 +376,8 @@ class Material(object):
 
         Returns
         -------
-        enthalpy : float
-            Enthalpy in [J].
+        molar_enthalpy : float
+            Enthalpy in [J/mol].
         """
         raise NotImplementedError(
             "need to implement molar_enthalpy() in derived class!")
@@ -564,9 +564,9 @@ class Material(object):
             "need to implement thermal_expansivity() in derived class!")
 
     @material_property
-    def heat_capacity_v(self):
+    def molar_heat_capacity_v(self):
         """
-        Returns heat capacity at constant volume of the mineral.
+        Returns molar heat capacity at constant volume of the mineral.
 
         Notes
         -----
@@ -575,16 +575,16 @@ class Material(object):
 
         Returns
         -------
-        heat_capacity_v : float
+        molar_heat_capacity_v : float
             Heat capacity in [J/K/mol].
         """
         raise NotImplementedError(
-            "need to implement heat_capacity_v() in derived class!")
+            "need to implement molar_heat_capacity_v() in derived class!")
 
     @material_property
-    def heat_capacity_p(self):
+    def molar_heat_capacity_p(self):
         """
-        Returns heat capacity at constant pressure of the mineral.
+        Returns molar heat capacity at constant pressure of the mineral.
 
         Notes
         -----
@@ -593,11 +593,11 @@ class Material(object):
 
         Returns
         -------
-        heat_capacity_p : float
+        molar_heat_capacity_p : float
             Heat capacity in [J/K/mol].
         """
         raise NotImplementedError(
-            "need to implement heat_capacity_p() in derived class!")
+            "need to implement molar_heat_capacity_p() in derived class!")
 
     #
     # Aliased properties
@@ -613,8 +613,8 @@ class Material(object):
 
     @property
     def energy(self):
-        """Alias for :func:`~burnman.material.Material.internal_energy`"""
-        return self.internal_energy
+        """Alias for :func:`~burnman.material.Material.molar_internal_energy`"""
+        return self.molar_internal_energy
 
     @property
     def helmholtz(self):
@@ -698,10 +698,10 @@ class Material(object):
 
     @property
     def C_v(self):
-        """Alias for :func:`~burnman.material.Material.heat_capacity_v`"""
-        return self.heat_capacity_v
+        """Alias for :func:`~burnman.material.Material.molar_heat_capacity_v`"""
+        return self.molar_heat_capacity_v
 
     @property
     def C_p(self):
-        """Alias for :func:`~burnman.material.Material.heat_capacity_p`"""
-        return self.heat_capacity_p
+        """Alias for :func:`~burnman.material.Material.molar_heat_capacity_p`"""
+        return self.molar_heat_capacity_p

--- a/burnman/mineral.py
+++ b/burnman/mineral.py
@@ -166,9 +166,9 @@ class Mineral(Material):
             / ((self._molar_volume_unmodified / K_T_orig) - self._property_modifiers['d2GdP2'])
 
     @material_property
-    @copy_documentation(Material.heat_capacity_p)
-    def heat_capacity_p(self):
-        return self.method.heat_capacity_p(self.pressure, self.temperature,
+    @copy_documentation(Material.molar_heat_capacity_p)
+    def molar_heat_capacity_p(self):
+        return self.method.molar_heat_capacity_p(self.pressure, self.temperature,
                                            self.molar_volume, self.params) \
             - self.temperature * self._property_modifiers['d2GdT2']
 
@@ -216,8 +216,8 @@ class Mineral(Material):
         return self.molar_mass / self.molar_volume
 
     @material_property
-    @copy_documentation(Material.internal_energy)
-    def internal_energy(self):
+    @copy_documentation(Material.molar_internal_energy)
+    def molar_internal_energy(self):
         return self.molar_gibbs - self.pressure * self.molar_volume + self.temperature * self.molar_entropy
 
     @material_property
@@ -236,7 +236,7 @@ class Mineral(Material):
         if self.temperature < 1.e-10:
             return self.isothermal_bulk_modulus
         else:
-            return self.isothermal_bulk_modulus * self.heat_capacity_p / self.heat_capacity_v
+            return self.isothermal_bulk_modulus * self.molar_heat_capacity_p / self.molar_heat_capacity_v
 
     @material_property
     @copy_documentation(Material.isothermal_compressibility)
@@ -270,8 +270,8 @@ class Mineral(Material):
         return self.method.grueneisen_parameter(self.pressure, self.temperature, self.molar_volume, self.params)
     
     @material_property
-    @copy_documentation(Material.heat_capacity_v)
-    def heat_capacity_v(self):
-        return self.heat_capacity_p - self.molar_volume * self.temperature \
+    @copy_documentation(Material.molar_heat_capacity_v)
+    def molar_heat_capacity_v(self):
+        return self.molar_heat_capacity_p - self.molar_volume * self.temperature \
             * self.thermal_expansivity * self.thermal_expansivity \
             * self.isothermal_bulk_modulus

--- a/burnman/mineral_helpers.py
+++ b/burnman/mineral_helpers.py
@@ -46,8 +46,8 @@ class HelperRockSwitcher(Material):
         return self.current_rock.unroll()
 
     @material_property
-    def internal_energy(self):
-        return self.current_rock.internal_energy
+    def molar_internal_energy(self):
+        return self.current_rock.molar_internal_energy
 
     @material_property
     def molar_gibbs(self):
@@ -118,12 +118,12 @@ class HelperRockSwitcher(Material):
         return self.current_rock.thermal_expansivity
 
     @material_property
-    def heat_capacity_v(self):
-        return self.current_rock.heat_capacity_v
+    def molar_heat_capacity_v(self):
+        return self.current_rock.molar_heat_capacity_v
 
     @material_property
-    def heat_capacity_p(self):
-        return self.current_rock.heat_capacity_p
+    def molar_heat_capacity_p(self):
+        return self.current_rock.molar_heat_capacity_p
 
 
 class HelperLowHighPressureRockTransition(HelperRockSwitcher):

--- a/burnman/model.py
+++ b/burnman/model.py
@@ -85,11 +85,11 @@ class Model(object):
 
         return self.alpha
 
-    def heat_capacity_p(self):
+    def molar_heat_capacity_p(self):
         self.calc_heat_capacities_()
         return self.c_p
 
-    def heat_capacity_v(self):
+    def molar_heat_capacity_v(self):
         self.calc_heat_capacities_()
         return self.c_v
 
@@ -111,8 +111,8 @@ class Model(object):
                         e['G'] = mineral.shear_modulus
                         e['rho'] = mineral.molar_mass / mineral.molar_volume
                         e['alpha'] = mineral.thermal_expansivity
-                        e['c_v'] = mineral.heat_capacity_v
-                        e['c_p'] = mineral.heat_capacity_p
+                        e['c_v'] = mineral.molar_heat_capacity_v
+                        e['c_p'] = mineral.molar_heat_capacity_p
                         self.moduli[idx].append(e)
 
     def avg_moduli_(self):

--- a/burnman/perplex.py
+++ b/burnman/perplex.py
@@ -226,8 +226,8 @@ class PerplexMaterial(Material):
         return self._property_interpolators['K_S'](self.pressure, self.temperature)[0]
         
     @material_property
-    @copy_documentation(Material.heat_capacity_p)
-    def heat_capacity_p(self):
+    @copy_documentation(Material.molar_heat_capacity_p)
+    def molar_heat_capacity_p(self):
         return self._property_interpolators['C_p'](self.pressure, self.temperature)[0]
     
     @material_property
@@ -281,8 +281,8 @@ class PerplexMaterial(Material):
         return self._property_interpolators['rho'](self.pressure, self.temperature)[0]
 
     @material_property
-    @copy_documentation(Material.internal_energy)
-    def internal_energy(self):
+    @copy_documentation(Material.molar_internal_energy)
+    def molar_internal_energy(self):
         return self.molar_gibbs - self.pressure * self.molar_volume + self.temperature * self.molar_entropy
 
     @material_property
@@ -301,9 +301,9 @@ class PerplexMaterial(Material):
         return 1. / self.adiabatic_bulk_modulus
     
     @material_property
-    @copy_documentation(Material.heat_capacity_v)
-    def heat_capacity_v(self):
-        return self.heat_capacity_p - self.molar_volume * self.temperature \
+    @copy_documentation(Material.molar_heat_capacity_v)
+    def molar_heat_capacity_v(self):
+        return self.molar_heat_capacity_p - self.molar_volume * self.temperature \
             * self.thermal_expansivity * self.thermal_expansivity \
             * self.isothermal_bulk_modulus
 
@@ -313,5 +313,5 @@ class PerplexMaterial(Material):
         return ( self.thermal_expansivity *
                  self.molar_volume *
                  self.adiabatic_bulk_modulus /
-                 self.heat_capacity_p )
+                 self.molar_heat_capacity_p )
     

--- a/burnman/planet.py
+++ b/burnman/planet.py
@@ -398,9 +398,9 @@ class Planet(object):
         return self.temperatures
 
     @material_property
-    def internal_energy(self):
+    def molar_internal_energy(self):
         """
-        Returns the internal energy of the planet.
+        Returns the molar internal energy of the planet.
 
         Notes
         -----
@@ -409,15 +409,15 @@ class Planet(object):
 
         Returns
         -------
-        internal_energy : array of floats
-            The internal energy in [J].
+        molar_internal_energy : array of floats
+            The internal energy in [J/mol].
         """
-        return self.evaluate(['internal_energy'])
+        return self.evaluate(['molar_internal_energy'])
 
     @material_property
     def molar_gibbs(self):
         """
-        Returns the Gibbs free energy of the planet.
+        Returns the molar Gibbs free energy of the planet.
 
         Notes
         -----
@@ -427,14 +427,14 @@ class Planet(object):
         Returns
         -------
         molar_gibbs : array of floats
-            Gibbs free energy in [J].
+            Gibbs free energy in [J/mol].
         """
         return self.evaluate(['molar_gibbs'])
 
     @material_property
     def molar_helmholtz(self):
         """
-        Returns the Helmholtz free energy of the planet.
+        Returns the molar Helmholtz free energy of the planet.
 
         Notes
         -----
@@ -444,7 +444,7 @@ class Planet(object):
         Returns
         -------
         molar_helmholtz : array of floats
-            Helmholtz free energy in [J].
+            Helmholtz free energy in [J/mol].
         """
         return self.evaluate(['molar_helmholtz'])
 
@@ -501,7 +501,7 @@ class Planet(object):
     @material_property
     def molar_entropy(self):
         """
-        Returns entropy of the planet.
+        Returns molar entropy of the planet.
 
         Notes
         -----
@@ -510,15 +510,15 @@ class Planet(object):
 
         Returns
         -------
-        entropy : array of floats
-            Entropy in [J].
+        molar_entropy : array of floats
+            Entropy in [J/mol].
         """
         return self.evaluate(['molar_entropy'])
 
     @material_property
     def molar_enthalpy(self):
         """
-        Returns enthalpy of the planet.
+        Returns molar enthalpy of the planet.
 
         Notes
         -----
@@ -527,8 +527,8 @@ class Planet(object):
 
         Returns
         -------
-        enthalpy : array of floats
-            Enthalpy in [J].
+        molar_enthalpy : array of floats
+            Enthalpy in [J/mol].
         """
         return self.evaluate(['molar_enthalpy'])
 
@@ -704,9 +704,9 @@ class Planet(object):
         return self.evaluate(['thermal_expansivity'])
 
     @material_property
-    def heat_capacity_v(self):
+    def molar_heat_capacity_v(self):
         """
-        Returns heat capacity at constant volume of the planet.
+        Returns molar heat capacity at constant volume of the planet.
 
         Notes
         -----
@@ -715,15 +715,15 @@ class Planet(object):
 
         Returns
         -------
-        heat_capacity_v : array of floats
+        molar_heat_capacity_v : array of floats
             Heat capacity in [J/K/mol].
         """
-        return self.evaluate(['heat_capacity_v'])
+        return self.evaluate(['molar_heat_capacity_v'])
 
     @material_property
-    def heat_capacity_p(self):
+    def molar_heat_capacity_p(self):
         """
-        Returns heat capacity at constant pressure of the planet.
+        Returns molar heat capacity at constant pressure of the planet.
 
         Notes
         -----
@@ -732,10 +732,10 @@ class Planet(object):
 
         Returns
         -------
-        heat_capacity_p : array of floats
+        molar_heat_capacity_p : array of floats
             Heat capacity in [J/K/mol].
         """
-        return self.evaluate(['heat_capacity_p'])
+        return self.evaluate(['molar_heat_capacity_p'])
 
 #
 # Aliased properties
@@ -751,8 +751,8 @@ class Planet(object):
     
     @property
     def energy(self):
-        """Alias for :func:`~burnman.material.Material.internal_energy`"""
-        return self.internal_energy
+        """Alias for :func:`~burnman.material.Material.molar_internal_energy`"""
+        return self.molar_internal_energy
     
     @property
     def helmholtz(self):
@@ -836,11 +836,11 @@ class Planet(object):
     
     @property
     def C_v(self):
-        """Alias for :func:`~burnman.material.Material.heat_capacity_v`"""
-        return self.heat_capacity_v
+        """Alias for :func:`~burnman.material.Material.molar_heat_capacity_v`"""
+        return self.molar_heat_capacity_v
     
     @property
     def C_p(self):
-        """Alias for :func:`~burnman.material.Material.heat_capacity_p`"""
-        return self.heat_capacity_p
+        """Alias for :func:`~burnman.material.Material.molar_heat_capacity_p`"""
+        return self.molar_heat_capacity_p
 

--- a/burnman/solidsolution.py
+++ b/burnman/solidsolution.py
@@ -210,9 +210,9 @@ class SolidSolution(Mineral):
         return self.solution_model.activity_coefficients(self.pressure, self.temperature, self.molar_fractions)
 
     @material_property
-    def internal_energy(self):
+    def molar_internal_energy(self):
         """
-        Returns internal energy of the mineral [J]
+        Returns molar internal energy of the mineral [J/mol]
         Aliased with self.energy
         """
         return self.molar_helmholtz + self.temperature * self.molar_entropy
@@ -220,7 +220,7 @@ class SolidSolution(Mineral):
     @material_property
     def excess_partial_gibbs(self):
         """
-        Returns excess partial gibbs free energy [J]
+        Returns excess partial molar gibbs free energy [J/mol]
         Property specific to solid solutions.
         """
         return self.solution_model.excess_partial_gibbs_free_energies(self.pressure, self.temperature, self.molar_fractions)
@@ -228,7 +228,7 @@ class SolidSolution(Mineral):
     @material_property
     def partial_gibbs(self):
         """
-        Returns excess partial gibbs free energy [J]
+        Returns excess partial molar gibbs free energy [J/mol]
         Property specific to solid solutions.
         """
         return np.array([self.endmembers[i][0].gibbs for i in range(self.n_endmembers)]) + self.excess_partial_gibbs
@@ -236,7 +236,7 @@ class SolidSolution(Mineral):
     @material_property
     def excess_gibbs(self):
         """
-        Returns excess gibbs free energy [J]
+        Returns molar excess gibbs free energy [J/mol]
         Property specific to solid solutions.
         """
         return self.solution_model.excess_gibbs_free_energy(self.pressure, self.temperature, self.molar_fractions)
@@ -244,7 +244,7 @@ class SolidSolution(Mineral):
     @material_property
     def molar_gibbs(self):
         """
-        Returns Gibbs free energy of the solid solution [J]
+        Returns molar Gibbs free energy of the solid solution [J/mol]
         Aliased with self.gibbs
         """
         return sum([self.endmembers[i][0].gibbs * self.molar_fractions[i] for i in range(self.n_endmembers)]) + self.excess_gibbs
@@ -252,7 +252,7 @@ class SolidSolution(Mineral):
     @material_property
     def molar_helmholtz(self):
         """
-        Returns Helmholtz free energy of the solid solution [J]
+        Returns molar Helmholtz free energy of the solid solution [J/mol]
         Aliased with self.helmholtz
         """
         return self.molar_gibbs - self.pressure * self.molar_volume
@@ -267,7 +267,7 @@ class SolidSolution(Mineral):
     @material_property
     def formula(self):
         """
-        Returns chemical formula of the solid solution
+        Returns molar chemical formula of the solid solution
         """
         return sum_formulae([self.endmembers[i][0].params['formula'] for i in range(self.n_endmembers)],
                             self.molar_fractions)
@@ -275,7 +275,7 @@ class SolidSolution(Mineral):
     @material_property
     def excess_volume(self):
         """
-        Returns excess volume of the solid solution [m^3/mol]
+        Returns excess molar volume of the solid solution [m^3/mol]
         Specific property for solid solutions
         """
         return self.solution_model.excess_volume(self.pressure, self.temperature, self.molar_fractions)
@@ -299,7 +299,7 @@ class SolidSolution(Mineral):
     @material_property
     def excess_entropy(self):
         """
-        Returns excess entropy [J]
+        Returns excess molar entropy [J/K/mol]
         Property specific to solid solutions.
         """
         return self.solution_model.excess_entropy(self.pressure, self.temperature, self.molar_fractions)
@@ -307,7 +307,7 @@ class SolidSolution(Mineral):
     @material_property
     def molar_entropy(self):
         """
-        Returns entropy of the solid solution [J]
+        Returns molar entropy of the solid solution [J/K/mol]
         Aliased with self.S
         """
         return sum([self.endmembers[i][0].S * self.molar_fractions[i] for i in range(self.n_endmembers)]) + self.excess_entropy
@@ -315,7 +315,7 @@ class SolidSolution(Mineral):
     @material_property
     def excess_enthalpy(self):
         """
-        Returns excess enthalpy [J]
+        Returns excess molar enthalpy [J/mol]
         Property specific to solid solutions.
         """
         return self.solution_model.excess_enthalpy(self.pressure, self.temperature, self.molar_fractions)
@@ -323,7 +323,7 @@ class SolidSolution(Mineral):
     @material_property
     def molar_enthalpy(self):
         """
-        Returns enthalpy of the solid solution [J]
+        Returns molar enthalpy of the solid solution [J/mol]
         Aliased with self.H
         """
         return sum([self.endmembers[i][0].H * self.molar_fractions[i] for i in range(self.n_endmembers)]) + self.excess_enthalpy
@@ -345,7 +345,7 @@ class SolidSolution(Mineral):
         if self.temperature < 1e-10:
             return self.isothermal_bulk_modulus
         else:
-            return self.isothermal_bulk_modulus * self.heat_capacity_p / self.heat_capacity_v
+            return self.isothermal_bulk_modulus * self.molar_heat_capacity_p / self.molar_heat_capacity_v
 
     @material_property
     def isothermal_compressibility(self):
@@ -407,7 +407,7 @@ class SolidSolution(Mineral):
         if self.temperature < 1e-10:
             return float('nan')
         else:
-            return self.thermal_expansivity * self.isothermal_bulk_modulus * self.molar_volume / self.heat_capacity_v
+            return self.thermal_expansivity * self.isothermal_bulk_modulus * self.molar_volume / self.molar_heat_capacity_v
 
     @material_property
     def thermal_expansivity(self):
@@ -418,17 +418,17 @@ class SolidSolution(Mineral):
         return (1. / self.V) * sum([self.endmembers[i][0].alpha * self.endmembers[i][0].V * self.molar_fractions[i] for i in range(self.n_endmembers)])
 
     @material_property
-    def heat_capacity_v(self):
+    def molar_heat_capacity_v(self):
         """
-        Returns heat capacity at constant volume of the solid solution [J/K/mol]
+        Returns molar heat capacity at constant volume of the solid solution [J/K/mol]
         Aliased with self.C_v
         """
-        return self.heat_capacity_p - self.molar_volume * self.temperature * self.thermal_expansivity * self.thermal_expansivity * self.isothermal_bulk_modulus
+        return self.molar_heat_capacity_p - self.molar_volume * self.temperature * self.thermal_expansivity * self.thermal_expansivity * self.isothermal_bulk_modulus
 
     @material_property
-    def heat_capacity_p(self):
+    def molar_heat_capacity_p(self):
         """
-        Returns heat capacity at constant pressure of the solid solution [J/K/mol]
+        Returns molar heat capacity at constant pressure of the solid solution [J/K/mol]
         Aliased with self.C_p
         """
-        return sum([self.endmembers[i][0].heat_capacity_p * self.molar_fractions[i] for i in range(self.n_endmembers)])
+        return sum([self.endmembers[i][0].molar_heat_capacity_p * self.molar_fractions[i] for i in range(self.n_endmembers)])

--- a/burnman/tools.py
+++ b/burnman/tools.py
@@ -587,7 +587,7 @@ def check_eos_consistency(m, P=1.e9, T=300., tol=1.e-4, verbose=False):
     expr = ['G = F + PV', 'G = H - TS', 'G = E - TS + PV']
     eq = [[m.gibbs, (m.helmholtz + P*m.V)],
           [m.gibbs, (m.H - T*m.S)],
-          [m.gibbs, (m.internal_energy - T*m.S + P*m.V)]]
+          [m.gibbs, (m.molar_internal_energy - T*m.S + P*m.V)]]
     
     m.set_state(P, T + dT)
     G1 = m.gibbs
@@ -604,7 +604,7 @@ def check_eos_consistency(m, P=1.e9, T=300., tol=1.e-4, verbose=False):
     expr.extend(['S = -dG/dT', 'alpha = 1/V dV/dT', 'C_p = T dS/dT'])
     eq.extend([[m.S, -(G1 - G0)/dT],
                [m.alpha, (V1 - V0)/dT/m.V],
-               [m.heat_capacity_p, (T + 0.5*dT)*(S1 - S0)/dT]])
+               [m.molar_heat_capacity_p, (T + 0.5*dT)*(S1 - S0)/dT]])
     
     # P derivatives
     m.set_state(P + 0.5*dP, T)
@@ -614,9 +614,9 @@ def check_eos_consistency(m, P=1.e9, T=300., tol=1.e-4, verbose=False):
 
     
     expr.extend(['C_v = Cp - alpha^2*K_T*V*T', 'K_S = K_T*Cp/Cv', 'gr = alpha*K_T*V/Cv'])
-    eq.extend([[m.heat_capacity_v, m.heat_capacity_p - m.alpha*m.alpha*m.K_T*m.V*T],
-               [m.K_S, m.K_T*m.heat_capacity_p/m.heat_capacity_v],
-               [m.gr, m.alpha*m.K_T*m.V/m.heat_capacity_v]])
+    eq.extend([[m.molar_heat_capacity_v, m.molar_heat_capacity_p - m.alpha*m.alpha*m.K_T*m.V*T],
+               [m.K_S, m.K_T*m.molar_heat_capacity_p/m.molar_heat_capacity_v],
+               [m.gr, m.alpha*m.K_T*m.V/m.molar_heat_capacity_v]])
 
 
     expr.extend(['Vphi = np.sqrt(K_S/rho)', 'Vp = np.sqrt((K_S + 4G/3)/rho)', 'Vs = np.sqrt(G_S/rho)'])

--- a/contrib/CHRU2014/paper_benchmark.py
+++ b/contrib/CHRU2014/paper_benchmark.py
@@ -99,7 +99,7 @@ def check_slb_fig7_txt():
         vol_comp[i] = 100. * (forsterite.molar_volume * 1.e6 - vol[i]) / vol[i]
         alpha_comp[i] = 100. * (
             forsterite.thermal_expansivity / 1.e-5 - alpha[i]) / (alpha[-1])
-        Cp_comp[i] = 100. * (forsterite.heat_capacity_p /
+        Cp_comp[i] = 100. * (forsterite.molar_heat_capacity_p /
                              forsterite.params['molar_mass'] / 1000. - Cp[i]) / (Cp[-1])
         gr_comp[i] = (forsterite.grueneisen_parameter - gr[i]) / gr[i]
 

--- a/contrib/eos_fitting/eos_fitting.py
+++ b/contrib/eos_fitting/eos_fitting.py
@@ -45,8 +45,8 @@ if __name__ == "__main__":
     H
     S
     V
-    heat_capacity_p
-    heat_capacity_v
+    molar_heat_capacity_p
+    molar_heat_capacity_v
     p_wave_velocity
     s_wave_velocity
     K_T

--- a/contrib/ipython/Create_1D_ASPECT_profile.ipynb
+++ b/contrib/ipython/Create_1D_ASPECT_profile.ipynb
@@ -298,7 +298,7 @@
     "    isentrope_spline = UnivariateSpline(pressures, temperatures)\n",
     "\n",
     "    # Properties can then be calculated along the isentrope\n",
-    "    properties = rock.evaluate(['V', 'rho', 'heat_capacity_p',\n",
+    "    properties = rock.evaluate(['V', 'rho', 'molar_heat_capacity_p',\n",
     "                                'thermal_expansivity', 'isothermal_compressibility',\n",
     "                                'p_wave_velocity', 'shear_wave_velocity'],\n",
     "                               pressures, temperatures)\n",

--- a/examples/example_fit_data.py
+++ b/examples/example_fit_data.py
@@ -144,9 +144,9 @@ if __name__ == "__main__":
     # Plot models
     temperatures = np.linspace(200., 2000., 101)
     pressures = np.array([298.15] * len(temperatures))
-    plt.plot(temperatures, per_HP.evaluate(['heat_capacity_p'], pressures, temperatures)[0], linestyle='--', label='HP')
-    plt.plot(temperatures, per_SLB.evaluate(['heat_capacity_p'], pressures, temperatures)[0], linestyle='--', label='SLB')
-    plt.plot(temperatures, per_opt.evaluate(['heat_capacity_p'], pressures, temperatures)[0], label='Optimised fit')
+    plt.plot(temperatures, per_HP.evaluate(['molar_heat_capacity_p'], pressures, temperatures)[0], linestyle='--', label='HP')
+    plt.plot(temperatures, per_SLB.evaluate(['molar_heat_capacity_p'], pressures, temperatures)[0], linestyle='--', label='SLB')
+    plt.plot(temperatures, per_opt.evaluate(['molar_heat_capacity_p'], pressures, temperatures)[0], label='Optimised fit')
 
     plt.legend(loc='lower right')
     plt.xlim(0., temperatures[-1])

--- a/examples/example_fit_eos.py
+++ b/examples/example_fit_eos.py
@@ -200,11 +200,11 @@ if __name__ == "__main__":
 
     temperatures = np.linspace(200., 2000., 101)
     pressures = np.array([298.15] * len(temperatures))
-    plt.plot(temperatures, per_HP.evaluate(['heat_capacity_p'], pressures, temperatures)[0], linestyle='--', label='HP')
-    plt.plot(temperatures, per_SLB.evaluate(['heat_capacity_p'], pressures, temperatures)[0], linestyle='--', label='SLB')
+    plt.plot(temperatures, per_HP.evaluate(['molar_heat_capacity_p'], pressures, temperatures)[0], linestyle='--', label='HP')
+    plt.plot(temperatures, per_SLB.evaluate(['molar_heat_capacity_p'], pressures, temperatures)[0], linestyle='--', label='SLB')
 
     temperatures = np.linspace(200., 1200., 101)
-    plt.plot(temperatures, per_opt.evaluate(['heat_capacity_p'], pressures, temperatures)[0], label='Optimised fit')
+    plt.plot(temperatures, per_opt.evaluate(['molar_heat_capacity_p'], pressures, temperatures)[0], label='Optimised fit')
     
     plt.legend(loc='lower right')
     plt.xlim(0., temperatures[-1])
@@ -294,9 +294,9 @@ if __name__ == "__main__":
     per_HP = burnman.minerals.HP_2011_ds62.per()
     temperatures = np.linspace(200., 2000., 101)
     pressures = np.array([298.15] * len(temperatures))
-    plt.plot(temperatures, per_HP.evaluate(['heat_capacity_p'], pressures, temperatures)[0], linestyle='--', label='HP')
-    plt.plot(temperatures, per_SLB.evaluate(['heat_capacity_p'], pressures, temperatures)[0], linestyle='--', label='SLB')
-    plt.plot(temperatures, per_opt.evaluate(['heat_capacity_p'], pressures, temperatures)[0], label='Optimised fit')
+    plt.plot(temperatures, per_HP.evaluate(['molar_heat_capacity_p'], pressures, temperatures)[0], linestyle='--', label='HP')
+    plt.plot(temperatures, per_SLB.evaluate(['molar_heat_capacity_p'], pressures, temperatures)[0], linestyle='--', label='SLB')
+    plt.plot(temperatures, per_opt.evaluate(['molar_heat_capacity_p'], pressures, temperatures)[0], label='Optimised fit')
 
     plt.legend(loc='lower right')
     plt.xlim(0., temperatures[-1])

--- a/examples/example_geodynamic_adiabat.py
+++ b/examples/example_geodynamic_adiabat.py
@@ -148,7 +148,7 @@ temperatures = isentrope(rock, pressures, entropy, potential_temperature)
 isentrope = UnivariateSpline(pressures, temperatures)
 
 # Properties can then be calculated along the isentrope
-properties = rock.evaluate(['V', 'rho', 'heat_capacity_p',
+properties = rock.evaluate(['V', 'rho', 'molar_heat_capacity_p',
                             'thermal_expansivity', 'isothermal_compressibility',
                             'p_wave_velocity', 'shear_wave_velocity'],
                            pressures, temperatures)

--- a/misc/benchmarks/ab_initio_liquids.py
+++ b/misc/benchmarks/ab_initio_liquids.py
@@ -59,7 +59,7 @@ for i, (phase, n_atoms, temperatures, volumes) in enumerate([(SiO2_liq, 3., SiO2
         for j, volume in enumerate(volumes):
             pressures[j]=phase.method.pressure(temperature, volume, phase.params)
             entropies[j]=phase.method._S_el(temperature, volume, phase.params)
-            energies[j]=phase.method.internal_energy(0., temperature, volume, phase.params)
+            energies[j]=phase.method.molar_internal_energy(0., temperature, volume, phase.params)
 
         ax_P.plot(volumes*1.e6, pressures/1.e9, linewidth=2, label='{0:.0f} K'.format(temperature))
         ax_S.plot(volumes*1.e6, entropies/n_atoms/constants.gas_constant, linewidth=2, label='{0:.0f} K'.format(temperature))

--- a/misc/benchmarks/ab_initio_solids.py
+++ b/misc/benchmarks/ab_initio_solids.py
@@ -56,7 +56,7 @@ for name, phase, PVT_range, EVT_range in phases:
     energies=np.empty_like(volumes)
     for temperature in temperatures:
         for i, volume in enumerate(volumes):
-            energies[i]=phase.method.internal_energy(0., temperature, volume, phase.params)
+            energies[i]=phase.method.molar_internal_energy(0., temperature, volume, phase.params)
         ax_E.plot(volumes*1e6, energies/1e3, linewidth=2, label='{0:.0f} K'.format(temperature))
 
     ax_E.legend(loc='upper right')

--- a/misc/benchmarks/benchmark.py
+++ b/misc/benchmarks/benchmark.py
@@ -353,7 +353,7 @@ def check_slb_fig7_txt():
         vol_comp[i] = 100. * (forsterite.molar_volume * 1.e6 - vol[i]) / vol[i]
         alpha_comp[i] = 100. * (
             forsterite.thermal_expansivity / 1.e-5 - alpha[i]) / (alpha[-1])
-        Cp_comp[i] = 100. * (forsterite.heat_capacity_p /
+        Cp_comp[i] = 100. * (forsterite.molar_heat_capacity_p /
                              forsterite.params['molar_mass'] / 1000. - Cp[i]) / (Cp[-1])
         gr_comp[i] = (forsterite.grueneisen_parameter - gr[i]) / gr[i]
         gibbs_comp[i] = 100. * (
@@ -423,7 +423,7 @@ def check_slb_fig7():
         volume[i] = forsterite.molar_volume / forsterite.params['V_0']
         bulk_modulus[i] = forsterite.adiabatic_bulk_modulus / Ks_0
         shear_modulus[i] = forsterite.shear_modulus / forsterite.params['G_0']
-        heat_capacity[i] = forsterite.heat_capacity_p / forsterite.params['n']
+        heat_capacity[i] = forsterite.molar_heat_capacity_p / forsterite.params['n']
 
     # compare with figure 7
     fig1 = mpimg.imread('../../burnman/data/input_figures/slb_fig7_vol.png')

--- a/misc/benchmarks/debye.py
+++ b/misc/benchmarks/debye.py
@@ -36,7 +36,7 @@ time_old = time.clock() - start
 new = np.empty_like(temperatures)
 start = time.clock()
 for i in range(len(temperatures)):
-    new[i] = burnman.eos.debye.heat_capacity_v(temperatures[i], Debye_T, 1.0)
+    new[i] = burnman.eos.debye.molar_heat_capacity_v(temperatures[i], Debye_T, 1.0)
 time_new = time.clock() - start
 
 print("error %e" % np.linalg.norm((old - new) / new))
@@ -50,7 +50,7 @@ Debye_T = 1000.
 for i in range(len(temperatures)):
     vibrational_energy[i] = burnman.eos.debye.thermal_energy(
         temperatures[i], Debye_T, 1.0)
-    heat_capacity[i] = burnman.eos.debye.heat_capacity_v(
+    heat_capacity[i] = burnman.eos.debye.molar_heat_capacity_v(
         temperatures[i], Debye_T, 1.0)
 
 plt.subplot(121)

--- a/misc/benchmarks/liquid_iron_comparison.py
+++ b/misc/benchmarks/liquid_iron_comparison.py
@@ -25,7 +25,7 @@ densities = [5.e3,10.e3, 15.e3]
 for rho in densities:
     V = m/rho
     for i, T in enumerate(temperatures):
-        Cvs[i] = liq.method.heat_capacity_v(0., T, V, liq.params)/burnman.constants.gas_constant
+        Cvs[i] = liq.method.molar_heat_capacity_v(0., T, V, liq.params)/burnman.constants.gas_constant
 
     plt.plot(temperatures, Cvs)
 

--- a/tests/test_composite.py
+++ b/tests/test_composite.py
@@ -174,11 +174,11 @@ class composite(BurnManTest):
         self.assertFloatEqual(H3, 0.4 * enthalpy1 + 0.6 * enthalpy2)
 
         # Energy
-        internal_energy1 = mineral1.internal_energy
-        internal_energy2 = mineral2.internal_energy
-        U1 = rock1.internal_energy
-        U2 = rock2.internal_energy
-        U3 = rock3.internal_energy
+        internal_energy1 = mineral1.molar_internal_energy
+        internal_energy2 = mineral2.molar_internal_energy
+        U1 = rock1.molar_internal_energy
+        U2 = rock2.molar_internal_energy
+        U3 = rock3.molar_internal_energy
         self.assertFloatEqual(U1, internal_energy1)
         self.assertFloatEqual(U2, internal_energy2)
         self.assertFloatEqual(
@@ -297,8 +297,8 @@ class composite(BurnManTest):
         self.assertFloatEqual(
             rock1.grueneisen_parameter, min1.params['grueneisen_0'])
         self.assertFloatEqual(rock1.thermal_expansivity, min1.alpha)
-        self.assertFloatEqual(rock1.heat_capacity_v, min1.C_v)
-        self.assertFloatEqual(rock1.heat_capacity_p, min1.C_p)
+        self.assertFloatEqual(rock1.molar_heat_capacity_v, min1.C_v)
+        self.assertFloatEqual(rock1.molar_heat_capacity_p, min1.C_p)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_debye.py
+++ b/tests/test_debye.py
@@ -48,7 +48,7 @@ class Debye(BurnManTest):
         test_helmholtz = burnman.eos.debye.helmholtz_free_energy(
             x, rock.params['Debye_0'], rock.params['n'])
         self.assertFloatEqual(test_helmholtz, 0.)
-        test_heat_capacity_v = burnman.eos.debye.heat_capacity_v(
+        test_heat_capacity_v = burnman.eos.debye.molar_heat_capacity_v(
             x, rock.params['Debye_0'], rock.params['n'])
         self.assertFloatEqual(test_heat_capacity_v, 0.)
         test_thermal_energy = burnman.eos.debye.thermal_energy(
@@ -61,7 +61,7 @@ class Debye(BurnManTest):
         test_helmholtz = burnman.eos.debye.helmholtz_free_energy(
             x, rock.params['Debye_0'], rock.params['n'])
         self.assertFloatEqual(test_helmholtz, 0.)
-        test_heat_capacity_v = burnman.eos.debye.heat_capacity_v(
+        test_heat_capacity_v = burnman.eos.debye.molar_heat_capacity_v(
             x, rock.params['Debye_0'], rock.params['n'])
         self.assertFloatEqual(test_heat_capacity_v, 0.)
         test_thermal_energy = burnman.eos.debye.thermal_energy(

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -55,11 +55,11 @@ class test_decorators__material_property(BurnManTest):
         self.assertEqual(
             self.MyCountingMaterial.some_property.__doc__, "my documentation")
 
-        internal_energy_doc = burnman.Material.internal_energy.__doc__
+        internal_energy_doc = burnman.Material.molar_internal_energy.__doc__
         self.assertTrue("internal energy of" in internal_energy_doc)
 
-        self.assertEqual(self.MyCountingMaterial.internal_energy.__doc__,
-                         burnman.Material.internal_energy.__doc__)
+        self.assertEqual(self.MyCountingMaterial.molar_internal_energy.__doc__,
+                         burnman.Material.molar_internal_energy.__doc__)
 
         pressure_doc = burnman.Material.pressure.__doc__
         self.assertTrue("current pressure" in pressure_doc)

--- a/tests/test_endmembers.py
+++ b/tests/test_endmembers.py
@@ -104,8 +104,8 @@ class test_endmembers(BurnManTest):
         self.assertFloatEqual(bdg.molar_volume, bdg.params['V_0'])
         self.assertFloatEqual(bdg.shear_modulus, bdg.params['G_0'])
         bdg.set_state(1.e5, 0.)
-        self.assertFloatEqual(bdg.heat_capacity_v, 0.)
-        self.assertFloatEqual(bdg.heat_capacity_p, 0.)
+        self.assertFloatEqual(bdg.molar_heat_capacity_v, 0.)
+        self.assertFloatEqual(bdg.molar_heat_capacity_p, 0.)
         self.assertFloatEqual(bdg.thermal_expansivity, 0.)
         self.assertFloatEqual(
             bdg.isothermal_bulk_modulus, bdg.adiabatic_bulk_modulus)

--- a/tests/test_eos.py
+++ b/tests/test_eos.py
@@ -142,19 +142,19 @@ class eos(BurnManTest):
                 Density_test, rock.params['molar_mass'] / rock.params['V_0'])
             alpha_test = i.thermal_expansivity(
                 pressure, temperature, rock.params['V_0'], rock.params)
-            Cp_test = i.heat_capacity_p(
+            Cp_test = i.molar_heat_capacity_p(
                 pressure, temperature, rock.params['V_0'], rock.params)
-            Cv_test = i.heat_capacity_v(
+            Cv_test = i.molar_heat_capacity_v(
                 pressure, temperature, rock.params['V_0'], rock.params)
             Grun_test = i.grueneisen_parameter(
                 pressure, temperature, rock.params['V_0'], rock.params)
 
         eoses_thermal = [burnman.eos.SLB2(), burnman.eos.SLB3()]
         for i in eoses_thermal:
-            Cp_test = i.heat_capacity_p(
+            Cp_test = i.molar_heat_capacity_p(
                 pressure, temperature, rock.params['V_0'], rock.params)
             self.assertFloatEqual(Cp_test, 37.076768469502042)
-            Cv_test = i.heat_capacity_v(
+            Cv_test = i.molar_heat_capacity_v(
                 pressure, temperature, rock.params['V_0'], rock.params)
             self.assertFloatEqual(Cv_test, 36.577717628901553)
             alpha_test = i.thermal_expansivity(
@@ -346,7 +346,7 @@ class test_eos_validation(BurnManTest):
             m.params['equation_of_state'] = eos
             burnman.Mineral.__init__(m)
             m.set_state(m.params['P_0'], m.params['T_0'])
-            energies.append(m.internal_energy)
+            energies.append(m.molar_internal_energy)
         
         self.assertArraysAlmostEqual(energies, [m.params['E_0']]*len(energies))
     
@@ -373,7 +373,7 @@ class test_eos_validation(BurnManTest):
             pressures = [P_0 - 0.5*dP, P_0, P_0 + 0.5*dP]
             temperatures = [0., 0., 0.]
 
-            E, G, H, A, V = m.evaluate(['internal_energy', 'gibbs', 'H', 'helmholtz', 'V'], pressures, temperatures)
+            E, G, H, A, V = m.evaluate(['molar_internal_energy', 'gibbs', 'H', 'helmholtz', 'V'], pressures, temperatures)
             
             calculated.append(P_0)
             derivative.append(-(E[2] - E[0])/(V[2] - V[0]))

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -77,9 +77,9 @@ class test_model(BurnManTest):
 
     def test_heatstuff1(self):
         m = self.model1()
-        self.assertArraysAlmostEqual(m.heat_capacity_p(), [52.32175110])
+        self.assertArraysAlmostEqual(m.molar_heat_capacity_p(), [52.32175110])
         self.assertArraysAlmostEqual(m.thermal_expansivity(), [2.40018801e-05])
-        self.assertArraysAlmostEqual(m.heat_capacity_v(), [49.3424724])
+        self.assertArraysAlmostEqual(m.molar_heat_capacity_v(), [49.3424724])
 
         # reproduce by hand:
         min = m.rock
@@ -87,22 +87,22 @@ class test_model(BurnManTest):
         self.assertArraysAlmostEqual(
             m.thermal_expansivity(), [min.thermal_expansivity])
         self.assertArraysAlmostEqual(
-            m.heat_capacity_v(), [min.heat_capacity_v])
+            m.molar_heat_capacity_v(), [min.molar_heat_capacity_v])
         self.assertArraysAlmostEqual(
-            m.heat_capacity_p(), [min.heat_capacity_p])
+            m.molar_heat_capacity_p(), [min.molar_heat_capacity_p])
 
     def test_heat2(self):
         m1 = self.model1()
         m2 = self.model2()
         m12 = self.model12()
 
-        self.assertArraysAlmostEqual(m1.heat_capacity_v(), [49.34247236])
-        self.assertArraysAlmostEqual(m2.heat_capacity_v(), [49.3490106])
-        self.assertArraysAlmostEqual(m12.heat_capacity_v(), [49.34770297])
+        self.assertArraysAlmostEqual(m1.molar_heat_capacity_v(), [49.34247236])
+        self.assertArraysAlmostEqual(m2.molar_heat_capacity_v(), [49.3490106])
+        self.assertArraysAlmostEqual(m12.molar_heat_capacity_v(), [49.34770297])
 
-        self.assertArraysAlmostEqual(m1.heat_capacity_p(), [52.32175110])
-        self.assertArraysAlmostEqual(m2.heat_capacity_p(), [52.77694375])
-        self.assertArraysAlmostEqual(m12.heat_capacity_p(), [52.68590522])
+        self.assertArraysAlmostEqual(m1.molar_heat_capacity_p(), [52.32175110])
+        self.assertArraysAlmostEqual(m2.molar_heat_capacity_p(), [52.77694375])
+        self.assertArraysAlmostEqual(m12.molar_heat_capacity_p(), [52.68590522])
 
         self.assertArraysAlmostEqual(m1.thermal_expansivity(), [2.40018801e-5])
         self.assertArraysAlmostEqual(m2.thermal_expansivity(), [2.74743810e-5])

--- a/tests/test_perplex.py
+++ b/tests/test_perplex.py
@@ -25,7 +25,7 @@ class PerpleX(BurnManTest):
         
     def test_grueneisen(self):
 
-        gr, alpha, V, K_S, cp = rock.evaluate(['grueneisen_parameter', 'alpha', 'V', 'adiabatic_bulk_modulus', 'heat_capacity_p'],
+        gr, alpha, V, K_S, cp = rock.evaluate(['grueneisen_parameter', 'alpha', 'V', 'adiabatic_bulk_modulus', 'molar_heat_capacity_p'],
                                               [10.e9, 11.e9], [2000., 2000.])
         self.assertArraysAlmostEqual(gr, alpha*V*K_S/cp)
 


### PR DESCRIPTION
When I added the thermodynamic properties to Material, I foolishly did not standardize my use of molar prefixes for molar properties. Specifically, `internal_energy`, `heat_capacity_p` and `heat_capacity_v` are all implicitly molar properties, not specific properties. This has the potential to cause a lot of confusion, especially for composites based on number of atoms, where the total number of moles of phases is not necessarily equal to one.  

In this PR, I change the aforementioned property names to `molar_internal_energy`, `molar_heat_capacity_p` and `molar_heat_capacity_v`

The changes to functional parts of the code can be recreated with the following sed recursive find and replace:
def heat_capacity_ -> def molar_heat_capacity_
\.heat_capacity_ -> \.molar_heat_capacity_
'heat_capacity_ -> 'molar_heat_capacity_

def internal_energy -> def molar_internal_energy
\.internal_energy -> \.molar_internal_energy
'internal_energy -> 'molar_internal_energy