### PR TITLE
avoid deprecation warnings

### DIFF
--- a/burnman/anisotropy.py
+++ b/burnman/anisotropy.py
@@ -82,7 +82,8 @@ class AnisotropicMaterial(Material):
 
     @material_property
     def full_compliance_tensor(self):
-        block = np.array(np.bmat( [[[[1.]*3]*3, [[2.]*3]*3], [[[2.]*3]*3, [[4.]*3]*3]] ))
+        block = np.block([[ np.ones((3, 3)), 2.*np.ones((3, 3))],
+                          [2.*np.ones((3, 3)), 4.*np.ones((3, 3))]])
         return self._voigt_notation_to_stiffness_tensor(np.divide(self.compliance_tensor, block))
 
     @material_property

--- a/burnman/eos/dks_liquid.py
+++ b/burnman/eos/dks_liquid.py
@@ -8,10 +8,11 @@ from os import path
 import numpy as np
 import scipy.optimize as opt
 try:
-    from scipy.misc import factorial
-except ImportError:
-    # scipy's factorial was moved in scipy 1.3.0+
+    # scipy's factorial was moved to special in scipy 1.3.0+
     from scipy.special import factorial
+except ImportError:
+    from scipy.misc import factorial
+
 import warnings
 
 from . import equation_of_state as eos

--- a/burnman/nonlinear_fitting.py
+++ b/burnman/nonlinear_fitting.py
@@ -517,7 +517,7 @@ def plot_residuals(ax, weighted_residuals, n_bins=None, flags=[]):
         try: # Only works for recent versions of numpy
             bin_heights, bin_bounds = np.histogram(weighted_residuals,
                                                    bins='auto',
-                                                   normed=1.)
+                                                   density=True)
             n_bins = len(bin_heights)
         except:
             n_bins = 11.
@@ -530,7 +530,7 @@ def plot_residuals(ax, weighted_residuals, n_bins=None, flags=[]):
         bins = np.linspace(dmin, dmax, n_bins)
         bin_heights, bin_bounds = np.histogram(weighted_residuals[mask],
                                                bins=bins,
-                                               normed=1.)
+                                               density=True)
 
         normalisation = float(len(weighted_residuals[mask]))/float(len(weighted_residuals))
         bin_centers = (bin_bounds[:-1] + bin_bounds[1:])/2.


### PR DESCRIPTION
numpy and scipy continue to improve, and this is leading to a few function moves / deprecation warnings. The following line changes keep burnman up to date.