### PR TITLE
added changelog to docs

### DIFF
--- a/sphinx/changelog/20210802_burnman_team.rst
+++ b/sphinx/changelog/20210802_burnman_team.rst
@@ -1,0 +1,3 @@
+* BurnMan 0.9.0 is released.
+
+  *The BurnMan Team, 2021/08/02*

--- a/sphinx/changelog/20210804_bobmyhill.rst
+++ b/sphinx/changelog/20210804_bobmyhill.rst
@@ -1,0 +1,4 @@
+* The BurnMan homepage is updated and moved to
+  https://geodynamics.github.io/burnman/
+
+  *Bob Myhill and Timo Heister, 2021/08/04*

--- a/sphinx/changelog/20210805_bobmyhill.rst
+++ b/sphinx/changelog/20210805_bobmyhill.rst
@@ -1,0 +1,7 @@
+* :class:`burnman.composite.Composite` now has new properties which include
+  the *endmember_formulae*, a list of *elements* which make up those formulae,
+  the *stoichiometric_matrix* (number of atoms of element j in formula i),
+  and an independent *reaction_basis*. These properties are calculated once
+  when they are first needed, and then cached.
+
+  *Bob Myhill, 2021/08/05*

--- a/sphinx/changes.rst
+++ b/sphinx/changes.rst
@@ -1,0 +1,5 @@
+
+Changes
+=======
+
+The following is a list of recent improvements to BurnMan.

--- a/sphinx/index_pdf.rst
+++ b/sphinx/index_pdf.rst
@@ -5,14 +5,16 @@
 
 BurnMan: a thermodynamic and geophysics toolkit for the Earth and planetary sciences
 ====================================================================================
-	   
+
 .. toctree::
    :maxdepth: 4
-	      
+   :glob:
+
    introduction
    background
    tutorial
    examples
    api
+   changes
+   changelog/*
    zreferences
-   


### PR DESCRIPTION
This PR adds a changelog to the pdf version of the documentation. 

Unfortunately, it seems that globbing is allowed in toctrees, but not includes, so we can't easily add a changelog to the html docs if we're using >1 file to store the changes (which is desirable to avoid version control issues).