### PR TITLE
remove tight_layout

### DIFF
--- a/burnman/nonlinear_fitting.py
+++ b/burnman/nonlinear_fitting.py
@@ -406,7 +406,7 @@ def corner_plot(popt, pcov, param_names=[], n_std=1.):
             ax_array[j-1][0].set_ylabel('{0:s} (x 10^{1:d})'.format(
                 param_names[j], -int(np.log10(np.sqrt(scaling[j][j])))))
 
-    fig.tight_layout()
+    fig.set_tight_layout(True)
     return fig, ax_array
 
 

--- a/contrib/CHRU2014/paper_incorrect_averaging.py
+++ b/contrib/CHRU2014/paper_incorrect_averaging.py
@@ -27,7 +27,7 @@ from misc.helper_solid_solution import HelperSolidSolution
 import misc.colors as colors
 
 if __name__ == "__main__":
-    plt.figure(dpi=100, figsize=(12, 6))
+    fig = plt.figure(dpi=100, figsize=(12, 6))
     prop = {'size': 12}
     plt.rc('text', usetex=True)
     plt.rcParams['text.latex.preamble'] = r'\usepackage{relsize}'
@@ -229,7 +229,7 @@ if __name__ == "__main__":
     plt.title(" V.-R.-H. on moduli")
     plt.xlabel("Pressure (GPa)")
     plt.ylabel("Shear Velocity Vs (km/s)")
-    plt.tight_layout()
+    fig.set_tight_layout(True)
     if "RUNNING_TESTS" not in globals():
         plt.savefig("example_incorrect_averaging.pdf", bbox_inches='tight')
     plt.show()

--- a/contrib/CHRU2014/paper_opt_pv.py
+++ b/contrib/CHRU2014/paper_opt_pv.py
@@ -43,7 +43,7 @@ import misc.colors as colors
 if __name__ == "__main__":
 
     # figsize=(6,5)
-    plt.figure(dpi=100, figsize=(12, 10))
+    fig = plt.figure(dpi=100, figsize=(12, 10))
     prop = {'size': 12}
     plt.rc('text', usetex=True)
     plt.rcParams['text.latex.preamble'] = r'\usepackage{relsize}'
@@ -230,7 +230,7 @@ if __name__ == "__main__":
 #    plt.savefig("opt_pv_4.pdf",bbox_inches='tight')
 #    plt.show()
 
-    plt.tight_layout()
+    fig.set_tight_layout(True)
     if "RUNNING_TESTS" not in globals():
         plt.savefig("paper_opt_pv.pdf", bbox_inches='tight')
     plt.show()

--- a/contrib/ipython/Create_1D_ASPECT_profile.ipynb
+++ b/contrib/ipython/Create_1D_ASPECT_profile.ipynb
@@ -372,7 +372,7 @@
     "\n",
     "    ax_T.legend(loc='lower right',prop={'size':8})\n",
     "    \n",
-    "    fig.tight_layout()\n",
+    "    fig.set_tight_layout(True)\n",
     "\n",
     "\n",
     "btn = widgets.Button(description=\"update\")\n",

--- a/examples/example_anisotropy.py
+++ b/examples/example_anisotropy.py
@@ -166,7 +166,7 @@ if __name__ == "__main__":
             cbar = fig.colorbar(im[i], ax=ax[i], ticks=ticks)
             cbar.add_lines(lines)
 
-        plt.tight_layout()
+        fig.set_tight_layout(True)
         plt.savefig("output_figures/example_anisotropy.png")
         plt.show()
 

--- a/examples/example_geodynamic_adiabat.py
+++ b/examples/example_geodynamic_adiabat.py
@@ -309,7 +309,7 @@ if __name__ == "__main__":
 
 
     ax_T.legend(loc='upper left')
-    fig.tight_layout()
+    fig.set_tight_layout(True)
 
     plt.show()
 

--- a/examples/example_spintransition_thermal.py
+++ b/examples/example_spintransition_thermal.py
@@ -99,7 +99,8 @@ if __name__ == "__main__":
                                [low_spin_wuestite, '[Fels]O']]
             self.energy_interaction = [[11.e3, 11.e3],
                                        [11.e3]]
-            burnman.SolidSolution.__init__(self, molar_fractions=molar_fractions)
+            burnman.SolidSolution.__init__(
+                self, molar_fractions=molar_fractions)
 
         def set_equilibrium_composition(self, molar_fraction_FeO):
             """
@@ -142,7 +143,6 @@ if __name__ == "__main__":
     # In this line, we create our solid solution object
     fper = ferropericlase()
 
-
     # Now we loop over a series of pressures at three different temperatures,
     # calculating the equilibrium composition of the solution at each.
     # We fix the bulk composition of the solution to be (Mg0.8Fe0.2)O.
@@ -179,8 +179,10 @@ if __name__ == "__main__":
             volumes_LS[i] = fper.V
 
         # Do some plotting
-        ax[0].fill_between(pressures/1.e9, volumes_HS*1.e6, volumes_LS*1.e6, alpha=0.15, color=color, label=f'{T} K, volume range')
-        ax[0].plot(pressures/1.e9, volumes*1.e6, c=color, linewidth=2, label=f'{T} K, equilibrium volume')
+        ax[0].fill_between(pressures/1.e9, volumes_HS*1.e6, volumes_LS
+                           * 1.e6, alpha=0.15, color=color, label=f'{T} K, volume range')
+        ax[0].plot(pressures/1.e9, volumes*1.e6, c=color,
+                   linewidth=2, label=f'{T} K, equilibrium volume')
 
         ax[1].plot(pressures/1.e9, 1.-p_LS, c=color, label=f'{T} K')
 
@@ -195,5 +197,5 @@ if __name__ == "__main__":
     ax[0].set_ylim(7, 13)
 
     # Tidy the plot and show it
-    fig.tight_layout()
+    fig.set_tight_layout(True)
     plt.show()

--- a/misc/benchmarks/property_modifier_benchmarks.py
+++ b/misc/benchmarks/property_modifier_benchmarks.py
@@ -41,7 +41,7 @@ for i, ylabel in enumerate(['$C_p$ (J/K/mol)', '$Q$', '$H$ (kJ/mol)']):
     ax[i].set_xlim(temperatures[0], temperatures[-1])
     ax[i].set_xlabel('T (K)')
     ax[i].set_ylabel(ylabel)
-plt.tight_layout()
+
 plt.show()
 
 
@@ -75,7 +75,7 @@ for i, ylabel in enumerate(['$C_p$ (J/K/mol)', '$Q$', '$H$ (kJ/mol)']):
     ax[i].set_xlim(temperatures[0], temperatures[-1])
     ax[i].set_xlabel('T (K)')
     ax[i].set_ylabel(ylabel)
-plt.tight_layout()
+
 plt.show()
 
 
@@ -123,5 +123,5 @@ for i, ylabel in enumerate(['$C_p$ (J/K/mol)', '$Q$', '$H$ (kJ/mol)']):
     ax[i].set_xlim(temperatures[0], temperatures[-1])
     ax[i].set_xlabel('T (K)')
     ax[i].set_ylabel(ylabel)
-plt.tight_layout()
+
 plt.show()


### PR DESCRIPTION
The tester is failing on at least one benchmark, apparently associated with use of plt.tight_layout().
I think this is related to an old Agg renderer warning that we deal with in test.sh. Presumably the message has changed, but the warning is still there.
 
This PR replaces the calls to tight_layout() with calls to set_tight_layout(True), which apparently isn't associated with the same warning.