### PR TITLE
update processchemistry.py

### DIFF
--- a/burnman/processchemistry.py
+++ b/burnman/processchemistry.py
@@ -357,6 +357,33 @@ def process_solution_chemistry(solution_model):
 
 def site_occupancies_to_strings(site_names, site_multiplicities,
                                 site_occupancies):
+    """
+    Converts a list of endmember site occupancies into a list
+    of string representations of those occupancies.
+
+    Parameters
+    ----------
+    site_names : 2d list of strings
+        List of sites, each of which contains a list of the species
+        occupying each site. The total number and order of site-species must
+        be the same as the 2nd dimension of site_occupancies.
+
+    site_multiplicities : list of floats
+        List of floats giving the
+        Must be the same length as site_names
+
+    site_occupancies : 2D list of floats
+        A list of endmember site occupancies.
+        The first dimension loops over the endmembers, and the
+        second dimension loops over the site-species for that endmember.
+
+    Returns
+    -------
+    site_formulae : list of strings
+        A list of strings in standard burnman format.
+        For example, [Mg]3[Al]2 would correspond to the
+        classic two-site pyrope garnet.
+    """
     site_formulae = []
     for mbr_occupancies in site_occupancies:
         i = 0

--- a/burnman/processchemistry.py
+++ b/burnman/processchemistry.py
@@ -38,7 +38,40 @@ def read_masses():
     return lookup
 
 
+"""
+atomic_masses is a dictionary of atomic masses
+"""
 atomic_masses = read_masses()
+
+"""
+IUPAC_element_order provides a list of all the elements.
+Element order is based loosely on electronegativity,
+following the scheme suggested by IUPAC, except that H
+comes after the Group 16 elements, not before them.
+"""
+IUPAC_element_order = ['v', 'Og', 'Rn', 'Xe', 'Kr', 'Ar', 'Ne', 'He',  # Group 18
+                       'Fr', 'Cs', 'Rb', 'K', 'Na', 'Li',  # Group 1 (not H)
+                       'Ra', 'Ba', 'Sr', 'Ca', 'Mg', 'Be',  # Group 2
+                       'Lr', 'No', 'Md', 'Fm', 'Es', 'Cf', 'Bk', 'Cm',
+                       'Am', 'Pu', 'Np', 'U', 'Pa', 'Th', 'Ac',  # Actinides
+                       'Lu', 'Yb', 'Tm', 'Er', 'Ho', 'Dy', 'Tb', 'Gd',
+                       'Eu', 'Sm', 'Pm', 'Nd', 'Pr', 'Ce', 'La',  # Lanthanides
+                       'Y', 'Sc',  # Group 3
+                       'Rf', 'Hf', 'Zr', 'Ti',  # Group 4
+                       'Db', 'Ta', 'Nb', 'V',  # Group 5
+                       'Sg', 'W', 'Mo', 'Cr',  # Group 6
+                       'Bh', 'Re', 'Tc', 'Mn',  # Group 7
+                       'Hs', 'Os', 'Ru', 'Fe',  # Group 8
+                       'Mt', 'Ir', 'Rh', 'Co',  # Group 9
+                       'Ds', 'Pt', 'Pd', 'Ni',  # Group 10
+                       'Rg', 'Au', 'Ag', 'Cu',  # Group 11
+                       'Cn', 'Hg', 'Cd', 'Zn',  # Group 12
+                       'Nh', 'Tl', 'In', 'Ga', 'Al', 'B',  # Group 13
+                       'Fl', 'Pb', 'Sn', 'Ge', 'Si', 'C',  # Group 14
+                       'Mc', 'Bi', 'Sb', 'As', 'P', 'N',  # Group 15
+                       'Lv', 'Po', 'Te', 'Se', 'S', 'O',  # Group 16
+                       'H',  # hydrogen
+                       'Ts', 'At', 'I', 'Br', 'Cl', 'F']  # Group 17
 
 
 def dictionarize_formula(formula):
@@ -403,35 +436,11 @@ def formula_to_string(formula):
     Returns
     -------
     formula_string : string
