### PR TITLE
 updated files to work with python 3.9.2

### DIFF
--- a/burnman/anisotropy.py
+++ b/burnman/anisotropy.py
@@ -208,7 +208,7 @@ class AnisotropicMaterial(Material):
         plane_normal = unit_normalize(plane_normal)
         shear_direction = unit_normalize(shear_direction)
 
-        assert np.abs(plane_normal.dot(shear_direction)) < np.finfo(np.float).eps, 'plane_normal and shear_direction must be orthogonal'
+        assert np.abs(plane_normal.dot(shear_direction)) < np.finfo(float).eps, 'plane_normal and shear_direction must be orthogonal'
         Sijkl = self.full_compliance_tensor
         G = Sijkl.dot(shear_direction).dot(plane_normal).dot(shear_direction).dot(plane_normal)
         return 0.25/G
@@ -223,7 +223,7 @@ class AnisotropicMaterial(Material):
 
         axial_direction = unit_normalize(axial_direction)
         lateral_direction = unit_normalize(lateral_direction)
-        assert np.abs(axial_direction.dot(lateral_direction)) < np.finfo(np.float).eps, 'axial_direction and lateral_direction must be orthogonal'
+        assert np.abs(axial_direction.dot(lateral_direction)) < np.finfo(float).eps, 'axial_direction and lateral_direction must be orthogonal'
 
         Sijkl = self.full_compliance_tensor
         x = axial_direction

--- a/burnman/eos/debye.py
+++ b/burnman/eos/debye.py
@@ -75,9 +75,9 @@ def debye_fn(x):
     return 3. * sol[0] / pow(x, 3.)
 
 
-eps = np.finfo(np.float).eps
-sqrt_eps = np.sqrt(np.finfo(np.float).eps)
-log_eps = np.log(np.finfo(np.float).eps)
+eps = np.finfo(float).eps
+sqrt_eps = np.sqrt(np.finfo(float).eps)
+log_eps = np.log(np.finfo(float).eps)
 
 
 @jit

