### PR TITLE
added stoichiometric matrix and associated properties to Composite

### DIFF
--- a/burnman/composite.py
+++ b/burnman/composite.py
@@ -12,26 +12,26 @@ import warnings
 from .material import Material, material_property, cached_property
 from .mineral import Mineral
 from . import averaging_schemes
-from . import chemicalpotentials
 from .solidsolution import SolidSolution
 from .processchemistry import sum_formulae, sort_element_list_to_IUPAC_order
 
+
 def check_pairs(phases, fractions):
-        if len(fractions) < 1:
-            raise Exception('ERROR: we need at least one phase')
+    if len(fractions) < 1:
+        raise Exception('ERROR: we need at least one phase')
 
-        if len(phases) != len(fractions):
-            raise Exception(
-                'ERROR: different array lengths for phases and fractions')
+    if len(phases) != len(fractions):
+        raise Exception(
+            'ERROR: different array lengths for phases and fractions')
 
-        total = sum(fractions)
-        if abs(total - 1.0) > 1e-10:
+    total = sum(fractions)
+    if abs(total - 1.0) > 1e-10:
+        raise Exception(
+            'ERROR: list of molar fractions does not add up to one')
+    for p in phases:
+        if not isinstance(p, Mineral):
             raise Exception(
-                'ERROR: list of molar fractions does not add up to one')
-        for p in phases:
-            if not isinstance(p, Mineral):
-                raise Exception(
-                    'ERROR: object of type ''%s'' is not of type Mineral' % (type(p)))
+                'ERROR: object of type ''%s'' is not of type Mineral' % (type(p)))
 
 
 # static composite of minerals/composites
@@ -497,7 +497,7 @@ class Composite(Material):
         """
         null_basis = np.array(self.stoichiometric_matrix.nullspace())
 
-        M = null_basis[:,self.dependent_element_indices]
+        M = null_basis[:, self.dependent_element_indices]
         assert (M.shape[0] == M.shape[1]) and (M == np.eye(M.shape[0])).all()
 
         return null_basis
@@ -554,7 +554,8 @@ class Composite(Material):
 
             if isinstance(ph, SolidSolution):
                 endmember_formulae.extend(ph.endmember_formulae)
-                endmember_names.extend([name+' in '+ph.name for name in ph.endmember_names])
+                endmember_names.extend([name+' in '+ph.name
+                                        for name in ph.endmember_names])
                 endmembers_per_phase.append(ph.n_endmembers)
 
             elif isinstance(ph, Mineral):

--- a/burnman/material.py
+++ b/burnman/material.py
@@ -30,18 +30,11 @@ class cached_property(property):
     https://tedboy.github.io/flask/_modules/werkzeug/utils.html#cached_property
     """
 
-    # implementation detail: A subclass of python's builtin property
-    # decorator, we override __get__ to check for a cached value. If one
-    # choses to invoke __get__ by hand the property will still work as
-    # expected because the lookup logic is replicated in __get__ for
-    # manual invocation.
-
     def __init__(self, func, name=None, doc=None):
         self.__name__ = name or func.__name__
         self.__module__ = func.__module__
         self.__doc__ = doc or func.__doc__
         self.func = func
-
 
     def __set__(self, obj, value):
         obj.__dict__[self.__name__] = value
@@ -55,6 +48,7 @@ class cached_property(property):
             value = self.func(obj)
             obj.__dict__[self.__name__] = value
         return value