-        A formula string, with element order based loosely
-        on electronegativity, following the scheme suggested by IUPAC,
-        except that H comes after the Group 16 elements, not before them.
+        A formula string, with element order as given in the list
+        IUPAC_element_order.
         If one or more keys in the dictionary are not one of the elements
         in the periodic table, then they are added at the end of the string.
     """
-    IUPAC_element_order = ['v', 'Og', 'Rn', 'Xe', 'Kr', 'Ar', 'Ne', 'He',  # Group 18
-                           'Fr', 'Cs', 'Rb', 'K', 'Na', 'Li',  # Group 1 (omitting H)
-                           'Ra', 'Ba', 'Sr', 'Ca', 'Mg', 'Be',  # Group 2
-                           'Lr', 'No', 'Md', 'Fm', 'Es', 'Cf', 'Bk', 'Cm',
-                           'Am', 'Pu', 'Np', 'U', 'Pa', 'Th', 'Ac',  # Actinides
-                           'Lu', 'Yb', 'Tm', 'Er', 'Ho', 'Dy', 'Tb', 'Gd',
-                           'Eu', 'Sm', 'Pm', 'Nd', 'Pr', 'Ce', 'La',  # Lanthanides
-                           'Y', 'Sc',  # Group 3
-                           'Rf', 'Hf', 'Zr', 'Ti',  # Group 4
-                           'Db', 'Ta', 'Nb', 'V',  # Group 5
-                           'Sg', 'W', 'Mo', 'Cr',  # Group 6
-                           'Bh', 'Re', 'Tc', 'Mn',  # Group 7
-                           'Hs', 'Os', 'Ru', 'Fe',  # Group 8
-                           'Mt', 'Ir', 'Rh', 'Co',  # Group 9
-                           'Ds', 'Pt', 'Pd', 'Ni',  # Group 10
-                           'Rg', 'Au', 'Ag', 'Cu',  # Group 11
-                           'Cn', 'Hg', 'Cd', 'Zn',  # Group 12
-                           'Nh', 'Tl', 'In', 'Ga', 'Al', 'B',  # Group 13
-                           'Fl', 'Pb', 'Sn', 'Ge', 'Si', 'C',  # Group 14
-                           'Mc', 'Bi', 'Sb', 'As', 'P', 'N',  # Group 15
-                           'Lv', 'Po', 'Te', 'Se', 'S', 'O',  # Group 16
-                           'H',  # hydrogen
-                           'Ts', 'At', 'I', 'Br', 'Cl', 'F']  # Group 17
 
     formula_string = ''
     for e in IUPAC_element_order:

--- a/burnman/processchemistry.py
+++ b/burnman/processchemistry.py
@@ -1,10 +1,12 @@
-# This file is part of BurnMan - a thermoelastic and thermodynamic toolkit for the Earth and Planetary Sciences
-# Copyright (C) 2012 - 2017 by the BurnMan team, released under the GNU
+# This file is part of BurnMan - a thermoelastic and thermodynamic toolkit
+# for the Earth and Planetary Sciences
+# Copyright (C) 2012 - 2021 by the BurnMan team, released under the GNU
 # GPL v2 or later.
 
-
-# This module provides the functions required to process the standard burnman formula compositions
-# ProcessChemistry returns the number of atoms and molar mass of a compound given its unit formula as an argument.
+# This module provides the functions required to process the
+# standard burnman formula formats.
+# ProcessChemistry returns the number of atoms and molar mass of a compound
+# given its unit formula as an argument.
 # process_solution_chemistry returns information required to calculate
 # solid solution properties from a set of endmember formulae
 
@@ -15,13 +17,8 @@ from fractions import Fraction
 from collections import Counter
 import pkgutil
 from string import ascii_uppercase as ucase
-from scipy.optimize import nnls
-from sympy import Matrix, nsimplify
+from sympy import nsimplify
 
-def simplify_matrix(arr):
-    def f(i,j):
-        return nsimplify(arr[i][j])
-    return Matrix( len(arr), len(arr[0]), f )
 
 def read_masses():
     """
