### PR TITLE
modify binder installation order

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -12,3 +12,5 @@ dependencies:
   - ipympl
   - ipywidgets
   - appmode
+  - pip:
+    - mpl-interactions

--- a/.binder/postBuild
+++ b/.binder/postBuild
@@ -1,2 +1,1 @@
 python -m pip install -vvv -e .
-python -m pip install mpl_interactions


### PR DESCRIPTION
This PR moves installation of mpl-interactions into environment.yml and removes it from postBuild, as suggested in #447.