### PR TITLE
moved path hack to own file in examples directory

### DIFF
--- a/examples/burnman_path.py
+++ b/examples/burnman_path.py
@@ -1,0 +1,6 @@
+import os
+import sys
+
+# hack to allow scripts to be placed in subdirectories next to burnman:
+if not os.path.exists('burnman') and os.path.exists('../burnman'):
+    sys.path.insert(1, os.path.abspath('..'))

--- a/examples/example_anisotropy.py
+++ b/examples/example_anisotropy.py
@@ -22,16 +22,12 @@ an elastic stiffness tensor into elastic properties.
 from __future__ import absolute_import
 from __future__ import print_function
 
-import os
-import sys
 import numpy as np
 import matplotlib.pyplot as plt
-# hack to allow scripts to be placed in subdirectories next to burnman:
-if not os.path.exists('burnman') and os.path.exists('../burnman'):
-    sys.path.insert(1, os.path.abspath('..'))
-
-import burnman
+import burnman_path  # adds the local burnman directory to the path
 from burnman import anisotropy
+
+assert burnman_path  # silence pyflakes warning
 
 if __name__ == "__main__":
 
@@ -39,10 +35,9 @@ if __name__ == "__main__":
         plt.style.use('ggplot')
         plt.rcParams['axes.facecolor'] = 'white'
         plt.rcParams['axes.edgecolor'] = 'black'
-        plt.rcParams['figure.figsize'] = 16, 10 # inches
+        plt.rcParams['figure.figsize'] = 16, 10  # inches
     except:
         pass
-
 
     # Let's first look at an isotropic material
     # As an example, let's use the lambda (C12), mu (C44) and rho

--- a/examples/example_averaging.py
+++ b/examples/example_averaging.py
@@ -34,16 +34,13 @@ of each averaging scheme.
 from __future__ import absolute_import
 from __future__ import print_function
 
-import os
-import sys
 import numpy as np
 import matplotlib.pyplot as plt
-# hack to allow scripts to be placed in subdirectories next to burnman:
-if not os.path.exists('burnman') and os.path.exists('../burnman'):
-    sys.path.insert(1, os.path.abspath('..'))
-
+import burnman_path  # adds the local burnman directory to the path
 import burnman
 from burnman import minerals