+
 
 def material_property(func):
     """

--- a/burnman/material.py
+++ b/burnman/material.py
@@ -6,6 +6,56 @@ from __future__ import print_function
 import numpy as np
 from copy import deepcopy
 
+
+# TODO: When we require Python 3.8+, replace with
+# functools.cached_property decorator
+class cached_property(property):
+
+    """A decorator that converts a function into a lazy property.  The
+    function wrapped is called the first time to retrieve the result
+    and then that calculated result is used the next time you access
+    the value::
+
+        class Foo(object):
+
+            @cached_property
+            def foo(self):
+                # calculate something important here
+                return 42
+
+    The class has to have a `__dict__` in order for this property to
+    work.
+
+    This decorator is adapted slightly from the one in the werkzeug module:
+    https://tedboy.github.io/flask/_modules/werkzeug/utils.html#cached_property
+    """
+
+    # implementation detail: A subclass of python's builtin property
+    # decorator, we override __get__ to check for a cached value. If one
+    # choses to invoke __get__ by hand the property will still work as
+    # expected because the lookup logic is replicated in __get__ for
+    # manual invocation.
+
+    def __init__(self, func, name=None, doc=None):
+        self.__name__ = name or func.__name__
+        self.__module__ = func.__module__
+        self.__doc__ = doc or func.__doc__
+        self.func = func
+
+
+    def __set__(self, obj, value):
+        obj.__dict__[self.__name__] = value
+
+    def __get__(self, obj, type=None):
+        if obj is None:
+            return self
+        try:
+            value = obj.__dict__[self.__name__]
+        except KeyError:
+            value = self.func(obj)
+            obj.__dict__[self.__name__] = value
+        return value
+
 def material_property(func):
     """
     Decorator @material_property to be used for cached properties of materials.

--- a/burnman/processchemistry.py
+++ b/burnman/processchemistry.py
@@ -508,3 +508,20 @@ def formula_to_string(formula):
                     formula_string += e + str(nsimplify(formula[e]))
 
     return formula_string
+
+
+def sort_element_list_to_IUPAC_order(element_list):
+    """
+    Parameters
+    ----------
+    element_list : list
+        List of elements
+
+    Returns
+    -------
+    sorted_list : list
+        List of elements sorted into IUPAC order
+    """
+    sorted_list = [e for e in IUPAC_element_order if e in element_list]
+    assert len(sorted_list) == len(element_list)
+    return sorted_list