--- a/burnman/eos/einstein.py
+++ b/burnman/eos/einstein.py
@@ -11,7 +11,7 @@ from .. import constants
 Functions for the Einstein model of a solid.
 """
 
-eps = np.finfo(np.float).eps
+eps = np.finfo(float).eps
 
 
 def thermal_energy(T, einstein_T, n):

--- a/burnman/nonlinear_fitting.py
+++ b/burnman/nonlinear_fitting.py
@@ -439,12 +439,13 @@ def weighted_residual_plot(ax, model, flag=None, sd_limit=3, cmap=plt.cm.RdYlBu,
     else:
         mask = [i for i, flg in enumerate(model.flags) if flg == flag]
 
-    cmap.set_under('k')
-    cmap.set_over('k')
+    cmap_cp = copy.copy(cmap)
+    cmap_cp.set_under('k')
+    cmap_cp.set_over('k')
     bounds = np.linspace(-sd_limit, sd_limit, sd_limit*2+1)
-    norm = colors.BoundaryNorm(bounds, cmap.N)
+    norm = colors.BoundaryNorm(bounds, cmap_cp.N)
 
-    im = ax.scatter(model.data[:,plot_axes[0]][mask]*scale_axes[0], model.data[:,plot_axes[1]][mask]*scale_axes[1], c=model.weighted_residuals[mask], cmap=cmap, norm=norm, s=50)
+    im = ax.scatter(model.data[:,plot_axes[0]][mask]*scale_axes[0], model.data[:,plot_axes[1]][mask]*scale_axes[1], c=model.weighted_residuals[mask], cmap=cmap_cp, norm=norm, s=50)
     plt.colorbar(im, ax=ax, label='Misfit (standard deviations)')
 
 

--- a/burnman/seismic.py
+++ b/burnman/seismic.py
@@ -260,14 +260,14 @@ class SeismicTable(Seismic1DModel):
     def pressure(self, depth):
         if len(self.table_pressure) == 0:
             warnings.warn(
-                "Pressure is not given in " + self.__class__.__name__ + " and is now being computed. This will only work when density is defined for the entire planet. Use at your own risk. ")
+                "Pressure is not given in " + self.__class__.__name__ + " and is now being computed. This will only work when density is defined for the entire planet. Use at your own risk.")
             self._compute_pressure()
         return self._lookup(depth, self.table_pressure)
 
     def gravity(self, depth):
         if len(self.table_gravity) == 0:
             warnings.warn(
-                "Gravity is not given in " + self.__class__.__name__ + " and is now being computed. This will only work when density is defined for the entire planet.  Use at your own risk. ")
+                "Gravity is not given in " + self.__class__.__name__ + " and is now being computed. This will only work when density is defined for the entire planet. Use at your own risk.")
             self._compute_gravity()
         return self._lookup(depth, self.table_gravity)
 
@@ -338,19 +338,24 @@ class SeismicTable(Seismic1DModel):
         # model, otherwise values for PREM are used.
 
         density = self.table_density[::-1]
-        radii = self.table_radius[::-1]
-        g = scipy.integrate.cumtrapz(
-            constants.G *
-            4. *
-            np.pi *
-            density *
-            radii *
-            radii,
-            x=radii,
-            initial=0)
-        g[1:] = g[1:] / radii[1:] / radii[1:]
 
-        self.table_gravity = g[::-1]
+        if len(density) > 0:
+            radii = self.table_radius[::-1]
+            g = scipy.integrate.cumtrapz(
+                constants.G *
+                4. *
+                np.pi *
+                density *
+                radii *
+                radii,
+                x=radii,
+                initial=0)
+            g[1:] = g[1:] / radii[1:] / radii[1:]
+
+            self.table_gravity = g[::-1]
+        else:
+            raise ValueError('Density profile is an empty list '
+                             'in this SeismicTable instance.')
 
     def _compute_pressure(self):
         # Calculate the pressure profile based on density and gravity.  This integrates

--- a/burnman/solidsolution.py
+++ b/burnman/solidsolution.py
@@ -153,7 +153,7 @@ class SolidSolution(Mineral):
             assert(sum(molar_fractions) < 1.0001)
 
         self.reset()
-        self.molar_fractions = molar_fractions
+        self.molar_fractions = np.array(molar_fractions)
 
     def set_method(self, method):
         for i in range(self.n_endmembers):

--- a/burnman/solidsolution.py
+++ b/burnman/solidsolution.py
@@ -397,7 +397,7 @@ class SolidSolution(Mineral):
         Aliased with self.G
         """
         G_list = np.fromiter(
-            (e[0].G for e in self.endmembers), dtype=np.float, count=self.n_endmembers)
+            (e[0].G for e in self.endmembers), dtype=float, count=self.n_endmembers)
         return reuss_average_function(self.molar_fractions, G_list)
 
     @material_property

--- a/contrib/CHRU2014/paper_fit_data.py
+++ b/contrib/CHRU2014/paper_fit_data.py
@@ -35,6 +35,8 @@ import scipy.optimize as opt
 import burnman
 import misc.colors as colors
 
+import warnings
+
 # hack to allow scripts to be placed in subdirectories next to burnman:
 if not os.path.exists('burnman') and os.path.exists('../burnman'):
     sys.path.insert(1, os.path.abspath('..'))
@@ -94,7 +96,11 @@ if __name__ == "__main__":
     print("2nd order fit: G = ", sol[0] / 1.e9, "GPa\tG' = ", sol[1])
     model_vs_2nd_order_correct = calc_shear_velocities(
         sol[0], sol[1], mg_perovskite_test, pressures)
-    mg_perovskite_test.set_method("bm3")
+
+    with warnings.catch_warnings(record=True) as w:
+        mg_perovskite_test.set_method("bm3")
+        print(w[-1].message)
+
     model_vs_2nd_order_incorrect = calc_shear_velocities(
         sol[0], sol[1], mg_perovskite_test, pressures)
 