+
+assert burnman_path  # silence pyflakes warning
 
 if __name__ == "__main__":
     """ choose 'slb2' (finite-strain 2nd order shear modulus,

--- a/examples/example_beginner.py
+++ b/examples/example_beginner.py
@@ -34,15 +34,8 @@ from __future__ import absolute_import
 # usage of BurnMan.  In particular, numpy is used for handling
 # numerical arrays and mathematical operations on them, and
 # matplotlib is used for generating plots of results of calculations
-import os
-import sys
 import numpy as np
 import matplotlib.pyplot as plt
-
-# hack to allow scripts to be placed in subdirectories next to burnman:
-if not os.path.exists('burnman') and os.path.exists('../burnman'):
-    sys.path.insert(1, os.path.abspath('..'))
-
 
 # Here we import the relevant modules from BurnMan.  The burnman
 # module imports several of the most important functionalities of
@@ -50,9 +43,11 @@ if not os.path.exists('burnman') and os.path.exists('../burnman'):
 # thermoelastic properties of them.  The minerals module includes
 # the mineral physical parameters for the predefined minerals in
 # BurnMan
+import burnman_path  # adds the local burnman directory to the path
 import burnman
 from burnman import minerals
 
+assert burnman_path  # silence pyflakes warning
 
 if __name__ == "__main__":
 

--- a/examples/example_build_planet.py
+++ b/examples/example_build_planet.py
@@ -56,7 +56,6 @@ import warnings
 
 assert burnman_path  # silence pyflakes warning
 
-
 if __name__ == '__main__':
     # FIRST: we must define the composition of the planet as individual layers.
     # A layer is defined by 4 parameters: Name, min_depth, max_depth,and number of slices within the layer.

--- a/examples/example_build_planet.py
+++ b/examples/example_build_planet.py
@@ -46,18 +46,16 @@ on each of the parameters which can be called.
 from __future__ import absolute_import
 from __future__ import print_function
 
-import os
-import sys
-# hack to allow scripts to be placed in subdirectories next to burnman:
-if not os.path.exists('burnman') and os.path.exists('../burnman'):
-    sys.path.insert(1, os.path.abspath('..'))
-
 import matplotlib.pyplot as plt
 import numpy as np
 
+import burnman_path  # adds the local burnman directory to the path
 import burnman
 
 import warnings
+
+assert burnman_path  # silence pyflakes warning
+
 
 if __name__ == '__main__':
     # FIRST: we must define the composition of the planet as individual layers.

--- a/examples/example_chemical_potentials.py
+++ b/examples/example_chemical_potentials.py
@@ -19,19 +19,17 @@ This example shows how to use the chemical potentials library of functions.
 from __future__ import absolute_import
 from __future__ import print_function
 
-import os
-import sys
 import numpy as np
 import matplotlib.pyplot as plt
-# hack to allow scripts to be placed in subdirectories next to burnman:
-if not os.path.exists('burnman') and os.path.exists('../burnman'):
-    sys.path.insert(1, os.path.abspath('..'))
 
+import burnman_path  # adds the local burnman directory to the path
 import burnman
 import burnman.constants as constants
 import burnman.processchemistry as processchemistry
 import burnman.chemicalpotentials as chemical_potentials
 import burnman.minerals as minerals
+
+assert burnman_path  # silence pyflakes warning
 
 if __name__ == "__main__":
 

--- a/examples/example_compare_all_methods.py
+++ b/examples/example_compare_all_methods.py
@@ -27,16 +27,14 @@ different methods.
 from __future__ import absolute_import
 from __future__ import print_function
 
-import os
-import sys
 import numpy as np
 import matplotlib.pyplot as plt
-# hack to allow scripts to be placed in subdirectories next to burnman:
-if not os.path.exists('burnman') and os.path.exists('../burnman'):
-    sys.path.insert(1, os.path.abspath('..'))
 
+import burnman_path  # adds the local burnman directory to the path
 import burnman
 from burnman import minerals
+
+assert burnman_path  # silence pyflakes warning
 
 if __name__ == "__main__":
     # Input composition.

--- a/examples/example_composite_seismic_velocities.py
+++ b/examples/example_composite_seismic_velocities.py
@@ -44,16 +44,15 @@ example_spintransition.py for explanation of how to implement this
 from __future__ import absolute_import
 from __future__ import print_function
 
-import os
-import sys
 import numpy as np
 import matplotlib.pyplot as plt
-# hack to allow scripts to be placed in subdirectories next to burnman:
-if not os.path.exists('burnman') and os.path.exists('../burnman'):
-    sys.path.insert(1, os.path.abspath('..'))
+
+import burnman_path  # adds the local burnman directory to the path
 
 import burnman
 from burnman import minerals
+
+assert burnman_path  # silence pyflakes warning
 
 if __name__ == "__main__":
 

--- a/examples/example_composition.py
+++ b/examples/example_composition.py
@@ -24,16 +24,7 @@ This example script demonstrates the use of BurnMan's Composition class.
 from __future__ import absolute_import
 from __future__ import print_function
 
-import os
-import sys
-import numpy as np
-import matplotlib.pyplot as plt
-
-# hack to allow scripts to be placed in subdirectories next to burnman:
-if not os.path.exists('burnman') and os.path.exists('../burnman'):
-    sys.path.insert(1, os.path.abspath('..'))
-
-import burnman
+import burnman_path
 from burnman.processchemistry import dictionarize_formula
 
 # Import the Composition class and a function to read compositions from file
@@ -42,6 +33,8 @@ from burnman.processchemistry import dictionarize_formula
 # All lines after the first are either molar or weight proportions
 # of the components given in the header, followed by the comment string
 from burnman.composition import file_to_composition_list, Composition
+
+assert burnman_path  # silence pyflakes warning
 
 if __name__ == "__main__":
     print('1) Creating a Composite instance, printing '

--- a/examples/example_dataset_uncertainties.py
+++ b/examples/example_dataset_uncertainties.py
@@ -25,20 +25,17 @@ from __future__ import absolute_import
 
 # Here we import standard python modules that are required for
 # usage of BurnMan.
-import os
-import sys
 import numpy as np
 import matplotlib.pyplot as plt
 
-# hack to allow scripts to be placed in subdirectories next to burnman:
-if not os.path.exists('burnman') and os.path.exists('../burnman'):
-    sys.path.insert(1, os.path.abspath('..'))
 
-
+import burnman_path  # adds the local burnman directory to the path
 # Here we import the relevant modules from BurnMan.
-import burnman
 from burnman.minerals import HP_2011_ds62
-from burnman.nonlinear_fitting import plot_cov_ellipse # for plotting
+from burnman.nonlinear_fitting import plot_cov_ellipse  # for plotting
+
+assert burnman_path  # silence pyflakes warning
+
 
 plt.style.use('ggplot')
 

--- a/examples/example_dataset_uncertainties.py
+++ b/examples/example_dataset_uncertainties.py
@@ -36,7 +36,6 @@ from burnman.nonlinear_fitting import plot_cov_ellipse  # for plotting
 
 assert burnman_path  # silence pyflakes warning
 
-
 plt.style.use('ggplot')
 
 # First, we read in the covariance matrix

--- a/examples/example_fit_data.py
+++ b/examples/example_fit_data.py
@@ -20,18 +20,15 @@ teaches:
 """
 from __future__ import absolute_import
 from __future__ import print_function