@@ -31,7 +28,8 @@ def read_masses():
     datastream = pkgutil.get_data(
         'burnman', 'data/input_masses/atomic_masses.dat')
     datalines = [line.strip()
-                 for line in datastream.decode('ascii').split('\n') if line.strip()]
+                 for line in datastream.decode('ascii').split('\n')
+                 if line.strip()]
     lookup = dict()
     for line in datalines:
         data = "%".join(line.split("%")[:1]).split()
@@ -39,12 +37,25 @@ def read_masses():
             lookup[data[0]] = float(data[1])
     return lookup
 
+
 atomic_masses = read_masses()
+
 
 def dictionarize_formula(formula):
     """
     A function to read a chemical formula string and
     convert it into a dictionary
+
+    Parameters
+    ----------
+    formula : string object
+        Chemical formula, written in the XnYm format, where
+        the formula has n atoms of element X and m atoms of element Y
+
+    Returns
+    -------
+    f : dictionary object
+        The same chemical formula, but expressed as a dictionary.
     """
     f = dict()
     elements = re.findall('[A-Z][^A-Z]*', formula)
@@ -59,7 +70,23 @@ def dictionarize_formula(formula):
 
     return f
 
+
 def sum_formulae(formulae, amounts=None):
+    """
+    Adds together a set of formulae.
+
+    Parameters
+    ----------
+    formulae : list of dictionary or counter objects
+        List of chemical formulae
+    amounts : list of floats
+        List of amounts of each formula
+
+    Returns
+    -------
+    summed_formula : Counter object
+        The sum of the user-provided formulae
+    """
     if amounts is None:
         amounts = [1. for formula in formulae]
     else:
@@ -67,48 +94,69 @@ def sum_formulae(formulae, amounts=None):
 
     summed_formula = Counter()
     for i, formula in enumerate(formulae):
-        summed_formula.update(Counter({element: amounts[i] * n_atoms for (element, n_atoms) in formula.items()}))
+        summed_formula.update(Counter({element: amounts[i] * n_atoms
+                                       for (element, n_atoms)
+                                       in formula.items()}))
     return summed_formula
+
 
 def formula_mass(formula):
     """
-    A function to take chemical formula and atomic mass
-    dictionaries and compute the formula mass.
-    """
-    mass = sum(
-        formula[element] * atomic_masses[element] for element in formula)
-    return mass
+    A function to take a chemical formula and compute the formula mass.
 
-def solution_bounds(endmember_occupancies):
-    """
     Parameters
     ----------
-    endmember_occupancies : 2d array of floats
-        A 1D array for each endmember in the solid solution,
-        containing the number of atoms of each element on each site.
+    formula : dictionary or counter object
+        A chemical formula
 
     Returns
     -------
-    solution_bounds : 2d array of floats
-        An abbreviated version of endmember_occupancies,
-        where the columns represent the independent compositional
-        bounds on the solution
+    mass : float
+        The mass per mole of formula
     """
-    # Find bounds for the solution
-    i_sorted =zip(*sorted([(i,
-                            sum([1 for val in endmember_occupancies.T[i]
-                                 if val>1.e-10]))
-                           for i in range(len(endmember_occupancies.T))
-                                          if np.any(endmember_occupancies.T[i] > 1.e-10)],
-                          key=lambda x: x[1]))[0]
+    mass = sum(formula[element] * atomic_masses[element]
+               for element in formula)
+    return mass
 