@@ -105,7 +111,11 @@ if __name__ == "__main__":
     print("3rd order fit: G = ", sol[0] / 1.e9, "GPa\tG' = ", sol[1])
     model_vs_3rd_order_correct = calc_shear_velocities(
         sol[0], sol[1], mg_perovskite_test, pressures)
-    mg_perovskite_test.set_method("bm2")
+
+    with warnings.catch_warnings(record=True) as w:
+        mg_perovskite_test.set_method("bm2")
+        print(w[-1].message)
+
     model_vs_3rd_order_incorrect = calc_shear_velocities(
         sol[0], sol[1], mg_perovskite_test, pressures)
 

--- a/contrib/eos_fitting/eos_fitting.py
+++ b/contrib/eos_fitting/eos_fitting.py
@@ -239,7 +239,7 @@ if __name__ == "__main__":
     # We can also look at the uncertainty in other properties
     # For example, let's look at the uncertainty in P wave velocities, bulk modulus, thermal expansion and thermal pressure
     def closest_factors(n):
-        d = np.int(np.floor(np.sqrt(n)))
+        d = int(np.floor(np.sqrt(n)))
         for i in reversed(range(1, d+1)):
             if (n % i) == 0:
                 return i, int(n/i)

--- a/contrib/tutorial/step_3.py
+++ b/contrib/tutorial/step_3.py
@@ -216,7 +216,7 @@ if __name__ == '__main__':
         0.4, '#bae4b3'), (0.6, '#74c476'), (0.8, '#31a354'), (1.0, '#006d2c')], gamma=0.1)
     c.set_bad('w', alpha=1.0)
     plt.imshow(
-        density_hist.transpose(), origin='low', cmap=c, interpolation='gaussian', alpha=.7,
+        density_hist.transpose(), origin='lower', cmap=c, interpolation='gaussian', alpha=.7,
         aspect=aspect_ratio, extent=[rho_xedge[0], rho_xedge[-1], rho_yedge[0], rho_yedge[-1]])
     plt.plot(pressure / 1.e9, seis_rho / 1.e3, linestyle="--",
              color='g', linewidth=2.0, label='Density')
@@ -227,7 +227,7 @@ if __name__ == '__main__':
         0.4, '#bdd7e7'), (0.6, '#6baed6'), (0.8, '#3182bd'), (1.0, '#08519c')], gamma=0.5)
     c.set_bad('w', alpha=1.0)
     plt.imshow(
-        vs_hist.transpose(), origin='low', cmap=c,  interpolation='gaussian', alpha=.7,
+        vs_hist.transpose(), origin='lower', cmap=c,  interpolation='gaussian', alpha=.7,
         aspect=aspect_ratio, extent=[vs_xedge[0], vs_xedge[-1], vs_yedge[0], vs_yedge[-1]])
     plt.plot(pressure / 1.e9, seis_vs / 1.e3, linestyle="--",
              color='b', linewidth=2.0, label='Vs')
@@ -238,7 +238,7 @@ if __name__ == '__main__':
         0.4, '#fcae91'), (0.6, '#fb6a4a'), (0.8, '#de2d26'), (1.0, '#a50f15')], gamma=0.5)
     c.set_bad('w', alpha=1.0)
     plt.imshow(
-        vphi_hist.transpose(), origin='low', cmap=c, interpolation='gaussian', alpha=.7,
+        vphi_hist.transpose(), origin='lower', cmap=c, interpolation='gaussian', alpha=.7,
         aspect=aspect_ratio, extent=[vphi_xedge[0], vphi_xedge[-1], vphi_yedge[0], vphi_yedge[-1]])
     plt.plot(pressure / 1.e9, seis_vphi / 1.e3,
              linestyle="--", color='r', linewidth=2.0, label='Vphi')

--- a/examples/example_build_planet.py
+++ b/examples/example_build_planet.py
@@ -58,6 +58,8 @@ import numpy as np
 import burnman
 import burnman.mineral_helpers as helpers
 
