### PR TITLE
grueneisen parameter now modified by modify_parameters

### DIFF
--- a/burnman/mineral.py
+++ b/burnman/mineral.py
@@ -277,7 +277,7 @@ class Mineral(Material):
     @material_property
     @copy_documentation(Material.grueneisen_parameter)
     def grueneisen_parameter(self):
-        return self.method.grueneisen_parameter(self.pressure, self.temperature, self.molar_volume, self.params)
+        return self.thermal_expansivity*self.isothermal_bulk_modulus*self.molar_volume/self.molar_heat_capacity_v
     
     @material_property
     @copy_documentation(Material.molar_heat_capacity_v)

--- a/burnman/mineral.py
+++ b/burnman/mineral.py
@@ -277,8 +277,24 @@ class Mineral(Material):
     @material_property
     @copy_documentation(Material.grueneisen_parameter)
     def grueneisen_parameter(self):
-        return self.thermal_expansivity*self.isothermal_bulk_modulus*self.molar_volume/self.molar_heat_capacity_v
-    
+        eps = np.finfo('float').eps
+        if np.abs(self.molar_heat_capacity_v) > eps:
+            
+            return (self.thermal_expansivity *
+                    self.isothermal_bulk_modulus *
+                    self.molar_volume /
+                    self.molar_heat_capacity_v)
+        elif ((np.abs(self._property_modifiers['d2GdPdT']) < eps) and  
+              (np.abs(self._property_modifiers['d2GdP2']) < eps) and
+              (np.abs(self._property_modifiers['dGdP']) < eps) and
+              (np.abs(self._property_modifiers['d2GdT2']) < eps)):
+            
+            return self.method.grueneisen_parameter(self.pressure, self.temperature,
+                                                    self.molar_volume, self.params)
+        else:
+            raise Exception('You are trying to calculate the grueneisen parameter at a temperature where the heat capacity is very low and where you have defined Gibbs property modifiers.')
+                
+            
     @material_property
     @copy_documentation(Material.molar_heat_capacity_v)
     def molar_heat_capacity_v(self):

--- a/burnman/minerals/Sundman_1991.py
+++ b/burnman/minerals/Sundman_1991.py
@@ -26,8 +26,7 @@ ENDMEMBERS
 class bcc_iron (Mineral):
 
     def __init__(self):
-        formula = 'Fe1.0'
-        formula = dictionarize_formula(formula)
+        formula = {'Fe': 1.0}
         self.params = {
             'name': 'BCC iron',
             'formula': formula,
@@ -41,18 +40,18 @@ class bcc_iron (Mineral):
             'Kprime_0': 5.16,
             'Kdprime_0': -3.1e-11,
             'n': sum(formula.values()),
-            'molar_mass': formula_mass(formula),
-            'curie_temperature': [1043., 0.0],
-            'magnetic_moment': [2.22, 0.0],
-            'magnetic_structural_parameter': 0.4}
+            'molar_mass': formula_mass(formula)}
+        self.property_modifiers = [
+            ['magnetic_chs', {'structural_parameter': 0.4,
+                              'curie_temperature': [1043., 0.],
+                              'magnetic_moment': [2.22, 0.]}]]
         Mineral.__init__(self)
 
 
 class fcc_iron (Mineral):
 
     def __init__(self):
-        formula = 'Fe1.0'
-        formula = dictionarize_formula(formula)
+        formula = {'Fe': 1.0}
         self.params = {
             'name': 'FCC iron',
             'formula': formula,
@@ -66,8 +65,9 @@ class fcc_iron (Mineral):
             'Kprime_0': 5.2,
             'Kdprime_0': -3.37e-11,
             'n': sum(formula.values()),
-            'molar_mass': formula_mass(formula),
-            'curie_temperature': [201., 0.0],
-            'magnetic_moment': [2.1, 0.0],
-            'magnetic_structural_parameter': 0.28}
+            'molar_mass': formula_mass(formula)}
+        self.property_modifiers = [
+            ['magnetic_chs', {'structural_parameter': 0.28,
+                              'curie_temperature': [201., 0.],
+                              'magnetic_moment': [2.1, 0.]}]]
         Mineral.__init__(self)