-    solution_bounds = endmember_occupancies[:,i_sorted[0],np.newaxis]
-    for i in i_sorted[1:]:
-        if np.abs(nnls(solution_bounds, endmember_occupancies.T[i])[1]) > 1.e-10:
-            solution_bounds = np.concatenate((solution_bounds,
-                                              endmember_occupancies[:,i,np.newaxis]),
-                                             axis=1)
-    return solution_bounds
+
+def convert_formula(formula, to_type='mass', normalize=False):
+    """
+    Converts a chemical formula from one type (mass or molar)
+    into the other. Renormalises amounts if normalize=True
+
+    Parameters
+    ----------
+    formula : dictionary or counter object
+        A chemical formula
+
+    to_type : string, one of 'mass' or 'molar'
+        Conversion type
+
+    normalize : boolean
+        Whether or not to normalize the converted formula to 1
+
+    Returns
+    -------
+    f : dictionary
+        The converted formula
+    """
+
+    if to_type == 'mass':
+        f = {element: n_atoms * atomic_masses[element]
+             for (element, n_atoms) in formula.items()}
+    elif to_type == 'molar':
+        f = {element: n_atoms / atomic_masses[element]
+             for (element, n_atoms) in formula.items()}
+    else:
+        raise Exception('Value of parameter to_type not recognised. '
+                        'Should be either "mass" or "molar".')
+
+    if normalize:
+        s = np.sum([n for (element, n) in f.items()])
+        f = {element: n/s for (element, n) in f.items()}
+
+    return f
+
 
 def process_solution_chemistry(solution_model):
     """
@@ -168,7 +216,6 @@ def process_solution_chemistry(solution_model):
         A 1D array for each endmember in the solid solution,
         containing the number of atoms of each element on each site
         per mole of endmember.
-
     """
     formulae = solution_model.formulas
     n_sites = formulae[0].count('[')
@@ -214,7 +261,8 @@ def process_solution_chemistry(solution_model):
                     proportion_element_on_site = Fraction(element_split[1])
 
                 solution_formula[element_on_site] = solution_formula.get(
-                    element_on_site, 0.0) + list_multiplicity[i_site] * proportion_element_on_site
+                    element_on_site, 0.0) + (list_multiplicity[i_site]
+                                             * proportion_element_on_site)
 
                 if element_on_site not in sites[i_site]:
                     n_occupancies += 1
@@ -259,7 +307,8 @@ def process_solution_chemistry(solution_model):
     solution_model.site_names = []
     for i, elements in enumerate(sites):
         for element in elements:
-            solution_model.site_names.append('{0}_{1}'.format(element, ucase[i]))
+            solution_model.site_names.append('{0}_{1}'.format(element,
+                                                              ucase[i]))
 
     # Finally, make attributes for solution model instance:
     solution_model.solution_formulae = solution_formulae
@@ -268,7 +317,31 @@ def process_solution_chemistry(solution_model):
     solution_model.n_occupancies = n_occupancies
     solution_model.site_multiplicities = site_multiplicities
     solution_model.endmember_occupancies = endmember_occupancies
-    solution_model.endmember_noccupancies = np.einsum('ij, j->ij', endmember_occupancies, site_multiplicities)
+    solution_model.endmember_noccupancies = np.einsum('ij, j->ij',
+                                                      endmember_occupancies,
+                                                      site_multiplicities)
+
+
+def site_occupancies_to_strings(site_names, site_multiplicities,
+                                site_occupancies):
+    site_formulae = []
+    for mbr_occupancies in site_occupancies:
+        i = 0
+        site_formulae.append('')
+        for site in site_names:
+            amounts = mbr_occupancies[i:i+len(site)]
+            mult = site_multiplicities[i]
+            if np.abs(mult - 1.) < 1.e-12:
+                mult = ''
+            else:
+                mult = str(nsimplify(mult))
+            amounts /= sum(amounts)
+            site_occupancy = formula_to_string(dict(zip(site, amounts)))
+            site_formulae[-1] += '[{0}]{1}'.format(site_occupancy, mult)
+            i += len(site)
+
+    return site_formulae
+
 
 def compositional_array(formulae):
     """
@@ -336,33 +409,33 @@ def formula_to_string(formula):
         If one or more keys in the dictionary are not one of the elements
         in the periodic table, then they are added at the end of the string.
     """