+import warnings
+
 if __name__ == '__main__':
     # FIRST: we must define the composition of the planet as individual layers.
     # A layer is defined by 4 parameters: Name, min_depth, max_depth,and number of slices within the layer.
@@ -111,10 +113,12 @@ if __name__ == '__main__':
     # to imitate Earth
     prem = burnman.seismic.PREM()
     premradii = 6371.e3 - prem.internal_depth_list()
-    premdensity, prempressure, premgravity,premvs,premvp = prem.evaluate(
-        ['density', 'pressure', 'gravity', 'v_s','v_p'])
 
-
+    with warnings.catch_warnings(record=True) as w:
+        premdensity, prempressure, premgravity,premvs,premvp = prem.evaluate(
+            ['density', 'pressure', 'gravity', 'v_s','v_p'])
+        print(w[-1].message)
+    
     # Now let's plot everything up
 
     # Optional prettier plotting

--- a/examples/example_fit_data.py
+++ b/examples/example_fit_data.py
@@ -32,6 +32,8 @@ if not os.path.exists('burnman') and os.path.exists('../burnman'):
 
 import burnman
 
+import warnings
+
 if __name__ == "__main__":
 
     # 1) Fitting shear modulus and its derivative to shear wave velocity data
@@ -69,7 +71,10 @@ if __name__ == "__main__":
     burnman.tools.pretty_print_values(fitted_eos.popt, fitted_eos.pcov, fitted_eos.fit_params)
     model_vs_2nd_order_correct = mg_perovskite_test.evaluate(['shear_wave_velocity'],
                                                              pressures, temperatures)[0]
-    mg_perovskite_test.set_method("bm3")
+    with warnings.catch_warnings(record=True) as w:
+        mg_perovskite_test.set_method("bm3")
+        print(w[-1].message)
+
     model_vs_2nd_order_incorrect = mg_perovskite_test.evaluate(['shear_wave_velocity'],
                                                                pressures, temperatures)[0]
     print('')
@@ -83,7 +88,10 @@ if __name__ == "__main__":
     burnman.tools.pretty_print_values(fitted_eos.popt, fitted_eos.pcov, fitted_eos.fit_params)
     model_vs_3rd_order_correct = mg_perovskite_test.evaluate(['shear_wave_velocity'],
                                                              pressures, temperatures)[0]
-    mg_perovskite_test.set_method("bm2")
+    with warnings.catch_warnings(record=True) as w:
+        mg_perovskite_test.set_method("bm2")
+        print(w[-1].message)
+
     model_vs_3rd_order_incorrect = mg_perovskite_test.evaluate(['shear_wave_velocity'],
                                                                pressures, temperatures)[0]
     print('')

--- a/examples/example_fit_eos.py
+++ b/examples/example_fit_eos.py
@@ -457,7 +457,7 @@ if __name__ == "__main__":
                                        (['alpha', 'K_T'], 1.e-6, 'Thermal pressure (MPa/K)')]
 
     def closest_factors(n):
-        d = np.int(np.floor(np.sqrt(n)))
+        d = int(np.floor(np.sqrt(n)))
         for i in reversed(range(1, d+1)):
             if (n % i) == 0:
                 return i, int(n/i)

--- a/examples/example_layer.py
+++ b/examples/example_layer.py
@@ -48,6 +48,7 @@ if not os.path.exists('burnman') and os.path.exists('../burnman'):
 import burnman
 from burnman import minerals
 
+import warnings
 
 if __name__ == "__main__":
     # This is the first actual work done in this example.  We define
@@ -64,8 +65,12 @@ if __name__ == "__main__":
     # query the seismic model for the pressure, density, P wave speed, S wave
     # speed, and bulk sound velocity at those depths
     depths = np.linspace(2890e3, 670e3, 20)