--- a/burnman/reductions.py
+++ b/burnman/reductions.py
@@ -1,0 +1,246 @@
+import numpy as np
+from sympy.core import S
+from sympy.core.numbers import Float, Integer
+from sympy.simplify.simplify import simplify as _simplify
+
+# The following functions are taken from sympy.matrices.utilities
+# and sympy.matrices.determinant and sympy.matrices.reductions.
+# This bit of sympy appears to be in a high state of flux,
+# so we copy the functions here for the time being.
+
+
+def _iszero(x):
+    """Returns True if x is zero."""
+    return getattr(x, 'is_zero', None)
+
+
+def _find_reasonable_pivot(col, iszerofunc=_iszero, simpfunc=_simplify):
+    """ Find the lowest index of an item in ``col`` that is
+    suitable for a pivot.  If ``col`` consists only of
+    Floats, the pivot with the largest norm is returned.
+    Otherwise, the first element where ``iszerofunc`` returns
+    False is used.  If ``iszerofunc`` doesn't return false,
+    items are simplified and retested until a suitable
+    pivot is found.
+
+    Returns a 4-tuple
+        (pivot_offset, pivot_val, assumed_nonzero, newly_determined)
+    where pivot_offset is the index of the pivot, pivot_val is
+    the (possibly simplified) value of the pivot, assumed_nonzero
+    is True if an assumption that the pivot was non-zero
+    was made without being proved, and newly_determined are
+    elements that were simplified during the process of pivot
+    finding."""
+
+    newly_determined = []
+    col = list(col)
+    # a column that contains a mix of floats and integers
+    # but at least one float is considered a numerical
+    # column, and so we do partial pivoting
+    if ((all(isinstance(x, (Float, Integer)) for x in col)
+         and any(isinstance(x, Float) for x in col))):
+        col_abs = [abs(x) for x in col]
+        max_value = max(col_abs)
+        if iszerofunc(max_value):
+            # just because iszerofunc returned True, doesn't
+            # mean the value is numerically zero.  Make sure
+            # to replace all entries with numerical zeros
+            if max_value != 0:
+                newly_determined = [(i, 0) for i, x in enumerate(col)
+                                    if x != 0]
+            return (None, None, False, newly_determined)
+        index = col_abs.index(max_value)
+        return (index, col[index], False, newly_determined)
+
+    # PASS 1 (iszerofunc directly)
+    possible_zeros = []
+    for i, x in enumerate(col):
+        is_zero = iszerofunc(x)
+        # is someone wrote a custom iszerofunc, it may return
+        # BooleanFalse or BooleanTrue instead of True or False,
+        # so use == for comparison instead of `is`
+        if is_zero is False:
+            # we found something that is definitely not zero
+            return (i, x, False, newly_determined)
+        possible_zeros.append(is_zero)
+
+    # by this point, we've found no certain non-zeros
+    if all(possible_zeros):
+        # if everything is definitely zero, we have
+        # no pivot
+        return (None, None, False, newly_determined)
+
+    # PASS 2 (iszerofunc after simplify)
+    # we haven't found any for-sure non-zeros, so
+    # go through the elements iszerofunc couldn't
+    # make a determination about and opportunistically
+    # simplify to see if we find something
+    for i, x in enumerate(col):
+        if possible_zeros[i] is not None:
+            continue
+        simped = simpfunc(x)
+        is_zero = iszerofunc(simped)
+        if is_zero is True or is_zero is False:
+            newly_determined.append((i, simped))
+        if is_zero is False:
+            return (i, simped, False, newly_determined)
+        possible_zeros[i] = is_zero
+
+    # after simplifying, some things that were recognized
+    # as zeros might be zeros
+    if all(possible_zeros):
+        # if everything is definitely zero, we have
+        # no pivot
+        return (None, None, False, newly_determined)
+
+    # PASS 3 (.equals(0))
+    # some expressions fail to simplify to zero, but
+    # ``.equals(0)`` evaluates to True.  As a last-ditch
+    # attempt, apply ``.equals`` to these expressions
+    for i, x in enumerate(col):
+        if possible_zeros[i] is not None:
+            continue
+        if x.equals(S.Zero):
+            # ``.iszero`` may return False with
+            # an implicit assumption (e.g., ``x.equals(0)``
+            # when ``x`` is a symbol), so only treat it
+            # as proved when ``.equals(0)`` returns True
+            possible_zeros[i] = True
+            newly_determined.append((i, S.Zero))
+
+    if all(possible_zeros):
+        return (None, None, False, newly_determined)
+
+    # at this point there is nothing that could definitely
+    # be a pivot.  To maintain compatibility with existing
+    # behavior, we'll assume that an illdetermined thing is
+    # non-zero.  We should probably raise a warning in this case
+    i = possible_zeros.index(None)
+    return (i, col[i], True, newly_determined)
+
+
+def _row_reduce_list(mat, rows, cols, iszerofunc, simpfunc,
+                     normalize_last=True, normalize=True, zero_above=True):
+    """Row reduce a flat list representation of a matrix and return a tuple
+    (rref_matrix, pivot_cols, swaps) where ``rref_matrix`` is a flat list,
+    ``pivot_cols`` are the pivot columns and ``swaps`` are any row swaps that
+    were used in the process of row reduction.
+    Parameters
+    ==========
+    mat : list
+        list of matrix elements, must be ``rows`` * ``cols`` in length
+    rows, cols : integer
+        number of rows and columns in flat list representation
+    iszerofunc : determines if an entry can be used as a pivot
+    simpfunc : used to simplify elements and test if they are
+        zero if ``iszerofunc`` returns `None`
+    normalize_last : indicates where all row reduction should
+        happen in a fraction-free manner and then the rows are
+        normalized (so that the pivots are 1), or whether
+        rows should be normalized along the way (like the naive
+        row reduction algorithm)
+    normalize : whether pivot rows should be normalized so that
+        the pivot value is 1
+    zero_above : whether entries above the pivot should be zeroed.
+        If ``zero_above=False``, an echelon matrix will be returned.
+    """
+
+    def get_col(i):
+        return mat[i::cols]
+
+    def row_swap(i, j):
+        mat[i*cols:(i + 1)*cols], mat[j*cols:(j + 1)*cols] = \
+            mat[j*cols:(j + 1)*cols], mat[i*cols:(i + 1)*cols]
+
+    def cross_cancel(a, i, b, j):
+        """Does the row op row[i] = a*row[i] - b*row[j]"""
+        q = (j - i)*cols
+        for p in range(i*cols, (i + 1)*cols):
+            mat[p] = isimp(a*mat[p] - b*mat[p + q])
+
+    isimp = lambda x: x
+    piv_row, piv_col = 0, 0
+    pivot_cols = []
+    swaps = []
+
+    # use a fraction free method to zero above and below each pivot
+    while piv_col < cols and piv_row < rows:
+        pivot_offset, pivot_val, \
+        assumed_nonzero, newly_determined = _find_reasonable_pivot(get_col(piv_col)[piv_row:], iszerofunc, simpfunc)
+
+        # _find_reasonable_pivot may have simplified some things
+        # in the process.  Let's not let them go to waste
+        for (offset, val) in newly_determined:
+            offset += piv_row
+            mat[offset*cols + piv_col] = val
+
+        if pivot_offset is None:
+            piv_col += 1
+            continue
+
+        pivot_cols.append(piv_col)
+        if pivot_offset != 0:
+            row_swap(piv_row, pivot_offset + piv_row)
+            swaps.append((piv_row, pivot_offset + piv_row))
+
+        # if we aren't normalizing last, we normalize
+        # before we zero the other rows
+        if normalize_last is False:
+            i, j = piv_row, piv_col
+            mat[i*cols + j] = S.One
+            for p in range(i*cols + j + 1, (i + 1)*cols):
+                mat[p] = isimp(mat[p] / pivot_val)
+            # after normalizing, the pivot value is 1
+            pivot_val = S.One
+
+        # zero above and below the pivot
+        for row in range(rows):
+            # don't zero our current row
+            if row == piv_row:
+                continue
+            # don't zero above the pivot unless we're told.
+            if zero_above is False and row < piv_row:
+                continue
+            # if we're already a zero, don't do anything
+            val = mat[row*cols + piv_col]
+            if iszerofunc(val):
+                continue
+
+            cross_cancel(pivot_val, row, val, piv_row)
+        piv_row += 1
+
+    # normalize each row
+    if normalize_last is True and normalize is True:
+        for piv_i, piv_j in enumerate(pivot_cols):
+            pivot_val = mat[piv_i*cols + piv_j]
+            mat[piv_i*cols + piv_j] = S.One
+            for p in range(piv_i*cols + piv_j + 1, (piv_i + 1)*cols):
+                mat[p] = isimp(mat[p] / pivot_val)
+
+    return mat, tuple(pivot_cols), tuple(swaps)
+
+
+# This functions is a candidate for caching
+# if it gets implemented for matrices.
+def row_reduce(M, iszerofunc=lambda x: x.is_zero,
+               simpfunc=lambda x: Rational(x).limit_denominator(1000),
+               normalize_last=True,
+               normalize=True, zero_above=True):
+
+    mat, pivot_cols, swaps = _row_reduce_list(list(M), M.rows, M.cols,
+                                              iszerofunc, simpfunc,
+                                              normalize_last=normalize_last,
+                                              normalize=normalize,
+                                              zero_above=zero_above)
+
+    return M._new(M.rows, M.cols, mat), pivot_cols, swaps
+
+
+def independent_row_indices(m, iszerofunc=lambda x: x.is_zero,
+                            simpfunc=lambda x: Rational(x).limit_denominator(1000)):
+
+        _, pivots, swaps = row_reduce(m, iszerofunc, simpfunc)
+        indices = np.array(range(len(m)))
+        for swap in np.array(swaps):
+            indices[swap] = indices[swap[::-1]]
+        return indices[:len(pivots)]

