### PR TITLE
fix modified properties with pvt eos

### DIFF
--- a/burnman/mineral.py
+++ b/burnman/mineral.py
@@ -139,7 +139,7 @@ class Mineral(Material):
     @material_property
     @copy_documentation(Material.molar_gibbs)
     def molar_gibbs(self):
-        return self.method.gibbs_free_energy(self.pressure, self.temperature, self.molar_volume, self.params) \
+        return self.method.gibbs_free_energy(self.pressure, self.temperature, self._molar_volume_unmodified, self.params) \
             + self._property_modifiers['G']
 
     @material_property
@@ -155,7 +155,7 @@ class Mineral(Material):
     @material_property
     @copy_documentation(Material.molar_entropy)
     def molar_entropy(self):
-        return self.method.entropy(self.pressure, self.temperature, self.molar_volume, self.params) \
+        return self.method.entropy(self.pressure, self.temperature, self._molar_volume_unmodified, self.params) \
             - self._property_modifiers['dGdT']
 
     @material_property
@@ -163,7 +163,7 @@ class Mineral(Material):
     def isothermal_bulk_modulus(self):
         K_T_orig = self.method.isothermal_bulk_modulus(
             self.pressure, self.temperature,
-            self.molar_volume, self.params)
+            self._molar_volume_unmodified, self.params)
 
         return self.molar_volume \
             / ((self._molar_volume_unmodified / K_T_orig) - self._property_modifiers['d2GdP2'])
@@ -173,7 +173,7 @@ class Mineral(Material):
     def molar_heat_capacity_p(self):
         return (self.method.molar_heat_capacity_p(self.pressure,
                                                   self.temperature,
-                                                  self.molar_volume,
+                                                  self._molar_volume_unmodified,
                                                   self.params)
                 - self.temperature * self._property_modifiers['d2GdT2'])
 
@@ -182,7 +182,8 @@ class Mineral(Material):
     def thermal_expansivity(self):
         return (
             (self.method.thermal_expansivity(self.pressure, self.temperature,
-                                             self.molar_volume, self.params)
+                                             self._molar_volume_unmodified,
+                                             self.params)
              * self._molar_volume_unmodified)
             + self._property_modifiers['d2GdPdT']) / self.molar_volume
 
@@ -190,7 +191,8 @@ class Mineral(Material):
     @copy_documentation(Material.shear_modulus)
     def shear_modulus(self):
         G = self.method.shear_modulus(
-            self.pressure, self.temperature, self.molar_volume, self.params)
+            self.pressure, self.temperature, self._molar_volume_unmodified,
+            self.params)
         if G < np.finfo('float').eps:
             warnings.formatwarning = lambda msg, * \
                 a: 'Warning from file \'{0}\', line {1}:\n{2}\n\n'.format(

--- a/misc/ref/endmember_benchmarks.py.out
+++ b/misc/ref/endmember_benchmarks.py.out
@@ -34,6 +34,6 @@ Periclase: -2.836e+05 1.014e+02 1.050e-05 5.211e+01 2.818e-05 2.036e+11 3.837e+0
 Wuestite: 7.362e+04 1.409e+02 1.158e-05 5.267e+01 2.581e-05 2.323e+11 6.206e+03
 Mg_Wadsleyite: -1.084e+06 3.416e+02 3.812e-05 1.792e+02 2.287e-05 2.121e+11 3.691e+03
 Mg_Ringwoodite: -1.020e+06 3.348e+02 3.693e-05 1.770e+02 1.877e-05 2.359e+11 3.810e+03
-Stishovite: -4.479e+05 1.282e+02 1.354e-05 7.610e+01 1.980e-05 3.410e+11 4.437e+03
+Stishovite: -4.479e+05 1.281e+02 1.354e-05 7.609e+01 1.979e-05 3.411e+11 4.437e+03
 Maximum percentage error in SLB database with configurational entropy and landau transition:
-alpha: 4e-02% at 20 GPa and 1673 K for Stishovite
+S: 1e-02% at 20 GPa and 1673 K for Stishovite

--- a/tests/test_modifiers.py
+++ b/tests/test_modifiers.py
@@ -4,6 +4,8 @@ from util import BurnManTest
 
 import burnman_path
 import burnman.eos.property_modifiers as pm
+from burnman.minerals import SLB_2011, HP_2011_ds62
+from burnman.tools import check_eos_consistency
 
 assert burnman_path  # silence pyflakes warning
 
@@ -54,6 +56,21 @@ class Modifiers(BurnManTest):
             gibbs_excesses_output.append(round(excesses[0]['G'], 4))
 
         self.assertArraysAlmostEqual(gibbs_excesses_output, gibbs_excesses)
+
+    def test_modifier_with_pvt_eos(self):
+        qtz = SLB_2011.quartz()
+        assert(check_eos_consistency(qtz, 1.e5, 600.))
+        assert(check_eos_consistency(qtz, 1.e5, 1100.))
+        assert(check_eos_consistency(qtz, 1.e9, 1100.))
+
+    def test_modifier_with_vpt_eos(self):
+        qtz = HP_2011_ds62.q()
+        assert(check_eos_consistency(qtz, 1.e5, 600.,
+                                     including_shear_properties=False))
+        assert(check_eos_consistency(qtz, 1.e5, 1100.,
+                                     including_shear_properties=False))
+        assert(check_eos_consistency(qtz, 1.e9, 1100.,
+                                     including_shear_properties=False))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
In cases where the SLB dataset has a modified volume (e.g. quartz, which has a Landau transition with non-zero volume of disorder), Mineral needs to use the unmodified volume to calculate all of the unmodified properties, and then amend those with the modified properties.

This PR ensures that we do this correctly, and adds two more tests.