-    pressure, gravity, seis_rho, seis_vp, seis_vs, seis_bullen = seismic_model.evaluate(
-        ['pressure', 'gravity', 'density', 'v_p', 'v_s', 'bullen'], depths)
+
+    with warnings.catch_warnings(record=True) as w:
+        eval = seismic_model.evaluate(['pressure', 'gravity', 'density',
+                                       'v_p', 'v_s', 'bullen'], depths)
+        pressure, gravity, seis_rho, seis_vp, seis_vs, seis_bullen = eval
+        print(w[-1].message)
 
     # Here we define the lower mantle as a Layer(). The layer needs various
     # parameters to set a depth array and radius array.

--- a/examples/example_seismic.py
+++ b/examples/example_seismic.py
@@ -45,6 +45,8 @@ if not os.path.exists('burnman') and os.path.exists('../burnman'):
 
 import burnman
 
+import warnings 
+
 if __name__ == "__main__":
 
     # List of seismic 1D models
@@ -77,14 +79,24 @@ if __name__ == "__main__":
                 # try to get and plot values for given model, if this fails the
                 # variable is likely not defined for that model
                 try:
-                    values = getattr(models[model_index], variables[variable_index])(depths)
-                    plt.plot(depths / 1.e3, values, color=colors[
-                             model_index], linestyle='-', label=models[model_index].__class__.__name__)
-                except:
+                    with warnings.catch_warnings(record=True) as wrn:
+                        values = getattr(models[model_index],
+                                         variables[variable_index])(depths)
+                        if (len(wrn) == 1) or (len(wrn) == 2):
+                            for w in wrn:
+                                print(w.message)
+                        elif len(wrn) > 2:
+                            raise Exception('Unexpected number of warnings')
+
+                    plt.plot(depths / 1.e3, values, color=colors[model_index],
+                             linestyle='-',
+                             label=models[model_index].__class__.__name__)
+                except ValueError:
                     # write out warning that the variable failed for given
                     # model
-                    print(
-                        variables[variable_index] + ' is not defined for ' + models[model_index].__class__.__name__)
+                    print(variables[variable_index]
+                          + ' is not defined for '
+                          + models[model_index].__class__.__name__)
 
         plt.title(variables[variable_index])
         box = ax.get_position()

--- a/misc/benchmarks/debye.py
+++ b/misc/benchmarks/debye.py
@@ -28,16 +28,16 @@ def old_heat(T, debye_T, n):
 temperatures = np.linspace(100, 5000, 10000)
 Debye_T = 1000.
 old = np.empty_like(temperatures)
-start = time.clock()
+start = time.process_time()
 for i in range(len(temperatures)):
     old[i] = old_heat(temperatures[i], Debye_T, 1.0)
-time_old = time.clock() - start
+time_old = time.process_time() - start
 
 new = np.empty_like(temperatures)
-start = time.clock()
+start = time.process_time()
 for i in range(len(temperatures)):
     new[i] = burnman.eos.debye.molar_heat_capacity_v(temperatures[i], Debye_T, 1.0)
-time_new = time.clock() - start
+time_new = time.process_time() - start
 
 assert(np.abs(np.linalg.norm((old-new)/new)) < 1.e-7)
 print("time old %g, time new %g" % (time_old, time_new))

--- a/misc/benchmarks/endmember_benchmarks.py
+++ b/misc/benchmarks/endmember_benchmarks.py
@@ -10,7 +10,7 @@ from burnman.minerals import SLB_2011
 from burnman.minerals import HP_2011_ds62
 from burnman import constants
 import numpy as np
-
+import warnings
 
 def p(v1, v2):
     return (v2 - v1) / v1
@@ -58,7 +58,12 @@ for database, f, mineral in filemin:
 variables = ['V', 'K_T', 'rho']
 
 fo = HP_2011_ds62.fo()
-fo.set_method('mt')
+
+with warnings.catch_warnings(record=True) as w:
+    fo.set_method('mt')
+    assert len(w) == 1
+    assert issubclass(w[-1].category, UserWarning)
+
 percentage_diff = []
 PT = []
 
@@ -127,4 +132,3 @@ print('Maximum percentage error in SLB database '
       'with configurational entropy and landau transition:')
 print('{0}: {1:.0e}% at {2:.0f} GPa and {3:.0f} K for {4}'.format(variables[j], percentage_diff[i, j],
                                                                   PT[i][0], PT[i][1], mineral_names[i]))