-import os
-import sys
+
 import numpy as np
 import matplotlib.pyplot as plt
 
-# hack to allow scripts to be placed in subdirectories next to burnman:
-if not os.path.exists('burnman') and os.path.exists('../burnman'):
-    sys.path.insert(1, os.path.abspath('..'))
-
+import burnman_path  # adds the local burnman directory to the path
 import burnman
-
 import warnings
+
+assert burnman_path  # silence pyflakes warning
 
 if __name__ == "__main__":
 

--- a/examples/example_fit_eos.py
+++ b/examples/example_fit_eos.py
@@ -21,17 +21,13 @@ teaches:
 from __future__ import absolute_import
 from __future__ import print_function
 
-import os
-import sys
 import numpy as np
 import matplotlib.pyplot as plt
-import matplotlib.colors as colors
 
-# hack to allow scripts to be placed in subdirectories next to burnman:
-if not os.path.exists('burnman') and os.path.exists('../burnman'):
-    sys.path.insert(1, os.path.abspath('..'))
-
+import burnman_path  # adds the local burnman directory to the path
 import burnman
+
+assert burnman_path  # silence pyflakes warning
 
 if __name__ == "__main__":
 

--- a/examples/example_geodynamic_adiabat.py
+++ b/examples/example_geodynamic_adiabat.py
@@ -40,24 +40,19 @@ volume in order to create smoothly varying relaxed properties.
 from __future__ import absolute_import
 from __future__ import print_function
 
-import os
-import sys
-
 import numpy as np
 import matplotlib.pyplot as plt
 
-# hack to allow scripts to be placed in subdirectories next to burnman:
-if not os.path.exists('burnman') and os.path.exists('../burnman'):
-    sys.path.insert(1, os.path.abspath('..'))
-
-
+import burnman_path  # adds the local burnman directory to the path
 import burnman
 from scipy.optimize import fsolve, brentq
 from scipy.integrate import odeint
 from scipy.interpolate import UnivariateSpline
 
