### PR TITLE
added including_shear_properties boolean for eos consistency check

### DIFF
--- a/burnman/tools.py
+++ b/burnman/tools.py
@@ -15,6 +15,7 @@ from scipy.ndimage.filters import gaussian_filter
 from scipy.interpolate import interp2d
 from collections import Counter
 import itertools
+import warnings
 
 from . import constants
 import itertools
@@ -629,8 +630,16 @@ def check_eos_consistency(m, P=1.e9, T=300., tol=1.e-4, verbose=False,
 
     if including_shear_properties:
         expr.extend(['Vp = np.sqrt((K_S + 4G/3)/rho)', 'Vs = np.sqrt(G_S/rho)'])
-        eq.extend([[m.p_wave_velocity, np.sqrt((m.K_S + 4.*m.G/3.)/m.rho)],
-                   [m.shear_wave_velocity, np.sqrt(m.G/m.rho)]])
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            eq.extend([[m.p_wave_velocity, np.sqrt((m.K_S + 4.*m.G/3.)/m.rho)],
+                       [m.shear_wave_velocity, np.sqrt(m.G/m.rho)]])
+            if len(w) == 1:
+                print(w[0].message)
+                print('\nYou can suppress this message by setting the '
+                      'parameter\nincluding_shear_properties to False '
+                      'when calling check_eos_consistency.\n')
         note = ''
     else:
         note = ' (not including shear properties)'

--- a/misc/benchmarks/ab_initio_liquids.py
+++ b/misc/benchmarks/ab_initio_liquids.py
@@ -34,7 +34,8 @@ for i, (phase, n_atoms, temperatures, volumes) in enumerate([(SiO2_liq, 3., SiO2
                                                              (MgO_liq, 2., MgO_temperatures,
                                                               MgO_volumes)]):
     print('EoS consistent for {0} model: {1}'.format(phase.name,
-                                                     burnman.tools.check_eos_consistency(phase, tol=1.e-4)))
+                                                     burnman.tools.check_eos_consistency(phase, tol=1.e-4,
+                                                                                         including_shear_properties=False)))
     fig = plt.figure()
     ax_P = fig.add_subplot(1,3,1)
     ax_S = fig.add_subplot(1,3,2)
@@ -77,7 +78,8 @@ for i, (phase, n_atoms, temperatures, volumes) in enumerate([(SiO2_liq, 3., SiO2
 fa_liq = burnman.minerals.RS_2014_liquids.Fe2SiO4_liquid()
 
 print('EoS consistent for {0} model: {1}'.format(fa_liq.name,
-                                                 burnman.tools.check_eos_consistency(fa_liq, tol=1.e-4)))
+                                                 burnman.tools.check_eos_consistency(fa_liq, tol=1.e-4,
+                                                                                     including_shear_properties=False)))
 fig = plt.figure()
 ax_P = fig.add_subplot(1, 2, 1)
 ax_hugoniot = fig.add_subplot(1, 2, 2)

--- a/misc/benchmarks/liquid_iron_comparison.py
+++ b/misc/benchmarks/liquid_iron_comparison.py
@@ -13,7 +13,8 @@ from scipy.optimize import fsolve
 import burnman
 
 liq = burnman.minerals.other.liquid_iron()
-burnman.tools.check_eos_consistency(liq, P=10.e9, T=7000., tol=1.e-3, verbose=True)
+burnman.tools.check_eos_consistency(liq, P=10.e9, T=7000., tol=1.e-3,
+                                    verbose=True, including_shear_properties=False)
 
 
 # Find heat capacities

--- a/misc/ref/ab_initio_liquids.py.out
+++ b/misc/ref/ab_initio_liquids.py.out
@@ -1,27 +1,3 @@
 EoS consistent for SiO2_liquid model: True
 EoS consistent for MgO_liquid model: True
 EoS consistent for Fe2SiO4_liquid model: True
-Warning from file 'BURNMAN/burnman/mineral.py', line 195:
-You are trying to calculate shear modulus for SiO2_liquid when it is exactly zero. 
-If SiO2_liquid is a liquid, then you can safely ignore this warning, but consider 
-calculating bulk modulus or bulk sound rather than Vp or Vs. 
-If SiO2_liquid is not a liquid, then shear modulus calculations for the 
-underlying equation of state (DKS_L) have not been implemented, 
-and Vp and Vs estimates will be incorrect.
-
-Warning from file 'BURNMAN/burnman/mineral.py', line 195:
-You are trying to calculate shear modulus for MgO_liquid when it is exactly zero. 
-If MgO_liquid is a liquid, then you can safely ignore this warning, but consider 
-calculating bulk modulus or bulk sound rather than Vp or Vs. 
-If MgO_liquid is not a liquid, then shear modulus calculations for the 
-underlying equation of state (DKS_L) have not been implemented, 
-and Vp and Vs estimates will be incorrect.
-
-Warning from file 'BURNMAN/burnman/mineral.py', line 195:
-You are trying to calculate shear modulus for Fe2SiO4_liquid when it is exactly zero. 
-If Fe2SiO4_liquid is a liquid, then you can safely ignore this warning, but consider 
-calculating bulk modulus or bulk sound rather than Vp or Vs. 
-If Fe2SiO4_liquid is not a liquid, then shear modulus calculations for the 
-underlying equation of state (DKS_L) have not been implemented, 
-and Vp and Vs estimates will be incorrect.
-

--- a/misc/ref/liquid_iron_comparison.py.out
+++ b/misc/ref/liquid_iron_comparison.py.out
@@ -1,5 +1,5 @@
-Checking EoS consistency for 'burnman.minerals.other.liquid_iron'
-Expressions within tolerance of 0.00100
+Checking EoS consistency for 'burnman.minerals.other.liquid_iron' (not including shear properties)
+Expressions within tolerance of 0.001000
 G = F + PV : True 
 G = H - TS : True 
 G = E - TS + PV : True 
@@ -12,8 +12,6 @@ C_v = Cp - alpha^2*K_T*V*T : True
 K_S = K_T*Cp/Cv : True 
 gr = alpha*K_T*V/Cv : True 
 Vphi = np.sqrt(K_S/rho) : True 
-Vp = np.sqrt((K_S + 4G/3)/rho) : True 
-Vs = np.sqrt(G_S/rho) : True 
 All EoS consistency constraints satisfied for 'burnman.minerals.other.liquid_iron'
 Pressure (GPa), Temperature (K), Density (kg/m^3), Grueneisen parameter
 0.0 7019 1811.0 1.7350
@@ -23,11 +21,3 @@ Pressure (GPa), Temperature (K), Density (kg/m^3), Grueneisen parameter
 277.4 12643 5816.8 1.5675
 331.5 13015 7654.8 1.5862
 397.1 13417 9826.3 1.5877
-Warning from file 'BURNMAN/burnman/mineral.py', line 195:
-You are trying to calculate shear modulus for liquid iron when it is exactly zero. 
-If liquid iron is a liquid, then you can safely ignore this warning, but consider 
-calculating bulk modulus or bulk sound rather than Vp or Vs. 
-If liquid iron is not a liquid, then shear modulus calculations for the 
-underlying equation of state (AA) have not been implemented, 
-and Vp and Vs estimates will be incorrect.
-


### PR DESCRIPTION
The EoS consistency checker has been changed so that the user can choose whether to include shear properties in its list of things to check. This is turned on by default.