-print('')

--- a/misc/ref/endmember_benchmarks.py.out
+++ b/misc/ref/endmember_benchmarks.py.out
@@ -37,5 +37,3 @@ Mg_Ringwoodite: -1.020e+06 3.348e+02 3.693e-05 1.770e+02 1.877e-05 2.359e+11 3.8
 Stishovite: -4.479e+05 1.282e+02 1.354e-05 7.610e+01 1.980e-05 3.410e+11 4.437e+03
 Maximum percentage error in SLB database with configurational entropy and landau transition:
 alpha: 4e-02% at 20 GPa and 1673 K for Stishovite
-
-UserWarning: Warning, you are changing the method to MT even though the material is designed to be used with the method HP_TMT.  This does not overwrite any mineral attributes

--- a/misc/ref/example_build_planet.py.out
+++ b/misc/ref/example_build_planet.py.out
@@ -24,5 +24,4 @@ outer core mass fraction of planet 0.338
 lower mantle mass fraction of planet 0.476
 upper mantle mass fraction of planet 0.167
 
-BURNMAN/burnman/seismic.py: UserWarning: Gravity is not given in PREM and is now being computed. This will only work when density is defined for the entire planet.  Use at your own risk. 
-  "Gravity is not given in " + self.__class__.__name__ + " and is now being computed. This will only work when density is defined for the entire planet.  Use at your own risk. ")
+Gravity is not given in PREM and is now being computed. This will only work when density is defined for the entire planet. Use at your own risk.

--- a/misc/ref/example_fit_data.py.out
+++ b/misc/ref/example_fit_data.py.out
@@ -3,10 +3,12 @@
 2nd order fit:
 G_0: (1.68 +/- 0.02) x 1e+11
 Gprime_0: (1.51 +/- 0.02) x 1e+00
+Warning, you are changing the method to BM3 even though the material is designed to be used with the method BM2.  This does not overwrite any mineral attributes
 
 3rd order fit:
 G_0: (1.63 +/- 0.02) x 1e+11
 Gprime_0: (1.65 +/- 0.02) x 1e+00
+Warning, you are changing the method to BM2 even though the material is designed to be used with the method BM3.  This does not overwrite any mineral attributes
 
 2) Fitting standard enthalpy and heat capacity to enthalpy data
 
@@ -17,5 +19,3 @@ Cp_b: (0.000 +/- 0.004) x 1e+00
 Cp_c: (-5 +/- 6) x 1e+05
 Cp_d: (-3 +/- 3) x 1e+02
 
-UserWarning: Warning, you are changing the method to BM3 even though the material is designed to be used with the method BM2.  This does not overwrite any mineral attributes
-UserWarning: Warning, you are changing the method to BM2 even though the material is designed to be used with the method BM3.  This does not overwrite any mineral attributes

--- a/misc/ref/example_layer.py.out
+++ b/misc/ref/example_layer.py.out
@@ -1,2 +1,1 @@
-BURNMAN/burnman/seismic.py: UserWarning: Gravity is not given in PREM and is now being computed. This will only work when density is defined for the entire planet.  Use at your own risk. 
-  "Gravity is not given in " + self.__class__.__name__ + " and is now being computed. This will only work when density is defined for the entire planet.  Use at your own risk. ")
+Gravity is not given in PREM and is now being computed. This will only work when density is defined for the entire planet. Use at your own risk.

--- a/misc/ref/example_seismic.py.out
+++ b/misc/ref/example_seismic.py.out
@@ -1,17 +1,8 @@
+Pressure is not given in STW105 and is now being computed. This will only work when density is defined for the entire planet. Use at your own risk.
+Gravity is not given in STW105 and is now being computed. This will only work when density is defined for the entire planet. Use at your own risk.
+Pressure is not given in AK135 and is now being computed. This will only work when density is defined for the entire planet. Use at your own risk.
+Gravity is not given in AK135 and is now being computed. This will only work when density is defined for the entire planet. Use at your own risk.
 pressure is not defined for IASP91
