### PR TITLE
adding EPOC results

### DIFF
--- a/burnman/minerals/ICL_2018.py
+++ b/burnman/minerals/ICL_2018.py
@@ -1,4 +1,3 @@
-# -*- coding: ascii -*-
 # This file is part of BurnMan - a thermoelastic and thermodynamic toolkit for the Earth and Planetary Sciences
 # Copyright (C) 2012 - 2017 by the BurnMan team, released under the GNU
 # GPL v2 or later.
@@ -8,10 +7,10 @@
 Irving et al. 2018
 ^^^^^^^^^^^^^
 
-Seismically derived EoS parameters for Earth's outer core using normal mode center frequencies.
-These parameters are derived parameterizing the outer core velocity and density with an equation-of-state, and inverting for K, K', and molar_volume (molar_mass is fixed to 0.05, as sensitivy of the normal modes is only to molar density). The equations-of-state are assumed to capture the isentropic behaviour across the outer core. Potentially, these parameters can be used to represent cores of other planets.
+Seismically derived EoS parameters for the outer core using normal mode center frequencies.
+These parameters are derived parameterizing the outer core velocity and density with an equation-of-state, and inverting for K, Kprime, and molar_volume (molar_mass is fixed to 0.05, as sensitivy of the normal modes is only to molar density). The equations-of-state are assumed to capture the isentropic behaviour across the outer core. Potentially, these parameters can be used to represent cores of other planets.
 See:
-Irving, Cottaar, Lekic (2018) Seismically determined elastic parameters for Earth’s outer core, Science Advances
+Irving, Cottaar, Lekic (2018) Seismically determined elastic parameters for the outer core, Science Advances
 
 """
 from __future__ import absolute_import

--- a/burnman/minerals/ICL_2018.py
+++ b/burnman/minerals/ICL_2018.py
@@ -1,0 +1,42 @@
+# This file is part of BurnMan - a thermoelastic and thermodynamic toolkit for the Earth and Planetary Sciences
+# Copyright (C) 2012 - 2017 by the BurnMan team, released under the GNU
+# GPL v2 or later.
+
+
+"""
+Irving et al. 2018
+^^^^^^^^^^^^^
+
+Seismically derived EoS parameters for Earth's outer core using normal mode center frequencies. 
+These parameters are derived parameterizing the outer core velocity and density with an equation-of-state, and inverting for K, K', and molar_volume (molar_mass is fixed to 0.05, as sensitivy of the normal modes is only to molar density). The equations-of-state are assumed to capture the isentropic behaviour across the outer core. Potentially, these parameters can be used to represent cores of other planets.
+See:
+Irving, Cottaar, Lekic (2018) Seismically determined elastic parameters for Earth’s outer core, Science Advances
+
+"""
+from __future__ import absolute_import
+
+from .. import mineral_helpers as helpers
+from ..mineral import Mineral
+
+
+class EPOC_vinet (Mineral):
+
+    def __init__(self):
+        self.params = {
+            'equation_of_state': 'vinet',
+            'V_0': 8.18e-6,
+            'K_0': 67.5e9,
+            'Kprime_0': 6.12,
+            'molar_mass': .05,}
+        Mineral.__init__(self)
+
+class EPOC_bm (Mineral):
+    
+    def __init__(self):
+        self.params = {
+            'equation_of_state': 'bm3',
+            'V_0': 7.63e-6,
+            'K_0': 120e9,
+            'Kprime_0': 4.6,
+            'molar_mass': .05,}
+        Mineral.__init__(self)

--- a/burnman/minerals/ICL_2018.py
+++ b/burnman/minerals/ICL_2018.py
@@ -1,3 +1,4 @@
+# -*- coding: ascii -*-
 # This file is part of BurnMan - a thermoelastic and thermodynamic toolkit for the Earth and Planetary Sciences
 # Copyright (C) 2012 - 2017 by the BurnMan team, released under the GNU
 # GPL v2 or later.
@@ -7,7 +8,7 @@
 Irving et al. 2018
 ^^^^^^^^^^^^^
 
-Seismically derived EoS parameters for Earth's outer core using normal mode center frequencies. 
+Seismically derived EoS parameters for Earth's outer core using normal mode center frequencies.
 These parameters are derived parameterizing the outer core velocity and density with an equation-of-state, and inverting for K, K', and molar_volume (molar_mass is fixed to 0.05, as sensitivy of the normal modes is only to molar density). The equations-of-state are assumed to capture the isentropic behaviour across the outer core. Potentially, these parameters can be used to represent cores of other planets.
 See:
 Irving, Cottaar, Lekic (2018) Seismically determined elastic parameters for Earth’s outer core, Science Advances

--- a/burnman/minerals/__init__.py
+++ b/burnman/minerals/__init__.py
@@ -47,5 +47,9 @@ from . import JH_2015
 
 # Kurnosov et al. 2017
 from . import KMFBZ_2017
+
+# Irving et al. 2018
+from . import ICL_2018
+
 # Other
 from . import other


### PR DESCRIPTION
EoS parameters for the outer core, derived from normal modes. These also have potential use for modelling other planetary cores. 
(I would like to use this for the cider practical)