-    IUPAC_element_order=['v', 'Og', 'Rn', 'Xe', 'Kr', 'Ar', 'Ne', 'He', # Group 18
-                         'Fr', 'Cs', 'Rb', 'K', 'Na', 'Li', # Group 1 (omitting H)
-                         'Ra', 'Ba', 'Sr', 'Ca', 'Mg', 'Be', # Group 2
-                         'Lr', 'No', 'Md', 'Fm', 'Es', 'Cf', 'Bk', 'Cm',
-                         'Am', 'Pu', 'Np', 'U', 'Pa', 'Th', 'Ac', # Actinides
-                         'Lu', 'Yb', 'Tm', 'Er', 'Ho', 'Dy', 'Tb', 'Gd',
-                         'Eu', 'Sm', 'Pm', 'Nd', 'Pr', 'Ce', 'La', # Lanthanides
-                         'Y', 'Sc', # Group 3
-                         'Rf', 'Hf', 'Zr', 'Ti', # Group 4
-                         'Db', 'Ta', 'Nb', 'V', # Group 5
-                         'Sg', 'W', 'Mo', 'Cr', # Group 6
-                         'Bh', 'Re', 'Tc', 'Mn', # Group 7
-                         'Hs', 'Os', 'Ru', 'Fe', # Group 8
-                         'Mt', 'Ir', 'Rh', 'Co', # Group 9
-                         'Ds', 'Pt', 'Pd', 'Ni', # Group 10
-                         'Rg', 'Au', 'Ag', 'Cu', # Group 11
-                         'Cn', 'Hg', 'Cd', 'Zn', # Group 12
-                         'Nh', 'Tl', 'In', 'Ga', 'Al', 'B', # Group 13
-                         'Fl', 'Pb', 'Sn', 'Ge', 'Si', 'C', # Group 14
-                         'Mc', 'Bi', 'Sb', 'As', 'P', 'N', # Group 15
-                         'Lv', 'Po', 'Te', 'Se', 'S', 'O', # Group 16
-                         'H', # hydrogen
-                         'Ts', 'At', 'I', 'Br', 'Cl', 'F']# Group 17
+    IUPAC_element_order = ['v', 'Og', 'Rn', 'Xe', 'Kr', 'Ar', 'Ne', 'He',  # Group 18
+                           'Fr', 'Cs', 'Rb', 'K', 'Na', 'Li',  # Group 1 (omitting H)
+                           'Ra', 'Ba', 'Sr', 'Ca', 'Mg', 'Be',  # Group 2
+                           'Lr', 'No', 'Md', 'Fm', 'Es', 'Cf', 'Bk', 'Cm',
+                           'Am', 'Pu', 'Np', 'U', 'Pa', 'Th', 'Ac',  # Actinides
+                           'Lu', 'Yb', 'Tm', 'Er', 'Ho', 'Dy', 'Tb', 'Gd',
+                           'Eu', 'Sm', 'Pm', 'Nd', 'Pr', 'Ce', 'La',  # Lanthanides
+                           'Y', 'Sc',  # Group 3
+                           'Rf', 'Hf', 'Zr', 'Ti',  # Group 4
+                           'Db', 'Ta', 'Nb', 'V',  # Group 5
+                           'Sg', 'W', 'Mo', 'Cr',  # Group 6
+                           'Bh', 'Re', 'Tc', 'Mn',  # Group 7
+                           'Hs', 'Os', 'Ru', 'Fe',  # Group 8
+                           'Mt', 'Ir', 'Rh', 'Co',  # Group 9
+                           'Ds', 'Pt', 'Pd', 'Ni',  # Group 10
+                           'Rg', 'Au', 'Ag', 'Cu',  # Group 11
+                           'Cn', 'Hg', 'Cd', 'Zn',  # Group 12
+                           'Nh', 'Tl', 'In', 'Ga', 'Al', 'B',  # Group 13
+                           'Fl', 'Pb', 'Sn', 'Ge', 'Si', 'C',  # Group 14
+                           'Mc', 'Bi', 'Sb', 'As', 'P', 'N',  # Group 15
+                           'Lv', 'Po', 'Te', 'Se', 'S', 'O',  # Group 16
+                           'H',  # hydrogen
+                           'Ts', 'At', 'I', 'Br', 'Cl', 'F']  # Group 17
 
     formula_string = ''
     for e in IUPAC_element_order:
-        if e in formula and np.abs(formula[e])>1.e-12:
+        if e in formula and np.abs(formula[e]) > 1.e-12:
             if np.abs(formula[e] - 1.) < 1.e-12:
                 formula_string += e
             else:
@@ -370,7 +443,7 @@ def formula_to_string(formula):
 
     for e in formula:
         if e not in IUPAC_element_order:
-            if e in formula and np.abs(formula[e])>1.e-12:
+            if e in formula and np.abs(formula[e]) > 1.e-12:
                 if np.abs(formula[e] - 1.) < 1.e-12:
                     formula_string += e
                 else:

