### PR TITLE
add cvxpy

### DIFF
--- a/docker/burnman-buildenv-bionic-python3/Dockerfile
+++ b/docker/burnman-buildenv-bionic-python3/Dockerfile
@@ -19,3 +19,4 @@ RUN apt update && \
 # requires libgmp3-dev.
 
 RUN pip3 install pycddlib
+RUN pip3 install cvxpy

--- a/sphinx/pip_requirements.txt
+++ b/sphinx/pip_requirements.txt
@@ -4,3 +4,5 @@ matplotlib
 scipy
 sympy
 sphinxcontrib.bibtex
+pycddlib
+cvxpy


### PR DESCRIPTION
This PR adds cvxpy to docker (ready for new functionality).
It also adds pycddlib and cvxpy to the pip_requirements.txt file.