### PR TITLE
test.sh now prints modules version numbers

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -18,6 +18,10 @@ then
 fi
 
 $PYTHON --version
+echo ""
+echo "Version numbers of required modules:"
+$PYTHON -m pip freeze | grep -f sphinx/pip_requirements.txt
+echo ""
 
 function testit {
 t=$1


### PR DESCRIPTION
Sometimes burnman functionality is highly dependent on the versions of modules used. This PR adds print statements at the start of test.sh so that the user can easily find out which version numbers the tester is using.

Useful output requires that pip be installed as a python module.