--- a/tests/test_processchemistry.py
+++ b/tests/test_processchemistry.py
@@ -1,0 +1,66 @@
+from __future__ import absolute_import
+import unittest
+import os
+import sys
+sys.path.insert(1, os.path.abspath('..'))
+import warnings
+
+import burnman
+from burnman.processchemistry import dictionarize_formula
+from burnman.processchemistry import sum_formulae
+from burnman.processchemistry import formula_mass
+from burnman.processchemistry import convert_formula
+from burnman.processchemistry import site_occupancies_to_strings
+import numpy as np
+
+from util import BurnManTest
+
+
+class processchemistry(BurnManTest):
+
+    def test_dictionarize_formula(self):
+        f = dictionarize_formula('Mg0.5FeAl2SiO12')
+        self.assertArraysAlmostEqual([f['Mg'], f['Fe'], f['Al'], f['Si'], f['O']], [0.5, 1., 2., 1., 12.])
+
+    def test_dictionarize_formula_repeated_element(self):
+        f = dictionarize_formula('Mg0.5FeAl2SiO12O2')
+        self.assertArraysAlmostEqual([f['Mg'], f['Fe'], f['Al'], f['Si'], f['O']], [0.5, 1., 2., 1., 14.])
+
+    def test_sum_formulae(self):
+        f1 = dictionarize_formula('Mg2SiO4')
+        f2 = dictionarize_formula('Fe2SiO4')
+        f = sum_formulae([f1, f2], [0.25, 0.75])
+        self.assertArraysAlmostEqual([f['Mg'], f['Fe'], f['Si'], f['O']], [0.5, 1.5, 1., 4.])
+
+    def test_formula_mass(self):
+        f = dictionarize_formula('Mg2SiO4')
+        self.assertFloatEqual(formula_mass(f), 0.1406931)
+
+    def test_convert_formula(self):
+        f = dictionarize_formula('Mg2SiO4')
+        f_mass = convert_formula(f, to_type='mass', normalize=False)
+        self.assertArraysAlmostEqual([f_mass['Mg'], f_mass['Si'], f_mass['O']], [0.04861, 0.0280855, 0.0639976])
+        f_mol = convert_formula(f_mass, to_type='molar', normalize=False)
+        self.assertArraysAlmostEqual([f_mol['Mg'], f_mol['Si'], f_mol['O']], [2, 1, 4])
+
+    def test_convert_formula_normalize(self):
+        f = dictionarize_formula('Mg2SiO4')
+        f_mass = convert_formula(f, to_type='mass', normalize=True)
+        self.assertArraysAlmostEqual([f_mass['Mg'], f_mass['Si'], f_mass['O']], [0.345504, 0.199622, 0.454874])
+        f_mol = convert_formula(f_mass, to_type='molar', normalize=True)
+        self.assertArraysAlmostEqual([f_mol['Mg'], f_mol['Si'], f_mol['O']], [2./7., 1./7., 4./7.])
+
+    def test_site_occupancies_to_strings(self):
+        site_names = [['Mg', 'Fe', 'Ca'],['Al', 'Fef']]
+        site_multiplicities = [3., 2.]
+        site_occupancies = np.array([[1., 0., 0., 1., 0.],
+                                     [0., 1., 0., 0., 1.]])
+
+        strings = site_occupancies_to_strings(site_names, site_multiplicities, site_occupancies)
+
+        self.assertEqual(strings[0], "[Mg]3[Al]2")
+        self.assertEqual(strings[1], "[Fe]3[Fef]2")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -22,6 +22,7 @@ from test_modifiers import *
 from test_partitioning import *
 from test_perplex import *
 from test_planet import *
+from test_processchemistry import *
 from test_seismic import *
 from test_solidsolution import *
 from test_solvers import *


### PR DESCRIPTION
This PR changes processchemistry.py by
- adding more informative docstrings to several functions
- exposing IUPAC_element_order
- removing simplify_matrix and solution_bounds (not used in the code base, included by mistake in a previous PR)
- adding convert_formula and site_occupancies_to_strings functions