--- a/burnman/reductions.py
+++ b/burnman/reductions.py
@@ -1,6 +1,6 @@
 import numpy as np
 from sympy.core import S
-from sympy.core.numbers import Float, Integer
+from sympy.core.numbers import Float, Integer, Rational
 from sympy.simplify.simplify import simplify as _simplify
 
 # The following functions are taken from sympy.matrices.utilities
@@ -158,15 +158,16 @@ def _row_reduce_list(mat, rows, cols, iszerofunc, simpfunc,
         for p in range(i*cols, (i + 1)*cols):
             mat[p] = isimp(a*mat[p] - b*mat[p + q])
 
-    isimp = lambda x: x
+    def isimp(x):
+        return x
     piv_row, piv_col = 0, 0
     pivot_cols = []
     swaps = []
 
     # use a fraction free method to zero above and below each pivot
     while piv_col < cols and piv_row < rows:
-        pivot_offset, pivot_val, \
-        assumed_nonzero, newly_determined = _find_reasonable_pivot(get_col(piv_col)[piv_row:], iszerofunc, simpfunc)
+        pivot_offset, pivot_val, assumed_nonzero, newly_determined = _find_reasonable_pivot(
+            get_col(piv_col)[piv_row:], iszerofunc, simpfunc)
 
         # _find_reasonable_pivot may have simplified some things
         # in the process.  Let's not let them go to waste
@@ -239,8 +240,8 @@ def row_reduce(M, iszerofunc=lambda x: x.is_zero,
 def independent_row_indices(m, iszerofunc=lambda x: x.is_zero,
                             simpfunc=lambda x: Rational(x).limit_denominator(1000)):
 
-        _, pivots, swaps = row_reduce(m, iszerofunc, simpfunc)
-        indices = np.array(range(len(m)))
-        for swap in np.array(swaps):
-            indices[swap] = indices[swap[::-1]]
-        return indices[:len(pivots)]
+    _, pivots, swaps = row_reduce(m, iszerofunc, simpfunc)
+    indices = np.array(range(len(m)))
+    for swap in np.array(swaps):
+        indices[swap] = indices[swap[::-1]]
+    return indices[:len(pivots)]

--- a/tests/test_composite.py
+++ b/tests/test_composite.py
@@ -278,7 +278,6 @@ class composite(BurnManTest):
         self.assertFloatEqual(K, K2)
         self.assertFloatEqual(G, G2)
 
-
     def test_query_properties(self):
         min1 = minerals.SLB_2011.periclase()
         rock1 = burnman.Composite([min1, min1], [0.5, 0.5])
@@ -297,6 +296,95 @@ class composite(BurnManTest):
         self.assertFloatEqual(rock1.thermal_expansivity, min1.alpha)
         self.assertFloatEqual(rock1.molar_heat_capacity_v, min1.C_v)
         self.assertFloatEqual(rock1.molar_heat_capacity_p, min1.C_p)
+
+    def test_stoichiometric_matrix_single_mineral(self):
+        rock = burnman.Composite([minerals.SLB_2011.quartz()])
+
+        self.assertTrue(len(rock.endmember_names) == 1)
+        self.assertTrue(len(rock.elements) == 2)
+        self.assertTrue(rock.elements[0] == 'Si')
+        self.assertTrue(rock.elements[1] == 'O')
+        self.assertTrue(rock.stoichiometric_matrix.shape == (1, 2))
+        self.assertTrue(rock.reaction_basis.shape[0] == 0)
+        self.assertArraysAlmostEqual(rock.compositional_null_basis[0],
+                                     [-2, 1])
+        self.assertTrue(rock.independent_element_indices[0] == 0)
+        self.assertTrue(rock.dependent_element_indices[0] == 1)
+        self.assertTrue(rock.n_reactions == 0)
+
+    def test_stoichiometric_matrix_two_minerals(self):
+        rock = burnman.Composite([minerals.HP_2011_ds62.andr(),
+                                  minerals.HP_2011_ds62.alm()])
+
+        self.assertTrue(len(rock.endmember_names) == 2)
+        self.assertTrue(len(rock.elements) == 5)
+        self.assertTrue(rock.stoichiometric_matrix.shape == (2, 5))
+        self.assertTrue(rock.reaction_basis.shape[0] == 0)
+        self.assertArraysAlmostEqual(rock.compositional_null_basis[0],
+                                     [4./9., -2./3., 1, 0, 0])
+        self.assertArraysAlmostEqual(rock.compositional_null_basis[1],
+                                     [-1./3., -1., 0, 1, 0])
+        self.assertArraysAlmostEqual(rock.compositional_null_basis[2],
+                                     [-4./3., -4., 0, 0, 1])
+        self.assertArraysAlmostEqual(rock.independent_element_indices, [0, 1])
+        self.assertArraysAlmostEqual(rock.dependent_element_indices, [2, 3, 4])
+        self.assertTrue(rock.n_reactions == 0)
+
+    def test_stoichiometric_matrix_binary_solution(self):
+        rock = burnman.Composite([minerals.SLB_2011.mg_fe_olivine()])
+
+        self.assertTrue(len(rock.endmember_names) == 2)
+        self.assertTrue(len(rock.elements) == 4)
+        self.assertTrue(rock.stoichiometric_matrix.shape == (2, 4))
+        self.assertTrue(rock.reaction_basis.shape[0] == 0)
+        self.assertArraysAlmostEqual(rock.compositional_null_basis[0],
+                                     [-1./2., -1./2., 1, 0])
+        self.assertArraysAlmostEqual(rock.compositional_null_basis[1],
+                                     [-2., -2., 0, 1])
+        self.assertArraysAlmostEqual(rock.independent_element_indices, [0, 1])
+        self.assertArraysAlmostEqual(rock.dependent_element_indices, [2, 3])
+        self.assertTrue(rock.n_reactions == 0)
+        
+    def test_stoichiometric_matrix_reaction(self):
+        rock = burnman.Composite([minerals.SLB_2011.mg_fe_olivine(),
+                                  minerals.SLB_2011.garnet()])
+
+        self.assertTrue(len(rock.endmember_names) == 7)
+        self.assertTrue(len(rock.elements) == 7)
+        self.assertTrue(rock.stoichiometric_matrix.shape == (7, 7))
+        self.assertArraysAlmostEqual(rock.reaction_basis[0],
+                                     [3./2., -3./2., -1., 1., 0., 0., 0])
+        self.assertArraysAlmostEqual(rock.compositional_null_basis[0],
+                                     [-1./2., -1., -1., -1., -3./2., -2., 1.])
+        self.assertArraysAlmostEqual(rock.independent_element_indices,
+                                     [0, 1, 2, 3, 4, 5])
+        self.assertArraysAlmostEqual(rock.dependent_element_indices, [6])
+        self.assertTrue(rock.n_reactions == 1)
+
+    def test_stoichiometric_matrix_reactions(self):
+        rock = burnman.Composite([minerals.SLB_2011.mg_fe_olivine(),
+                                  minerals.SLB_2011.mg_fe_olivine(),
+                                  minerals.SLB_2011.mg_fe_olivine()])
+
+        self.assertTrue(len(rock.endmember_names) == 6)
+        self.assertTrue(len(rock.elements) == 4)
+        self.assertTrue(rock.stoichiometric_matrix.shape == (6, 4))
+        self.assertArraysAlmostEqual(rock.reaction_basis[0],
+                                     [-1, 0, 1, 0, 0, 0])
+        self.assertArraysAlmostEqual(rock.reaction_basis[1],
+                                     [0, -1, 0, 1, 0, 0])
+        self.assertArraysAlmostEqual(rock.reaction_basis[2],
+                                     [-1, 0, 0, 0, 1, 0])
+        self.assertArraysAlmostEqual(rock.reaction_basis[3],
+                                     [0, -1, 0, 0, 0, 1])
+        self.assertArraysAlmostEqual(rock.compositional_null_basis[0],
+                                  [-1./2., -1./2., 1, 0])
+        self.assertArraysAlmostEqual(rock.compositional_null_basis[1],
+                                  [-2., -2., 0, 1])
+        self.assertArraysAlmostEqual(rock.independent_element_indices, [0, 1])
+        self.assertArraysAlmostEqual(rock.dependent_element_indices, [2, 3])
+        self.assertTrue(rock.n_reactions == 4)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_composite.py
+++ b/tests/test_composite.py
@@ -1,19 +1,16 @@
 from __future__ import absolute_import
+from util import BurnManTest
+import warnings
 import unittest
 import os
 import sys
 sys.path.insert(1, os.path.abspath('..'))
-import warnings
 
 import burnman
 from burnman import minerals
 
-from util import BurnManTest
-
 
 # TODO: test composite that changes number of entries
-
-
 class composite(BurnManTest):
 
     def test_unroll(self):
@@ -271,7 +268,7 @@ class composite(BurnManTest):
         rock = burnman.Composite(
             [minerals.SLB_2005.wuestite(), minerals.SLB_2005.mg_perovskite()], [0.5, 0.5])
 
-        K, G = rock.evaluate(['K_S','G'],40.e9, 2000.)
+        K, G = rock.evaluate(['K_S', 'G'], 40.e9, 2000.)
         rock.set_state(40.e9, 2000.)
         K2 = rock.K_S
         G2 = rock.G
@@ -344,7 +341,7 @@ class composite(BurnManTest):
         self.assertArraysAlmostEqual(rock.independent_element_indices, [0, 1])
         self.assertArraysAlmostEqual(rock.dependent_element_indices, [2, 3])
         self.assertTrue(rock.n_reactions == 0)
-        
+
     def test_stoichiometric_matrix_reaction(self):
         rock = burnman.Composite([minerals.SLB_2011.mg_fe_olivine(),
                                   minerals.SLB_2011.garnet()])
@@ -378,9 +375,9 @@ class composite(BurnManTest):
         self.assertArraysAlmostEqual(rock.reaction_basis[3],
                                      [0, -1, 0, 0, 0, 1])
         self.assertArraysAlmostEqual(rock.compositional_null_basis[0],
-                                  [-1./2., -1./2., 1, 0])
+                                     [-1./2., -1./2., 1, 0])
         self.assertArraysAlmostEqual(rock.compositional_null_basis[1],
-                                  [-2., -2., 0, 1])
+                                     [-2., -2., 0, 1])
         self.assertArraysAlmostEqual(rock.independent_element_indices, [0, 1])
         self.assertArraysAlmostEqual(rock.dependent_element_indices, [2, 3])
         self.assertTrue(rock.n_reactions == 4)


### PR DESCRIPTION
This PR adds Composite properties which correspond to the stoichiometric matrix and associated column, row and nullspaces. These are useful for equilibrium calculations. 

This PR requires use of the pivots from Gaussian elimination. The necessary functions from sympy have been changing very quickly recently. For this PR, those functions are copied into reductions.py. We should be able to remove this code when sympy settles down. 

Secondly, the calculations are relatively expensive and rely on some optional parameters being set. For this reason, we only want to calculate the matrices once when they are first required, and then store the properties forever (i.e. we don't want to have to recalculate them every time we set_state or set_fractions). For this reason, I've also added a cached_property decorator. This can be replaced by the functools.cached_property decorator when we require Python 3.8+.