--- a/burnman/minerals/__init__.py
+++ b/burnman/minerals/__init__.py
@@ -52,4 +52,5 @@ from . import KMFBZ_2017
 from . import ICL_2018
 
 # Other
+from . import Sundman_1991
 from . import other

--- a/misc/ref/table.py.out
+++ b/misc/ref/table.py.out
@@ -629,6 +629,9 @@ SLB_2011_ZSB_2013.mg_perovskite                                     2.445e-05 2.
 SLB_2011_ZSB_2013.periclase                                         1.124e-05  1.61e+11      3.8      1.31e+11      2.1     0.0403 2   767.0         1.36  1.7     2.8
 SLB_2011_ZSB_2013.stishovite                                        1.402e-05  3.14e+11      3.8       2.2e+11      1.9     0.0601 3  1108.0         1.37  2.8     4.6
 SLB_2011_ZSB_2013.wuestite                                          1.226e-05  1.79e+11      4.9 59000000000.0      1.4     0.0718 2   454.0         1.53  1.7    -0.1
+Name (hp_tmt equation of state)                V_0       K_0 Kprime_0 Kdprime_0 molar_mass   n                                     Cp
+Sundman_1991.bcc_iron                     7.09e-06  1.64e+11     5.16  -3.1e-11   0.055845 1.0 [21.09, 0.0101455, -221508.0, 47.1947]
+Sundman_1991.fcc_iron            6.93863394593e-06 1.539e+11      5.2 -3.37e-11   0.055845 1.0 [22.24, 0.0088656, -221517.0, 47.1998]
 Name (aa equation of state)     T_0   S_0               V_0       K_S Kprime_S Kprime_prime_S grueneisen_0   grueneisen_prime grueneisen_n
 other.liquid_iron            1811.0 100.0 7.95626157572e-06 1.097e+11    4.661       -4.3e-11        1.735 -2.32787178798e-06        -1.87
 Name (mgd3 equation of state)         V_0       K_0 Kprime_0 G_0 Gprime_0 molar_mass n Debye_0 grueneisen_0 q_0 eta_s_0

--- a/tests/test_eos_consistency.py
+++ b/tests/test_eos_consistency.py
@@ -4,7 +4,6 @@ import os
 import sys
 
 sys.path.insert(1, os.path.abspath('..'))
-import warnings
 
 import burnman
 from burnman import minerals
@@ -16,10 +15,7 @@ class EosConsistency(BurnManTest):
     def test_HP(self):
         P = 10.e9
         T = 3000.
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            self.assertEqual(burnman.tools.check_eos_consistency(burnman.minerals.HP_2011_ds62.per(), P, T),
-                             True)
+        self.assertEqual(burnman.tools.check_eos_consistency(burnman.minerals.HP_2011_ds62.per(), P, T, including_shear_properties=False), True)
 
     def test_SLB(self):
         P = 10.e9
@@ -30,10 +26,7 @@ class EosConsistency(BurnManTest):
     def test_modifier(self):
         P = 10.e9
         T = 3000.
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            self.assertEqual(burnman.tools.check_eos_consistency(burnman.minerals.Sundman_1991.bcc_iron(), P, T),
-                             True)
+        self.assertEqual(burnman.tools.check_eos_consistency(burnman.minerals.Sundman_1991.bcc_iron(), P, T, including_shear_properties=False), True)
 
     def test_solution(self):
         P = 10.e9

--- a/tests/test_eos_consistency.py
+++ b/tests/test_eos_consistency.py
@@ -26,6 +26,14 @@ class EosConsistency(BurnManTest):
         T = 3000.
         self.assertEqual(burnman.tools.check_eos_consistency(burnman.minerals.SLB_2011.periclase(), P, T),
                          True)
+        
+    def test_modifier(self):
+        P = 10.e9
+        T = 3000.
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            self.assertEqual(burnman.tools.check_eos_consistency(burnman.minerals.Sundman_1991.bcc_iron(), P, T),
+                             True)
 
     def test_solution(self):
         P = 10.e9


### PR DESCRIPTION
The grueneisen parameter in burnman is a dependent property, and can therefore be modified by the property_modifiers. This PR fixes that issue. 

Sundman_1991.py is also updated in order to test this fix.