### PR TITLE
fix docker CI image

### DIFF
--- a/docker/burnman-buildenv-bionic-python3/Dockerfile
+++ b/docker/burnman-buildenv-bionic-python3/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 RUN apt update && \
   DEBIAN_FRONTEND='noninteractive' \


### PR DESCRIPTION
Ubuntu 18.04 contains python 3.6.9 and installation of cvxpy fails with

RuntimeError: Python version >= 3.7 required.

Fix by updating to Ubuntu 20.04.