+Gravity is not given in PREM and is now being computed. This will only work when density is defined for the entire planet. Use at your own risk.
 gravity is not defined for IASP91
 density is not defined for IASP91
-BURNMAN/burnman/seismic.py: UserWarning: Pressure is not given in STW105 and is now being computed. This will only work when density is defined for the entire planet. Use at your own risk. 
-  "Pressure is not given in " + self.__class__.__name__ + " and is now being computed. This will only work when density is defined for the entire planet. Use at your own risk. ")
-BURNMAN/burnman/seismic.py: UserWarning: Gravity is not given in STW105 and is now being computed. This will only work when density is defined for the entire planet.  Use at your own risk. 
-  "Gravity is not given in " + self.__class__.__name__ + " and is now being computed. This will only work when density is defined for the entire planet.  Use at your own risk. ")
-BURNMAN/burnman/seismic.py: UserWarning: Pressure is not given in AK135 and is now being computed. This will only work when density is defined for the entire planet. Use at your own risk. 
-  "Pressure is not given in " + self.__class__.__name__ + " and is now being computed. This will only work when density is defined for the entire planet. Use at your own risk. ")
-BURNMAN/burnman/seismic.py: UserWarning: Gravity is not given in AK135 and is now being computed. This will only work when density is defined for the entire planet.  Use at your own risk. 
-  "Gravity is not given in " + self.__class__.__name__ + " and is now being computed. This will only work when density is defined for the entire planet.  Use at your own risk. ")
-BURNMAN/burnman/seismic.py: UserWarning: Pressure is not given in IASP91 and is now being computed. This will only work when density is defined for the entire planet. Use at your own risk. 
-  "Pressure is not given in " + self.__class__.__name__ + " and is now being computed. This will only work when density is defined for the entire planet. Use at your own risk. ")
-BURNMAN/burnman/seismic.py: UserWarning: Gravity is not given in IASP91 and is now being computed. This will only work when density is defined for the entire planet.  Use at your own risk. 
-  "Gravity is not given in " + self.__class__.__name__ + " and is now being computed. This will only work when density is defined for the entire planet.  Use at your own risk. ")
-BURNMAN/burnman/seismic.py: UserWarning: Gravity is not given in PREM and is now being computed. This will only work when density is defined for the entire planet.  Use at your own risk. 
-  "Gravity is not given in " + self.__class__.__name__ + " and is now being computed. This will only work when density is defined for the entire planet.  Use at your own risk. ")

--- a/misc/ref/paper_fit_data.py.out
+++ b/misc/ref/paper_fit_data.py.out
@@ -2,11 +2,11 @@ Optimization terminated successfully.
          Current function value: 14212.187371
          Iterations: 113
          Function evaluations: 245
-2nd order fit: G =  173.346202394 GPa	G' =  1.52206201609
+2nd order fit: G =  173.34620239353828 GPa	G' =  1.5220620160937355
+Warning, you are changing the method to BM3 even though the material is designed to be used with the method BM2.  This does not overwrite any mineral attributes
 Optimization terminated successfully.
          Current function value: 16309.304196
          Iterations: 117
          Function evaluations: 257
-3rd order fit: G =  168.927042088 GPa	G' =  1.66680648163
-UserWarning: Warning, you are changing the method to BM3 even though the material is designed to be used with the method BM2.  This does not overwrite any mineral attributes
-UserWarning: Warning, you are changing the method to BM2 even though the material is designed to be used with the method BM3.  This does not overwrite any mineral attributes
+3rd order fit: G =  168.92704208800933 GPa	G' =  1.6668064816268249
+Warning, you are changing the method to BM2 even though the material is designed to be used with the method BM3.  This does not overwrite any mineral attributes


### PR DESCRIPTION
This PR builds on #375, and removes deprecation warnings related to the release of numpy 1.20.0: https://numpy.org/devdocs/release/1.20.0-notes.html