### PR TITLE
split new and 2014 tutorials in the documentation

### DIFF
--- a/docs/cider_tutorial.rst
+++ b/docs/cider_tutorial.rst
@@ -1,0 +1,35 @@
+
+
+CIDER Tutorial 2014
+*******************
+
+The tutorial for BurnMan presented at CIDER 2014 consists of three separate units:
+  - :mod:`step 1 <contrib.cider_tutorial_2014.step_1>`,
+  - :mod:`step 2 <contrib.cider_tutorial_2014.step_2>`, and
+  - :mod:`step 3 <contrib.cider_tutorial_2014.step_3>`.
+
+.. _ref-example-tut1:
+
+.. automodule:: contrib.cider_tutorial_2014.step_1
+
+When run (without putting in a more realistic composition), the program produces the following image:
+
+.. image:: figures/tut-step1.png
+
+Your goal in this tutorial is to improve this awful fit...
+
+
+
+.. automodule:: contrib.cider_tutorial_2014.step_2
+
+Without changing any input, the program should produce the following image showing the misfit as a function of perovskite content:
+
+.. image:: figures/tut-step2.png
+
+
+
+.. automodule:: contrib.cider_tutorial_2014.step_3
+
+After changing the standard deviations for :math:`K_{0}^{'}` and :math:`G_{0}^{'}` to 0.2, the following figure of velocities for 1000 realizations is produced:
+
+.. image:: figures/tut-step3.png

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -72,6 +72,7 @@ Acknowledgement and Support
   introduction
   background
   tutorial
+  cider_tutorial
   examples
   api
   zreferences

--- a/docs/index_pdf.rst
+++ b/docs/index_pdf.rst
@@ -13,6 +13,7 @@ BurnMan: a thermodynamic and geophysics toolkit for the Earth and planetary scie
    introduction
    background
    tutorial
+   cider_tutorial
    examples
    api
    changes

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -5,6 +5,9 @@
 The BurnMan Tutorial
 ********************
 
+This tutorial introduces users to the main classes and some of the important
+functions implemented in BurnMan. The tutorial is split into several parts:
+
 .. toctree::
   :maxdepth: 1
 
@@ -13,37 +16,3 @@ The BurnMan Tutorial
   tutorial_03_layers_and_planets.ipynb
   tutorial_04_fitting.ipynb
   tutorial_05_equilibrium.ipynb
-
-CIDER Tutorial 2014
-*******************
-
-The tutorial for BurnMan presented at CIDER 2014 consists of three separate units:
-  - :mod:`step 1 <contrib.cider_tutorial_2014.step_1>`,
-  - :mod:`step 2 <contrib.cider_tutorial_2014.step_2>`, and
-  - :mod:`step 3 <contrib.cider_tutorial_2014.step_3>`.
-
-.. _ref-example-tut1:
-
-.. automodule:: contrib.cider_tutorial_2014.step_1
-
-When run (without putting in a more realistic composition), the program produces the following image:
-
-.. image:: figures/tut-step1.png
-
-Your goal in this tutorial is to improve this awful fit...
-
-
-
-.. automodule:: contrib.cider_tutorial_2014.step_2
-
-Without changing any input, the program should produce the following image showing the misfit as a function of perovskite content:
-
-.. image:: figures/tut-step2.png
-
-
-
-.. automodule:: contrib.cider_tutorial_2014.step_3
-
-After changing the standard deviations for :math:`K_{0}^{'}` and :math:`G_{0}^{'}` to 0.2, the following figure of velocities for 1000 realizations is produced:
-
-.. image:: figures/tut-step3.png


### PR DESCRIPTION
Some minor cleanup up of the documentation so that the new and old tutorials are properly separated in ReadTheDocs.