### PR TITLE
fixed scipy's factorial import issue

### DIFF
--- a/burnman/eos/dks_liquid.py
+++ b/burnman/eos/dks_liquid.py
@@ -7,7 +7,11 @@ from __future__ import absolute_import
 from os import path
 import numpy as np
 import scipy.optimize as opt
-from scipy.misc import factorial
+try:
+    from scipy.misc import factorial
+except ImportError:
+    # scipy's factorial was moved in scipy 1.3.0+
+    from scipy.special import factorial
 import warnings
 
 from . import equation_of_state as eos


### PR DESCRIPTION
scipy version 1.3.0+ moved factorial from scipy.misc to scipy.special. This change will attempt to pull from misc (for older versions) and fall back to special.