+assert burnman_path  # silence pyflakes warning
 
-# Define fitting function to find the temperature along the isentrope
+
+#  Define fitting function to find the temperature along the isentrope
 def isentrope(rock, pressures, entropy, T_guess):
     def _deltaS(T, S, P, rock):
         rock.set_state(P, T)

--- a/examples/example_geodynamic_adiabat.py
+++ b/examples/example_geodynamic_adiabat.py
@@ -51,7 +51,6 @@ from scipy.interpolate import UnivariateSpline
 
 assert burnman_path  # silence pyflakes warning
 
-
 #  Define fitting function to find the temperature along the isentrope
 def isentrope(rock, pressures, entropy, T_guess):
     def _deltaS(T, S, P, rock):

--- a/examples/example_geotherms.py
+++ b/examples/example_geotherms.py
@@ -31,16 +31,15 @@ These are:
 """
 from __future__ import absolute_import
 
-import os
-import sys
 import numpy as np
 import matplotlib.pyplot as plt
-# hack to allow scripts to be placed in subdirectories next to burnman:
-if not os.path.exists('burnman') and os.path.exists('../burnman'):
-    sys.path.insert(1, os.path.abspath('..'))
+
+import burnman_path  # adds the local burnman directory to the path
 
 import burnman
 from burnman import minerals
+
+assert burnman_path  # silence pyflakes warning
 
 if __name__ == "__main__":
     # we want to evaluate several geotherms at these values

--- a/examples/example_gibbs_modifiers.py
+++ b/examples/example_gibbs_modifiers.py
@@ -51,7 +51,6 @@ from burnman import minerals
 
 assert burnman_path  # silence pyflakes warning
 
-
 if __name__ == "__main__":
 
     # Here we show the interesting features of Landau transitions

--- a/examples/example_gibbs_modifiers.py
+++ b/examples/example_gibbs_modifiers.py
@@ -35,15 +35,10 @@ from __future__ import absolute_import
 # usage of BurnMan.  In particular, numpy is used for handling
 # numerical arrays and mathematical operations on them, and
 # matplotlib is used for generating plots of results of calculations
-import os
-import sys
 import numpy as np
 import matplotlib.pyplot as plt
 
-# hack to allow scripts to be placed in subdirectories next to burnman:
-if not os.path.exists('burnman') and os.path.exists('../burnman'):
-    sys.path.insert(1, os.path.abspath('..'))
-
+import burnman_path  # adds the local burnman directory to the path
 
 # Here we import the relevant modules from BurnMan.  The burnman
 # module imports several of the most important functionalities of
@@ -53,6 +48,8 @@ if not os.path.exists('burnman') and os.path.exists('../burnman'):
 # BurnMan
 import burnman
 from burnman import minerals
+
+assert burnman_path  # silence pyflakes warning
 
 
 if __name__ == "__main__":

--- a/examples/example_grid.py
+++ b/examples/example_grid.py
@@ -16,20 +16,17 @@ from __future__ import print_function
 # usage of BurnMan.  In particular, numpy is used for handling
 # numerical arrays and mathematical operations on them, and
 # matplotlib is used for generating plots of results of calculations
-import os
-import sys
 import numpy as np
 import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d import Axes3D
 from matplotlib import cm
 
-
-# hack to allow scripts to be placed in subdirectories next to burnman:
-if not os.path.exists('burnman') and os.path.exists('../burnman'):
-    sys.path.insert(1, os.path.abspath('..'))
+import burnman_path  # adds the local burnman directory to the path
 
 import burnman
 from burnman import minerals
+
+assert burnman_path  # silence pyflakes warning
 
 if __name__ == "__main__":
 

--- a/examples/example_inv_murakami.py
+++ b/examples/example_inv_murakami.py
@@ -4,13 +4,11 @@ from __future__ import print_function
 # Copyright (C) 2012 - 2015 by the BurnMan team, released under the GNU
 # GPL v2 or later.
 
-import os
 import sys
 import numpy as np
 import matplotlib.pyplot as plt
-# hack to allow scripts to be placed in subdirectories next to burnman:
-if not os.path.exists('burnman') and os.path.exists('../burnman'):
-    sys.path.insert(1, os.path.abspath('..'))
+
+import burnman_path  # adds the local burnman directory to the path
 
 import burnman
 from burnman import minerals
@@ -20,6 +18,7 @@ import cProfile
 import scipy.stats as sp
 import matplotlib.mlab as mlab
 
+assert burnman_path  # silence pyflakes warning
 
 if __name__ == "__main__":
     seismic_model = burnman.seismic.PREM()

--- a/examples/example_layer.py
+++ b/examples/example_layer.py
@@ -43,9 +43,9 @@ import burnman_path  # adds the local burnman directory to the path
 # Here we import the relevant modules from BurnMan.
 import burnman
 from burnman import minerals
+import warnings
 
 assert burnman_path  # silence pyflakes warning
-import warnings
 
 if __name__ == "__main__":
     # This is the first actual work done in this example.  We define

--- a/examples/example_layer.py
+++ b/examples/example_layer.py
@@ -35,20 +35,16 @@ from __future__ import absolute_import
 
 # Here we import standard python modules that are required for
 # usage of BurnMan.
-import os
-import sys
 import numpy as np
 import matplotlib.pyplot as plt
 
-# hack to allow scripts to be placed in subdirectories next to burnman:
-if not os.path.exists('burnman') and os.path.exists('../burnman'):
-    sys.path.insert(1, os.path.abspath('..'))
-
+import burnman_path  # adds the local burnman directory to the path
 
 # Here we import the relevant modules from BurnMan.
 import burnman
 from burnman import minerals
 
+assert burnman_path  # silence pyflakes warning
 import warnings
 
 if __name__ == "__main__":

--- a/examples/example_optimize_pv.py
+++ b/examples/example_optimize_pv.py
@@ -29,16 +29,15 @@ seismic data against PREM. For more extensive comments on this setup, see tutori
 from __future__ import absolute_import
 from __future__ import print_function
 
-import os
-import sys
 import numpy as np
 import matplotlib.pyplot as plt
-# hack to allow scripts to be placed in subdirectories next to burnman:
-if not os.path.exists('burnman') and os.path.exists('../burnman'):
-    sys.path.insert(1, os.path.abspath('..'))
+
+import burnman_path  # adds the local burnman directory to the path
 
 import burnman
 from burnman import minerals
+
+assert burnman_path  # silence pyflakes warning
 
 if __name__ == "__main__":
 

--- a/examples/example_perplex.py
+++ b/examples/example_perplex.py
@@ -23,15 +23,13 @@ It also demonstrates how we can smooth a given property on a given P-T grid.
 
 
 """
-import sys
-import os
 import numpy as np
 
-sys.path.insert(1, os.path.abspath('..'))
-
+import burnman_path  # adds the local burnman directory to the path
 import burnman
 import matplotlib.pyplot as plt
 
+assert burnman_path  # silence pyflakes warning
 
 rock=burnman.PerplexMaterial('../burnman/data/input_perplex/in23_1.tab')
 P = 1.e9

--- a/examples/example_premite_isothermal.py
+++ b/examples/example_premite_isothermal.py
@@ -15,18 +15,17 @@ teaches:
 from __future__ import absolute_import
 from __future__ import print_function
 
-import os
-import sys
 import numpy as np
 import matplotlib.pyplot as plt
-# hack to allow scripts to be placed in subdirectories next to burnman:
-if not os.path.exists('burnman') and os.path.exists('../burnman'):
-    sys.path.insert(1, os.path.abspath('..'))
+
+import burnman_path  # adds the local burnman directory to the path
 
 import burnman
 import pymc
 
-seismic_model = burnman.seismic.PREM() # pick a seismic model, see seismiic.py for details
+assert burnman_path  # silence pyflakes warning
+
+seismic_model = burnman.seismic.PREM()  # pick a seismic model, see seismiic.py for details
 number_of_points = 20  # set on how many depth slices the computations should be done
 depths = np.linspace(750.e3, 2890.e3, number_of_points)
 seis_p, seis_rho, seis_vp, seis_vs, seis_vphi = seismic_model.evaluate(

--- a/examples/example_seismic.py
+++ b/examples/example_seismic.py
@@ -38,16 +38,13 @@ here shown by importing AK135 :cite:`kennett1995`.
 from __future__ import absolute_import
 from __future__ import print_function
 
-import os
-import sys
 import numpy as np
 import matplotlib.pyplot as plt
-# hack to allow scripts to be placed in subdirectories next to burnman:
-if not os.path.exists('burnman') and os.path.exists('../burnman'):
-    sys.path.insert(1, os.path.abspath('..'))
 
+import burnman_path  # adds the local burnman directory to the path
 import burnman
 
+assert burnman_path  # silence pyflakes warning
 import warnings
 
 if __name__ == "__main__":

--- a/examples/example_seismic.py
+++ b/examples/example_seismic.py
@@ -43,9 +43,9 @@ import matplotlib.pyplot as plt
 
 import burnman_path  # adds the local burnman directory to the path
 import burnman
+import warnings
 
 assert burnman_path  # silence pyflakes warning
-import warnings
 
 if __name__ == "__main__":
 

--- a/examples/example_seismic_travel_times.py
+++ b/examples/example_seismic_travel_times.py
@@ -16,21 +16,19 @@ To find out more about the specific routines in this example see
 # Imports to be compatible with Python2 and Python3
 from __future__ import absolute_import
 from __future__ import print_function
-import os
-import sys  # Library used to interact with your operating system
+
 import numpy as np  # Library used for general array
 import matplotlib.pyplot as plt  # Library used for plotting
 # Import BurnMan
-sys.path.insert(1, os.path.abspath('../'))  # add path to burnman
+import burnman_path  # adds the local burnman directory to the path
 import burnman
 from burnman import minerals  # import mineral library seperately
-
 
 # This example relies heavily  on the ObsPy, a python seismology toolkit
 import obspy
 from obspy.taup import TauPyModel
 
-
+assert burnman_path  # silence pyflakes warning
 
 
 def plot_rays_and_times(modelname):

--- a/examples/example_solid_solution.py
+++ b/examples/example_solid_solution.py
@@ -41,16 +41,15 @@ These solid solutions can potentially deal with:
 """
 from __future__ import absolute_import
 
-import os
-import sys
 import numpy as np
 import matplotlib.pyplot as plt
-# hack to allow scripts to be placed in subdirectories next to burnman:
-if not os.path.exists('burnman') and os.path.exists('../burnman'):
-    sys.path.insert(1, os.path.abspath('..'))
+
+import burnman_path  # adds the local burnman directory to the path
 
 import burnman
 from burnman import minerals
+
+assert burnman_path  # silence pyflakes warning
 
 if __name__ == "__main__":
     '''

--- a/examples/example_spintransition.py
+++ b/examples/example_spintransition.py
@@ -29,16 +29,15 @@ defined minerals by comparing the current pressure to the transition pressure.
 from __future__ import absolute_import
 from __future__ import print_function
 
-import os
-import sys
 import numpy as np
 import matplotlib.pyplot as plt
-# hack to allow scripts to be placed in subdirectories next to burnman:
-if not os.path.exists('burnman') and os.path.exists('../burnman'):
-    sys.path.insert(1, os.path.abspath('..'))
+
+import burnman_path  # adds the local burnman directory to the path
 
 import burnman
 from burnman import minerals
+
+assert burnman_path  # silence pyflakes warning
 
 if __name__ == "__main__":
     # seismic model for comparison:

--- a/examples/example_tools.py
+++ b/examples/example_tools.py
@@ -17,24 +17,24 @@ This example demonstrates BurnMan's tools, which are currently
 from __future__ import absolute_import
 from __future__ import print_function
 
-import os
-import sys
 import numpy as np
 import matplotlib.pyplot as plt
 
-# hack to allow scripts to be placed in subdirectories next to burnman:
-if not os.path.exists('burnman') and os.path.exists('../burnman'):
-    sys.path.insert(1, os.path.abspath('..'))
-
+import burnman_path  # adds the local burnman directory to the path
 import burnman
+
+assert burnman_path  # silence pyflakes warning
+
 
 def round_to_n(x, xerr, n):
     return round(x, -int(np.floor(np.log10(np.abs(xerr)))) + (n - 1))
 
+
 if __name__ == "__main__":
 
     # First, let's check the EoS consistency of SLB_2011 periclase
-    burnman.tools.check_eos_consistency(burnman.minerals.SLB_2011.periclase(), P=10.e9, T=3000., verbose=True)
+    burnman.tools.check_eos_consistency(burnman.minerals.SLB_2011.periclase(),
+                                        P=10.e9, T=3000., verbose=True)
     print('')
 
     # Next, let's create the Mg2SiO4 phase diagram

--- a/examples/example_user_input_material.py
+++ b/examples/example_user_input_material.py
@@ -24,14 +24,11 @@ need to be input for BurnMan to calculate :math:`V_P, V_\Phi, V_S` and density a
 from __future__ import absolute_import
 from __future__ import print_function
 
-import os
-import sys
 import numpy as np
-# hack to allow scripts to be placed in subdirectories next to burnman:
-if not os.path.exists('burnman') and os.path.exists('../burnman'):
-    sys.path.insert(1, os.path.abspath('..'))
-
+import burnman_path  # adds the local burnman directory to the path
 import burnman
+
+assert burnman_path  # silence pyflakes warning
 
 # A note about units: all the material parameters are expected to be in plain SI units.
 # This means that the elastic moduli should be in Pascals and NOT Gigapascals,

--- a/examples/example_woutput.py
+++ b/examples/example_woutput.py
@@ -27,15 +27,13 @@ teaches:
 from __future__ import absolute_import
 from __future__ import print_function
 
-import os
-import sys
 import numpy as np
-# hack to allow scripts to be placed in subdirectories next to burnman:
-if not os.path.exists('burnman') and os.path.exists('../burnman'):
-    sys.path.insert(1, os.path.abspath('..'))
 
+import burnman_path  # adds the local burnman directory to the path
 import burnman
 from burnman import minerals
+
+assert burnman_path  # silence pyflakes warning
 
 if __name__ == "__main__":
     # input variables ###

--- a/examples/example_writeout_for_synthetic_seismo.py
+++ b/examples/example_writeout_for_synthetic_seismo.py
@@ -19,16 +19,16 @@ www.axisem.info
 # Imports to be compatible with Python2 and Python3
 from __future__ import absolute_import
 from __future__ import print_function
-import os
-import sys  # Library used to interact with your operating system
+
 import numpy as np  # Library used for general array
 import matplotlib.pyplot as plt  # Library used for plotting
+
 # Import BurnMan
-sys.path.insert(1, os.path.abspath('../'))  # add path to burnman
+import burnman_path  # adds the local burnman directory to the path
 import burnman
 from burnman import minerals  # import mineral library seperately
 
-
+assert burnman_path  # silence pyflakes warning
 
 if __name__ == "__main__":
 


### PR DESCRIPTION
This PR removes the ugly hack adding the local burnman path to each of the example files, and instead puts it in its own file. This makes the preamble of all the files cleaner, but doesn't change the functionality in any way.