### PR TITLE
Remove burnman_path hacks

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -50,9 +50,10 @@ Authors (as of 2021):
     `git clone https://github.com/geodynamics/burnman.git`
 
     Alternatively, if you don't want to use git, you can download the current master branch from https://github.com/geodynamics/burnman/archive/master.zip.
-2. Install using apt by opening a terminal window and entering
-`sudo apt-get install python python-scipy python-numpy python-sympy python-matplotlib`
-3. Go to the Burnman examples directory and type:
+2. Install python (if you don't have a recent version) using apt by opening a terminal window and entering
+`sudo apt-get install python`
+3. Install this repository, either in static mode: `python -m pip install .` or in development mode (if you want to develop or modify the code): `python -m pip install -e .`. 
+4. Go to the Burnman examples directory and type:
 ```python example_beginner.py```
 Figures should show up, indicating that it is working.
 

--- a/Readme.md
+++ b/Readme.md
@@ -39,36 +39,38 @@ Authors (as of 2021):
 * pycddlib
 
 ## Installation
-Installation of BurnMan is mostly platform independent. As long as you know how to use a terminal, you should be able to get set up quickly! The following instructions should help, but let us know if you have any problems.
+Installation of BurnMan is mostly platform independent.
+As long as you know how to use a terminal, the process should be straightforward.
+The following instructions should help, but let us know if you have any problems.
 
 ### Dependencies
 First, make sure you have a sufficiently recent version of python installed on your machine (see above for the latest requirements).  To check your version of python, type the following in a terminal:
     python --version
 If your version is not recent enough, visit https://www.python.org/ to find out how to install a newer version.
 
-Once you have checked your version of python, you should make sure you have installed the python module pip. This module will install BurnMan and should take care of all project dependencies. If you don't have it already, you can install it by opening a terminal window and typing:
+Once you have checked your version of python, you should make sure you have installed the python module pip. We will use this module to install BurnMan. If you don't have it already, you can install it by opening a terminal window and typing:
 
     python -m ensurepip --upgrade
 
-Mac users will also need to have Xcode, which can be installed via the MacStore.
+Mac users will also need to install Xcode, which can be found in the MacStore.
 
 ### Stable version
-If you are only interested in using burnman (rather than developing the software), and you aren't interested in any of the latest developments, you can install the stable version of BurnMan by typing the following into a terminal window:
+If you are only interested in using BurnMan (rather than developing the software), and you aren't interested in any of the latest changes, you can install the stable version by typing the following into a terminal window:
 
     python -m pip install burnman
 
-This method of installation does not give you easy access to all the examples, or the test suite. You can download these from https://github.com/geodynamics/burnman/releases.
+This method of installation does not give you easy access to all the examples, or the test suite. These can be found in the latest release package which can be downloaded from https://github.com/geodynamics/burnman/releases.
 
 ### Development version
-If you want to install the development version of BurnMan (with all the latest features), you will first need to download all the files onto your system. The best way to do this is by using git (a version control system). To install git, follow the instructions at https://git-scm.com/downloads.
+If you want to install the development version of BurnMan (with all the latest features), you will first need to download the source code. The best way to do this is by using git (a version control system). To install git, follow the instructions at https://git-scm.com/downloads.
 
-Then go to the directory into which you want to clone the BurnMan repository, and type
+Then, using a terminal, navigate to the directory into which you want to clone the BurnMan repository, and type
 
     git clone https://github.com/geodynamics/burnman.git
 
 (If you don't want to use git, you can download the current master branch from https://github.com/geodynamics/burnman/archive/master.zip.)
 
-Once the repository is cloned, navigate to the top-level directory by typing `cd burnman` in the terminal, and then install, either in static mode: `python -m pip install .` or in development mode (if you want to develop or modify the code): `python -m pip install -e .`.
+Once the repository is cloned, navigate to the top-level directory by typing `cd burnman` in the terminal, and then install BurnMan, either in static mode: `python -m pip install .` or in development mode (if you want to develop or modify the code): `python -m pip install -e .`.
 
 ### Checking that the installation worked
 

--- a/Readme.md
+++ b/Readme.md
@@ -68,13 +68,13 @@ Then go to the directory into which you want to clone the BurnMan repository, an
 
 (If you don't want to use git, you can download the current master branch from https://github.com/geodynamics/burnman/archive/master.zip.)
 
-Once the repository is cloned, navigate to the top-level directory using `cd burnman` in the terminal, and then install, either in static mode: `python -m pip install .` or in development mode (if you want to develop or modify the code): `python -m pip install -e .`.
+Once the repository is cloned, navigate to the top-level directory by typing `cd burnman` in the terminal, and then install, either in static mode: `python -m pip install .` or in development mode (if you want to develop or modify the code): `python -m pip install -e .`.
 
 ### Checking that the installation worked
 
 To check that the installation has worked, you can run the test suite (`./test.sh`). This takes a few minutes to run.
 
-A basic check that BurnMan is installed is to navigate to the Burnman examples directory and type:
+A more basic check that BurnMan is installed is to navigate to the Burnman examples directory and type:
 
     python example_beginner.py
 

--- a/Readme.md
+++ b/Readme.md
@@ -38,85 +38,48 @@ Authors (as of 2021):
 * cvxpy
 * pycddlib
 
+## Installation
+Installation of BurnMan is mostly platform independent. As long as you know how to use a terminal, you should be able to get set up quickly! The following instructions should help, but let us know if you have any problems.
 
-## Install under Ubuntu
+### Dependencies
+First, make sure you have a sufficiently recent version of python installed on your machine (see above for the latest requirements).  To check your version of python, type the following in a terminal:
+    python --version
+If your version is not recent enough, visit https://www.python.org/ to find out how to install a newer version.
 
-1. Clone this repository using git (or download it). To install git, open a terminal window and type
+Once you have checked your version of python, you should make sure you have installed the python module pip. This module will install BurnMan and should take care of all project dependencies. If you don't have it already, you can install it by opening a terminal window and typing:
 
-    `sudo apt-get install git`
+    python -m ensurepip --upgrade
 
-    Then go to the directory into which you want to clone the repository, and type
+Mac users will also need to have Xcode, which can be installed via the MacStore.
 
-    `git clone https://github.com/geodynamics/burnman.git`
+### Stable version
+If you are only interested in using burnman (rather than developing the software), and you aren't interested in any of the latest developments, you can install the stable version of BurnMan by typing the following into a terminal window:
 
-    Alternatively, if you don't want to use git, you can download the current master branch from https://github.com/geodynamics/burnman/archive/master.zip.
-2. Install python (if you don't have a recent version) using apt by opening a terminal window and entering
-`sudo apt-get install python`
-3. Install this repository, either in static mode: `python -m pip install .` or in development mode (if you want to develop or modify the code): `python -m pip install -e .`. 
-4. Go to the Burnman examples directory and type:
-```python example_beginner.py```
-Figures should show up, indicating that it is working.
+    python -m pip install burnman
 
+This method of installation does not give you easy access to all the examples, or the test suite. You can download these from https://github.com/geodynamics/burnman/releases.
 
-## Install on a Mac
+### Development version
+If you want to install the development version of BurnMan (with all the latest features), you will first need to download all the files onto your system. The best way to do this is by using git (a version control system). To install git, follow the instructions at https://git-scm.com/downloads.
 
-1. Clone this repository using git (or download it). To install git, open a terminal window and type
+Then go to the directory into which you want to clone the BurnMan repository, and type
 
-    `ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`
+    git clone https://github.com/geodynamics/burnman.git
 
-    `brew doctor`
+(If you don't want to use git, you can download the current master branch from https://github.com/geodynamics/burnman/archive/master.zip.)
 
-    `brew install git`
+Once the repository is cloned, navigate to the top-level directory using `cd burnman` in the terminal, and then install, either in static mode: `python -m pip install .` or in development mode (if you want to develop or modify the code): `python -m pip install -e .`.
 
-    Then go to the directory into which you want to clone the repository, and type
+### Checking that the installation worked
 
-    `git clone https://github.com/geodynamics/burnman.git`
+To check that the installation has worked, you can run the test suite (`./test.sh`). This takes a few minutes to run.
 
-    Alternatively, if you don't want to use git, you can download the current master branch from https://github.com/geodynamics/burnman/archive/master.zip.
-2. get Xcode
-3. If you don't have Python yet, download it (for free) from
-   python.org/download . Make sure to use a modern version of Python (3.7+).
-   To check your version of python, type the following in a
-   terminal:
-     python --version
-4. Install the latest Numpy version: http://sourceforge.net/projects/numpy/files/NumPy/
-5. Install the latest Scipy at http://sourceforge.net/projects/scipy/files/
-6. Install the latest Scipy at http://sourceforge.net/projects/sympy/files/
-7. Install the latest Matplotlib from http://sourceforge.net/projects/matplotlib/files/matplotlib/matplotlib-1.1.1/
-8. Go to the Burnman examples directory and type:
-	python example_beginner.py
-    Figures should show up, indicating that it is working.
+A basic check that BurnMan is installed is to navigate to the Burnman examples directory and type:
 
-Problems you might run into:
+    python example_beginner.py
 
-* Installing numpy/scipy/sympy/matplotlib for a different python version than the
-  one on your computer
+If figures show up, BurnMan has been installed.
 
-* Having matplotlib for 32-bit instead of 64-bit (for me this got fixed by
-  installing the very latest version). This will give you the error `no
-  matching architecture in universal wrapper`. You can check if your python
-  distribution is 32 or 64 bit with the following lines:
-```
-python
->>> import platform
->>> print platform.architecture()
-```
-
-## Install under Windows
-
-1. Clone this repository using git (or download it). git can be downloaded from here: https://gitforwindows.org/. There are a number of different ways to use git as installed under windows (command-line, gui). Use your favoured method to clone the burnman repository: https://github.com/geodynamics/burnman.git. Alternatively, if you don't want to use git, you can download the current master branch from https://github.com/geodynamics/burnman/archive/master.zip.
-
-To get Python running under Windows:
-
-1. Download Python from http://www.python.org/ and install
-2. Go to http://www.lfd.uci.edu/~gohlke/pythonlibs/#numpy, download and install
-3. Go to http://www.lfd.uci.edu/~gohlke/pythonlibs/#scipy, download and install
-3. Go to http://www.lfd.uci.edu/~gohlke/pythonlibs/#sympy, download and install
-4. Go to http://www.lfd.uci.edu/~gohlke/pythonlibs/#matplotlib, download and install
-5. Download BurnMan from github (https://github.com/geodynamics/burnman)
-6. Open Python Shell (IDLE Python GUI)
-7. File -- Open -- find one of the example files
-8. Run the module (or press F5)
 
 ## Start Here
 

--- a/burnman/__init__.py
+++ b/burnman/__init__.py
@@ -89,7 +89,7 @@ Installation
 ------------
 
 Installation of BurnMan is mostly platform independent.
-As long as you know how to use a terminal, you should be able to get set up quickly!
+As long as you know how to use a terminal, the process should be straightforward.
 The following instructions should help, but let us know if you have any problems.
 
 Dependencies
@@ -102,38 +102,37 @@ If your version is not recent enough, visit https://www.python.org/ to
 find out how to install a newer version.
 
 Once you have checked your version of python, you should make sure you have
-installed the python module pip. This module will install BurnMan and should
-take care of all project dependencies. If you don't have it already,
-you can install it by opening a terminal window and typing:
+installed the python module pip. We will use this module to install BurnMan.
+If you don't have it already, you can install it by opening a
+terminal window and typing:
 
     python -m ensurepip --upgrade
 
-Mac users will also need to have Xcode, which can be installed via the MacStore.
+Mac users will also need to install Xcode, which can be found in the MacStore.
 
 Stable version
 ^^^^^^^^^^^^^^
 
-If you are only interested in using burnman
+If you are only interested in using BurnMan
 (rather than developing the software), and you aren't interested in any of the
-latest developments, you can install the stable version of BurnMan by typing
+latest changes, you can install the stable version by typing
 the following into a terminal window:
 
     python -m pip install burnman
 
 This method of installation does not give you easy access to all the examples,
-or the test suite. You can download these from
-https://github.com/geodynamics/burnman/releases.
+or the test suite. These can be found in the latest release package which can
+be downloaded from https://github.com/geodynamics/burnman/releases.
 
 Development version
 ^^^^^^^^^^^^^^^^^^^
 If you want to install the development version of BurnMan
-(with all the latest features), you will first need to download all the files
-onto your system. The best way to do this is by using git
-(a version control system). To install git, follow the instructions at
-https://git-scm.com/downloads.
+(with all the latest features), you will first need to download the source code.
+The best way to do this is by using git (a version control system).
+To install git, follow the instructions at https://git-scm.com/downloads.
 
-Then go to the directory into which you want to clone the BurnMan repository,
-and type
+Then, using a terminal, navigate to the directory into which you want to
+clone the BurnMan repository, and type
 
     git clone https://github.com/geodynamics/burnman.git
 
@@ -141,7 +140,7 @@ and type
 from https://github.com/geodynamics/burnman/archive/master.zip.)
 
 Once the repository is cloned, navigate to the top-level directory by typing
-`cd burnman` in the terminal, and then install, either in static mode:
+`cd burnman` in the terminal, and then install BurnMan, either in static mode:
 `python -m pip install .` or in development mode
 (if you want to develop or modify the code): `python -m pip install -e .`.
 

--- a/burnman/__init__.py
+++ b/burnman/__init__.py
@@ -77,61 +77,85 @@ Structure
 
 .. _ref-installation:
 
-Installation
-------------
 
 Requirements
-^^^^^^^^^^^^
+------------
 
   - Python 3.7+
   - Python modules: NumPy, SciPy, SymPy, Matplotlib
+  - Optional modules: cvxpy, pycddlib
 
+Installation
+------------
 
-Source code
-^^^^^^^^^^^
-The source code can be found at https://github.com/geodynamics/burnman.
+Installation of BurnMan is mostly platform independent.
+As long as you know how to use a terminal, you should be able to get set up quickly!
+The following instructions should help, but let us know if you have any problems.
 
-Install under Ubuntu
-^^^^^^^^^^^^^^^^^^^^
+Dependencies
+^^^^^^^^^^^^
+First, make sure you have a sufficiently recent version of python installed
+on your machine (see above for the latest requirements).
+To check your version of python, type the following in a terminal:
+    python --version
+If your version is not recent enough, visit https://www.python.org/ to
+find out how to install a newer version.
 
-1. Install dependencies using apt by opening a terminal window and entering
-   ``sudo apt-get install python python-scipy python-numpy python-sympy python-matplotlib git``
-2. Clone the BurnMan repository ``git clone https://github.com/geodynamics/burnman.git``
-3. Go to the Burnman examples directory and type:
-   ``python example_beginner.py``
-   Figures should show up, indicating that it is working.
+Once you have checked your version of python, you should make sure you have
+installed the python module pip. This module will install BurnMan and should
+take care of all project dependencies. If you don't have it already,
+you can install it by opening a terminal window and typing:
 
+    python -m ensurepip --upgrade
 
-Install on a Mac
-^^^^^^^^^^^^^^^^
+Mac users will also need to have Xcode, which can be installed via the MacStore.
 
-1. get Xcode
-2. If you don't have Python yet, download it (for free) from
-   python.org/download . Make sure to use Python 3.7+.
-   To check your version of python, type the following in a
-   terminal: ``python --version``
-3. Install the latest Numpy version from http://sourceforge.net/projects/numpy/files/NumPy/
-4. Install the latest Scipy from http://sourceforge.net/projects/scipy/files/
-5. Install the latest Sympy from http://sourceforge.net/projects/sympy/files/
-6. Install the latest Matplotlib from http://sourceforge.net/projects/matplotlib/files/matplotlib/matplotlib-1.1.1/
-7. Clone the BurnMan repository ``git clone https://github.com/geodynamics/burnman.git``
-8. Go to the Burnman examples directory and type ``python example_beginner.py``
-   Figures should show up, indicating that it is working.
+Stable version
+^^^^^^^^^^^^^^
 
-Install under Windows
-^^^^^^^^^^^^^^^^^^^^^
+If you are only interested in using burnman
+(rather than developing the software), and you aren't interested in any of the
+latest developments, you can install the stable version of BurnMan by typing
+the following into a terminal window:
 
-To get Python running under Windows:
+    python -m pip install burnman
 
-1. Download Python from http://www.python.org/ and install
-2. Go to http://www.lfd.uci.edu/~gohlke/pythonlibs/#numpy, download and install
-3. Go to http://www.lfd.uci.edu/~gohlke/pythonlibs/#scipy, download and install
-4. Go to http://www.lfd.uci.edu/~gohlke/pythonlibs/#sympy, download and install
-5. Go to http://www.lfd.uci.edu/~gohlke/pythonlibs/#matplotlib, download and install
-6. Download BurnMan from github (https://github.com/geodynamics/burnman)
-7. Open Python Shell (IDLE Python GUI)
-8. File -- Open -- find one of the example files
-9. Run the module (or press F5)
+This method of installation does not give you easy access to all the examples,
+or the test suite. You can download these from
+https://github.com/geodynamics/burnman/releases.
+
+Development version
+^^^^^^^^^^^^^^^^^^^
+If you want to install the development version of BurnMan
+(with all the latest features), you will first need to download all the files
+onto your system. The best way to do this is by using git
+(a version control system). To install git, follow the instructions at
+https://git-scm.com/downloads.
+
+Then go to the directory into which you want to clone the BurnMan repository,
+and type
+
+    git clone https://github.com/geodynamics/burnman.git
+
+(If you don't want to use git, you can download the current master branch
+from https://github.com/geodynamics/burnman/archive/master.zip.)
+
+Once the repository is cloned, navigate to the top-level directory by typing
+`cd burnman` in the terminal, and then install, either in static mode:
+`python -m pip install .` or in development mode
+(if you want to develop or modify the code): `python -m pip install -e .`.
+
+Checking that the installation worked
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+To check that the installation has worked, you can run the test suite
+(`./test.sh`). This takes a few minutes to run.
+
+A more basic check that BurnMan is installed is to navigate to the Burnman
+examples directory and type:
+
+    python example_beginner.py
+
+If figures show up, BurnMan has been installed.
 
 
 Citing BurnMan

--- a/contrib/anisotropic_eos/burnman_path.py
+++ b/contrib/anisotropic_eos/burnman_path.py
@@ -1,6 +1,0 @@
-import os
-import sys
-
-# hack to allow scripts to be placed in subdirectories next to burnman:
-if not os.path.exists('burnman') and os.path.exists('../../burnman'):
-    sys.path.insert(1, os.path.abspath('../..'))

--- a/contrib/anisotropic_eos/cubic_fitting.py
+++ b/contrib/anisotropic_eos/cubic_fitting.py
@@ -28,12 +28,10 @@ import matplotlib.pyplot as plt
 from scipy.optimize import minimize
 from tools import print_table_for_mineral_constants
 
-import burnman_path  # adds the local burnman directory to the path
 import burnman
 
 from burnman import AnisotropicMineral
 
-assert burnman_path  # silence pyflakes warning
 
 run_fitting = False
 

--- a/contrib/anisotropic_eos/orthorhombic_fitting.py
+++ b/contrib/anisotropic_eos/orthorhombic_fitting.py
@@ -27,7 +27,6 @@ import numpy as np
 import matplotlib.pyplot as plt
 from scipy.optimize import minimize
 
-import burnman_path  # adds the local burnman directory to the path
 import burnman
 
 from burnman import AnisotropicMineral
@@ -35,7 +34,6 @@ from burnman import AnisotropicMineral
 from tools import print_table_for_mineral_constants
 from burnman.tools.plot import plot_projected_elastic_properties
 
-assert burnman_path  # silence pyflakes warning
 
 run_fitting = False
 

--- a/docs/changelog/20211102_bobmyhill.rst
+++ b/docs/changelog/20211102_bobmyhill.rst
@@ -1,0 +1,8 @@
+* Running the examples now requires BurnMan to be installed. This change is
+  made to ensure that tester behaviour always matches installed behaviour,
+  rather than local behaviour (the cause of the problem with the 1.0.0 release).
+  If the user wishes to develop the BurnMan code, they may install the module
+  from the top-level directory using pip with the `-e` (editable) flag:
+  `python -m pip install -e .`.
+
+  *Bob Myhill, 2021/11/02*

--- a/examples/burnman_path.py
+++ b/examples/burnman_path.py
@@ -1,6 +1,0 @@
-import os
-import sys
-
-# hack to allow scripts to be placed in subdirectories next to burnman:
-if not os.path.exists('burnman') and os.path.exists('../burnman'):
-    sys.path.insert(1, os.path.abspath('..'))

--- a/examples/example_anisotropic_mineral.py
+++ b/examples/example_anisotropic_mineral.py
@@ -25,13 +25,11 @@ from __future__ import print_function
 
 import numpy as np
 import matplotlib.pyplot as plt
-import burnman_path  # adds the local burnman directory to the path
 from burnman import AnisotropicMineral
 from burnman.minerals import SLB_2011
 from burnman.tools.eos import check_anisotropic_eos_consistency
 from burnman.tools.plot import plot_projected_elastic_properties
 
-assert burnman_path  # silence pyflakes warning
 
 if __name__ == "__main__":
 

--- a/examples/example_anisotropy.py
+++ b/examples/example_anisotropy.py
@@ -24,10 +24,8 @@ from __future__ import print_function
 
 import numpy as np
 import matplotlib.pyplot as plt
-import burnman_path  # adds the local burnman directory to the path
 from burnman.classes import anisotropy
 
-assert burnman_path  # silence pyflakes warning
 
 if __name__ == "__main__":
 

--- a/examples/example_averaging.py
+++ b/examples/example_averaging.py
@@ -37,11 +37,9 @@ from __future__ import print_function
 
 import numpy as np
 import matplotlib.pyplot as plt
-import burnman_path  # adds the local burnman directory to the path
 import burnman
 from burnman import minerals
 
-assert burnman_path  # silence pyflakes warning
 
 if __name__ == "__main__":
 

--- a/examples/example_beginner.py
+++ b/examples/example_beginner.py
@@ -43,11 +43,9 @@ import matplotlib.pyplot as plt
 # thermoelastic properties of them.  The minerals module includes
 # the mineral physical parameters for the predefined minerals in
 # BurnMan
-import burnman_path  # adds the local burnman directory to the path
 import burnman
 from burnman import minerals
 
-assert burnman_path  # silence pyflakes warning
 
 if __name__ == "__main__":
 

--- a/examples/example_build_planet.py
+++ b/examples/example_build_planet.py
@@ -49,12 +49,10 @@ from __future__ import print_function
 import matplotlib.pyplot as plt
 import numpy as np
 
-import burnman_path  # adds the local burnman directory to the path
 import burnman
 
 import warnings
 
-assert burnman_path  # silence pyflakes warning
 
 if __name__ == '__main__':
     # FIRST: we must define the composition of the planet as individual layers.

--- a/examples/example_chemical_potentials.py
+++ b/examples/example_chemical_potentials.py
@@ -23,14 +23,12 @@ from __future__ import print_function
 import numpy as np
 import matplotlib.pyplot as plt
 
-import burnman_path  # adds the local burnman directory to the path
 import burnman
 from burnman import Composite
 import burnman.constants as constants
 from burnman.tools import chemistry
 import burnman.minerals as minerals
 
-assert burnman_path  # silence pyflakes warning
 
 if __name__ == "__main__":
 

--- a/examples/example_compare_all_methods.py
+++ b/examples/example_compare_all_methods.py
@@ -30,11 +30,9 @@ from __future__ import print_function
 import numpy as np
 import matplotlib.pyplot as plt
 
-import burnman_path  # adds the local burnman directory to the path
 import burnman
 from burnman import minerals
 
-assert burnman_path  # silence pyflakes warning
 
 if __name__ == "__main__":
     # Input composition.

--- a/examples/example_composite.py
+++ b/examples/example_composite.py
@@ -35,12 +35,10 @@ import numpy as np
 from scipy.optimize import brentq, fsolve
 import matplotlib.pyplot as plt
 
-import burnman_path  # adds the local burnman directory to the path
 
 import burnman
 from burnman import minerals
 
-assert burnman_path  # silence pyflakes warning
 
 if __name__ == "__main__":
 

--- a/examples/example_composite_seismic_velocities.py
+++ b/examples/example_composite_seismic_velocities.py
@@ -47,12 +47,10 @@ from __future__ import print_function
 import numpy as np
 import matplotlib.pyplot as plt
 
-import burnman_path  # adds the local burnman directory to the path
 
 import burnman
 from burnman import minerals
 
-assert burnman_path  # silence pyflakes warning
 
 if __name__ == "__main__":
 

--- a/examples/example_composition.py
+++ b/examples/example_composition.py
@@ -25,7 +25,6 @@ This example script demonstrates the use of BurnMan's Composition class.
 from __future__ import absolute_import
 from __future__ import print_function
 
-import burnman_path
 from burnman.tools.chemistry import dictionarize_formula
 
 # Import the Composition class and a function to read compositions from file
@@ -36,7 +35,6 @@ from burnman.tools.chemistry import dictionarize_formula
 from burnman import Composition
 from burnman.classes.composition import file_to_composition_list
 
-assert burnman_path  # silence pyflakes warning
 
 if __name__ == "__main__":
     print('1) Creating a Composite instance, printing '

--- a/examples/example_dataset_uncertainties.py
+++ b/examples/example_dataset_uncertainties.py
@@ -29,12 +29,10 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 
-import burnman_path  # adds the local burnman directory to the path
 # Here we import the relevant modules from BurnMan.
 from burnman.minerals import HP_2011_ds62
 from burnman.optimize.nonlinear_fitting import plot_cov_ellipse  # for plotting
 
-assert burnman_path  # silence pyflakes warning
 
 plt.style.use('ggplot')
 

--- a/examples/example_equilibrate.py
+++ b/examples/example_equilibrate.py
@@ -64,13 +64,11 @@ from copy import copy
 import numpy as np
 import matplotlib.pyplot as plt
 
-import burnman_path
 import burnman
 from burnman import equilibrate
 from burnman.minerals import HP_2011_ds62, SLB_2011, JH_2015
 from burnman.tools.polytope import simplify_composite_with_composition
 
-assert burnman_path  # silence pyflakes warning
 
 run_aluminosilicates = True
 run_ordering = True

--- a/examples/example_fit_composition.py
+++ b/examples/example_fit_composition.py
@@ -33,12 +33,10 @@ import numpy as np
 import matplotlib.pyplot as plt
 import itertools
 
-import burnman_path  # adds the local burnman directory to the path
 from burnman import minerals
 from burnman.optimize.composition_fitting import fit_composition_to_solution
 from burnman.optimize.composition_fitting import fit_phase_proportions_to_bulk_composition
 
-assert burnman_path  # silence pyflakes warning
 
 if __name__ == "__main__":
 

--- a/examples/example_fit_data.py
+++ b/examples/example_fit_data.py
@@ -25,11 +25,9 @@ from __future__ import print_function
 import numpy as np
 import matplotlib.pyplot as plt
 
-import burnman_path  # adds the local burnman directory to the path
 import burnman
 import warnings
 
-assert burnman_path  # silence pyflakes warning
 
 if __name__ == "__main__":
 

--- a/examples/example_fit_eos.py
+++ b/examples/example_fit_eos.py
@@ -25,13 +25,11 @@ from __future__ import print_function
 import numpy as np
 import matplotlib.pyplot as plt
 
-import burnman_path  # adds the local burnman directory to the path
 import burnman
 
 from burnman.tools.unitcell import molar_volume_from_unit_cell_volume
 from burnman.tools.misc import attribute_function
 
-assert burnman_path  # silence pyflakes warning
 
 if __name__ == "__main__":
 

--- a/examples/example_geodynamic_adiabat.py
+++ b/examples/example_geodynamic_adiabat.py
@@ -46,11 +46,9 @@ from scipy.optimize import fsolve, brentq
 from scipy.integrate import odeint
 from scipy.interpolate import UnivariateSpline
 
-import burnman_path  # adds the local burnman directory to the path
 import burnman
 from burnman.tools.math import interp_smoothed_array_and_derivatives
 
-assert burnman_path  # silence pyflakes warning
 
 if __name__ == "__main__":
     #  Define fitting function to find the temperature along the isentrope

--- a/examples/example_geotherms.py
+++ b/examples/example_geotherms.py
@@ -35,12 +35,10 @@ from __future__ import absolute_import
 import numpy as np
 import matplotlib.pyplot as plt
 
-import burnman_path  # adds the local burnman directory to the path
 
 import burnman
 from burnman import minerals
 
-assert burnman_path  # silence pyflakes warning
 
 if __name__ == "__main__":
     # we want to evaluate several geotherms at these values

--- a/examples/example_gibbs_modifiers.py
+++ b/examples/example_gibbs_modifiers.py
@@ -42,7 +42,6 @@ from __future__ import absolute_import
 import numpy as np
 import matplotlib.pyplot as plt
 
-import burnman_path  # adds the local burnman directory to the path
 
 # Here we import the relevant modules from BurnMan.  The burnman
 # module imports several of the most important functionalities of
@@ -53,7 +52,6 @@ import burnman_path  # adds the local burnman directory to the path
 import burnman
 from burnman import minerals
 
-assert burnman_path  # silence pyflakes warning
 
 if __name__ == "__main__":
 

--- a/examples/example_grid.py
+++ b/examples/example_grid.py
@@ -21,12 +21,10 @@ import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d import Axes3D
 from matplotlib import cm
 
-import burnman_path  # adds the local burnman directory to the path
 
 import burnman
 from burnman import minerals
 
-assert burnman_path  # silence pyflakes warning
 
 if __name__ == "__main__":
 

--- a/examples/example_inv_murakami.py
+++ b/examples/example_inv_murakami.py
@@ -8,7 +8,6 @@ import sys
 import numpy as np
 import matplotlib.pyplot as plt
 
-import burnman_path  # adds the local burnman directory to the path
 
 import burnman
 from burnman import minerals
@@ -18,7 +17,6 @@ import cProfile
 import scipy.stats as sp
 import matplotlib.mlab as mlab
 
-assert burnman_path  # silence pyflakes warning
 
 if __name__ == "__main__":
     seismic_model = burnman.seismic.PREM()

--- a/examples/example_layer.py
+++ b/examples/example_layer.py
@@ -38,14 +38,12 @@ from __future__ import absolute_import
 import numpy as np
 import matplotlib.pyplot as plt
 
-import burnman_path  # adds the local burnman directory to the path
 
 # Here we import the relevant modules from BurnMan.
 import burnman
 from burnman import minerals
 import warnings
 
-assert burnman_path  # silence pyflakes warning
 
 if __name__ == "__main__":
     # This is the first actual work done in this example.  We define

--- a/examples/example_mineral.py
+++ b/examples/example_mineral.py
@@ -42,7 +42,6 @@ from __future__ import absolute_import
 import numpy as np
 import matplotlib.pyplot as plt
 
-import burnman_path  # adds the local burnman directory to the path
 
 import burnman
 from burnman.minerals import HGP_2018_ds633, SLB_2011
@@ -51,7 +50,6 @@ from burnman import CombinedMineral
 from burnman.tools.chemistry import dictionarize_formula, formula_mass
 from burnman.tools.chemistry import formula_to_string
 
-assert burnman_path  # silence pyflakes warning
 
 if __name__ == "__main__":
     '''

--- a/examples/example_olivine_binary.py
+++ b/examples/example_olivine_binary.py
@@ -28,12 +28,10 @@ from __future__ import print_function
 import numpy as np
 import matplotlib.pyplot as plt
 
-import burnman_path
 import burnman
 from burnman import equilibrate
 from burnman.minerals import SLB_2011
 
-assert burnman_path  # silence pyflakes warning
 
 
 if __name__ == "__main__":

--- a/examples/example_optimize_pv.py
+++ b/examples/example_optimize_pv.py
@@ -32,12 +32,10 @@ from __future__ import print_function
 import numpy as np
 import matplotlib.pyplot as plt
 
-import burnman_path  # adds the local burnman directory to the path
 
 import burnman
 from burnman import minerals
 
-assert burnman_path  # silence pyflakes warning
 
 if __name__ == "__main__":
 

--- a/examples/example_perplex.py
+++ b/examples/example_perplex.py
@@ -28,11 +28,9 @@ It also demonstrates how we can smooth a given property on a given P-T grid.
 import numpy as np
 import matplotlib.pyplot as plt
 
-import burnman_path  # adds the local burnman directory to the path
 import burnman
 from burnman.tools.math import smooth_array
 
-assert burnman_path  # silence pyflakes warning
 
 if __name__ == "__main__":
     rock = burnman.PerplexMaterial('../burnman/data/input_perplex/in23_1.tab')

--- a/examples/example_polytopetools.py
+++ b/examples/example_polytopetools.py
@@ -36,7 +36,6 @@ composite polytope.
 from __future__ import absolute_import
 import numpy as np
 
-import burnman_path  # adds the local burnman directory to the path
 import burnman
 from burnman.minerals import SLB_2011
 from burnman.tools.polytope import solution_polytope_from_charge_balance
@@ -46,7 +45,6 @@ from burnman.tools.polytope import simplify_composite_with_composition
 from burnman.tools.chemistry import site_occupancies_to_strings
 from burnman.tools.chemistry import formula_to_string
 
-assert burnman_path  # silence pyflakes warning
 
 if __name__ == "__main__":
     """

--- a/examples/example_premite_isothermal.py
+++ b/examples/example_premite_isothermal.py
@@ -18,12 +18,10 @@ from __future__ import print_function
 import numpy as np
 import matplotlib.pyplot as plt
 
-import burnman_path  # adds the local burnman directory to the path
 
 import burnman
 import pymc
 
-assert burnman_path  # silence pyflakes warning
 
 seismic_model = burnman.seismic.PREM()  # pick a seismic model, see seismiic.py for details
 number_of_points = 20  # set on how many depth slices the computations should be done

--- a/examples/example_seismic.py
+++ b/examples/example_seismic.py
@@ -41,11 +41,9 @@ from __future__ import print_function
 import numpy as np
 import matplotlib.pyplot as plt
 
-import burnman_path  # adds the local burnman directory to the path
 import burnman
 import warnings
 
-assert burnman_path  # silence pyflakes warning
 
 if __name__ == "__main__":
 

--- a/examples/example_seismic_travel_times.py
+++ b/examples/example_seismic_travel_times.py
@@ -20,7 +20,6 @@ from __future__ import print_function
 import numpy as np  # Library used for general array
 import matplotlib.pyplot as plt  # Library used for plotting
 # Import BurnMan
-import burnman_path  # adds the local burnman directory to the path
 import burnman
 from burnman import minerals  # import mineral library seperately
 
@@ -29,7 +28,6 @@ import obspy
 from obspy.taup import taup_create
 from obspy.taup import TauPyModel
 
-assert burnman_path  # silence pyflakes warning
 
 
 def plot_rays_and_times(modelname):

--- a/examples/example_solid_solution.py
+++ b/examples/example_solid_solution.py
@@ -44,12 +44,10 @@ from __future__ import absolute_import
 import numpy as np
 import matplotlib.pyplot as plt
 
-import burnman_path  # adds the local burnman directory to the path
 
 import burnman
 from burnman import minerals
 
-assert burnman_path  # silence pyflakes warning
 
 if __name__ == "__main__":
     '''

--- a/examples/example_spintransition.py
+++ b/examples/example_spintransition.py
@@ -32,12 +32,10 @@ from __future__ import print_function
 import numpy as np
 import matplotlib.pyplot as plt
 
-import burnman_path  # adds the local burnman directory to the path
 
 import burnman
 from burnman import minerals
 
-assert burnman_path  # silence pyflakes warning
 
 if __name__ == "__main__":
     # seismic model for comparison:

--- a/examples/example_spintransition_thermal.py
+++ b/examples/example_spintransition_thermal.py
@@ -43,13 +43,11 @@ from scipy.optimize import brentq
 import numpy as np
 import matplotlib.pyplot as plt
 
-import burnman_path  # adds the local burnman directory to the path
 
 import burnman
 from burnman import Mineral, minerals
 from burnman.tools.chemistry import formula_mass
 
-assert burnman_path  # silence pyflakes warning
 
 if __name__ == "__main__":
 

--- a/examples/example_tools.py
+++ b/examples/example_tools.py
@@ -21,14 +21,12 @@ from __future__ import print_function
 import numpy as np
 import matplotlib.pyplot as plt
 
-import burnman_path  # adds the local burnman directory to the path
 import burnman
 from burnman.tools.chemistry import equilibrium_pressure
 from burnman.tools.chemistry import equilibrium_temperature
 from burnman.tools.chemistry import invariant_point
 from burnman.tools.chemistry import hugoniot
 from burnman.tools.eos import check_eos_consistency
-assert burnman_path  # silence pyflakes warning
 
 
 def round_to_n(x, xerr, n):

--- a/examples/example_user_input_material.py
+++ b/examples/example_user_input_material.py
@@ -25,10 +25,8 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import numpy as np
-import burnman_path  # adds the local burnman directory to the path
 import burnman
 
-assert burnman_path  # silence pyflakes warning
 
 # A note about units: all the material parameters are expected to be in plain SI units.
 # This means that the elastic moduli should be in Pascals and NOT Gigapascals,

--- a/examples/example_woutput.py
+++ b/examples/example_woutput.py
@@ -29,11 +29,9 @@ from __future__ import print_function
 
 import numpy as np
 
-import burnman_path  # adds the local burnman directory to the path
 import burnman
 from burnman import minerals
 
-assert burnman_path  # silence pyflakes warning
 
 if __name__ == "__main__":
     # input variables ###

--- a/examples/example_writeout_for_synthetic_seismo.py
+++ b/examples/example_writeout_for_synthetic_seismo.py
@@ -23,11 +23,9 @@ from __future__ import print_function
 import numpy as np  # Library used for general array
 
 # Import BurnMan
-import burnman_path  # adds the local burnman directory to the path
 import burnman
 from burnman import minerals  # import mineral library seperately
 
-assert burnman_path  # silence pyflakes warning
 
 if __name__ == "__main__":
 

--- a/misc/benchmarks/DKS_mixing.py
+++ b/misc/benchmarks/DKS_mixing.py
@@ -1,14 +1,12 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-import burnman_path  # adds the local burnman directory to the path
 from burnman.minerals import DKS_2013_liquids
 import numpy as np
 
 import matplotlib.pyplot as plt
 import matplotlib.image as mpimg
 
-assert burnman_path  # silence pyflakes warning
 
 phases = [DKS_2013_liquids.SiO2_liquid(),
           DKS_2013_liquids.MgSiO3_liquid(),

--- a/misc/benchmarks/ab_initio_liquids.py
+++ b/misc/benchmarks/ab_initio_liquids.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-import burnman_path  # adds the local burnman directory to the path
 import burnman
 from burnman.minerals import DKS_2013_liquids
 from burnman import constants
@@ -12,7 +11,6 @@ import matplotlib.image as mpimg
 from burnman.tools.eos import check_eos_consistency
 from burnman.tools.chemistry import hugoniot
 
-assert burnman_path  # silence pyflakes warning
 
 SiO2_liq=DKS_2013_liquids.SiO2_liquid()
 MgO_liq=DKS_2013_liquids.MgO_liquid()

--- a/misc/benchmarks/ab_initio_solids.py
+++ b/misc/benchmarks/ab_initio_solids.py
@@ -1,14 +1,12 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-import burnman_path  # adds the local burnman directory to the path
 from burnman.minerals import DKS_2013_solids
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.image as mpimg
 from burnman.tools.eos import check_eos_consistency
 
-assert burnman_path  # silence pyflakes warning
 
 '''
 SOLIDS

--- a/misc/benchmarks/benchmark.py
+++ b/misc/benchmarks/benchmark.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import
 # GPL v2 or later.
 
 
-import burnman_path  # adds the local burnman directory to the path
 import numpy as np
 import matplotlib.pyplot as plt
 
@@ -19,7 +18,6 @@ from burnman.tools.unitcell import molar_volume_from_unit_cell_volume
 
 import matplotlib.image as mpimg
 
-assert burnman_path  # silence pyflakes warning
 
 
 def check_birch_murnaghan():

--- a/misc/benchmarks/brosh_iron_endmembers.py
+++ b/misc/benchmarks/brosh_iron_endmembers.py
@@ -7,7 +7,6 @@ from __future__ import absolute_import
 from __future__ import print_function
 # Benchmarks for the solid solution class
 
-import burnman_path  # adds the local burnman directory to the path
 
 
 import numpy as np
@@ -19,7 +18,6 @@ from burnman import minerals
 from burnman import equilibrate
 from burnman.tools.eos import check_eos_consistency
 
-assert burnman_path  # silence pyflakes warning
 
 
 fcc = minerals.SE_2015.fcc_iron()

--- a/misc/benchmarks/burnman_path.py
+++ b/misc/benchmarks/burnman_path.py
@@ -1,6 +1,0 @@
-import os
-import sys
-
-# hack to allow scripts to be placed in subdirectories next to burnman:
-if not os.path.exists('burnman') and os.path.exists('../../burnman'):
-    sys.path.insert(1, os.path.abspath('../..'))

--- a/misc/benchmarks/chemical_potential_benchmarks.py
+++ b/misc/benchmarks/chemical_potential_benchmarks.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 # Benchmarks for the chemical potential functions
 
-import burnman_path  # adds the local burnman directory to the path
 import numpy as np
 import matplotlib.pyplot as plt
 
@@ -11,7 +10,6 @@ from burnman.tools.chemistry import dictionarize_formula, formula_mass
 from burnman.tools.chemistry import fugacity
 import burnman.constants as constants
 
-assert burnman_path  # silence pyflakes warning
 
 
 class Re (burnman.Mineral):

--- a/misc/benchmarks/debye.py
+++ b/misc/benchmarks/debye.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-import burnman_path  # adds the local burnman directory to the path
 
 import numpy as np
 import matplotlib.pyplot as plt
@@ -10,7 +9,6 @@ from burnman.eos import debye
 import scipy.integrate
 import time
 
-assert burnman_path  # silence pyflakes warning
 
 
 def old_thermal(T, debye_T, n):

--- a/misc/benchmarks/endmember_benchmarks.py
+++ b/misc/benchmarks/endmember_benchmarks.py
@@ -2,14 +2,12 @@ from __future__ import absolute_import
 from __future__ import print_function
 # Benchmarks for the solid solution class
 
-import burnman_path  # adds the local burnman directory to the path
 
 from burnman.minerals import SLB_2011
 from burnman.minerals import HP_2011_ds62
 import numpy as np
 import warnings
 
-assert burnman_path  # silence pyflakes warning
 
 
 def p(v1, v2):

--- a/misc/benchmarks/hp_liquid_benchmarks.py
+++ b/misc/benchmarks/hp_liquid_benchmarks.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 # Benchmarks for the solid solution class
-import burnman_path  # adds the local burnman directory to the path
 
 import numpy as np
 import matplotlib.pyplot as plt
@@ -10,7 +9,6 @@ from burnman.tools.chemistry import equilibrium_temperature
 from burnman.tools.eos import check_eos_consistency
 from burnman.minerals import HGP_2018_ds633
 
-assert burnman_path  # silence pyflakes warning
 
 # Here, we test that burnman outputs the correct properties for
 # albite liquid from the Holland and Powell dataset (v. 6.33, 2018)

--- a/misc/benchmarks/liquid_iron_comparison.py
+++ b/misc/benchmarks/liquid_iron_comparison.py
@@ -3,7 +3,6 @@
 # GPL v2 or later.
 
 
-import burnman_path  # adds the local burnman directory to the path
 
 import numpy as np
 import matplotlib.pyplot as plt
@@ -12,7 +11,6 @@ from scipy.optimize import fsolve
 import burnman
 from burnman.tools.eos import check_eos_consistency
 
-assert burnman_path  # silence pyflakes warning
 
 liq = burnman.minerals.other.liquid_iron()
 check_eos_consistency(liq, P=10.e9, T=7000., tol=1.e-3,

--- a/misc/benchmarks/olivine_phase_diagram_benchmark.py
+++ b/misc/benchmarks/olivine_phase_diagram_benchmark.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 # Benchmarks for the chemical potential functions
-import burnman_path  # adds the local burnman directory to the path
 
 import burnman
 import numpy as np
@@ -8,7 +7,6 @@ import matplotlib.pyplot as plt
 import matplotlib.image as mpimg
 from scipy import optimize
 
-assert burnman_path  # silence pyflakes warning
 
 # Equilibrium functions
 def eqm_P_xMgB(A, B):

--- a/misc/benchmarks/property_modifier_benchmarks.py
+++ b/misc/benchmarks/property_modifier_benchmarks.py
@@ -1,13 +1,11 @@
 from __future__ import absolute_import
 from __future__ import print_function
 # Benchmarks for the solid solution class
-import burnman_path  # adds the local burnman directory to the path
 from burnman import minerals
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.image as mpimg
 
-assert burnman_path  # silence pyflakes warning
 
 # Quartz is a mineral with a Landau type order-disorder model
 qtz = minerals.HGP_2018_ds633.q()

--- a/misc/benchmarks/solidsolution_benchmarks.py
+++ b/misc/benchmarks/solidsolution_benchmarks.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 # Benchmarks for the solid solution class
-import burnman_path  # adds the local burnman directory to the path
 import burnman
 from burnman import minerals
 
@@ -8,7 +7,6 @@ import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.image as mpimg
 
-assert burnman_path  # silence pyflakes warning
 
 '''
 Solvus shapes (a proxy for Gibbs free energy checking

--- a/misc/burnman_path.py
+++ b/misc/burnman_path.py
@@ -1,6 +1,0 @@
-import os
-import sys
-
-# hack to allow scripts to be placed in subdirectories next to burnman:
-if not os.path.exists('burnman') and os.path.exists('../burnman'):
-    sys.path.insert(1, os.path.abspath('..'))

--- a/misc/create_burnman_readable_perplex_table.py
+++ b/misc/create_burnman_readable_perplex_table.py
@@ -5,11 +5,9 @@ from __future__ import print_function
 # GPL v2 or later.
 
 import argparse
-import burnman_path  # adds the local burnman directory to the path
 
 from burnman.classes.perplex import create_perplex_table
 
-assert burnman_path  # silence pyflakes warning
 
 parser = argparse.ArgumentParser(description='Call werami to create a burnman-readable tab file.')
 

--- a/misc/performance.py
+++ b/misc/performance.py
@@ -6,13 +6,11 @@ from __future__ import print_function
 
 import numpy as np
 
-import burnman_path  # adds the local burnman directory to the path
 import burnman
 from burnman import minerals
 
 import timeit
 
-assert burnman_path  # silence pyflakes warning
 
 if True:
     def test_set_state(runs=10000):

--- a/misc/table_mineral_library.py
+++ b/misc/table_mineral_library.py
@@ -11,7 +11,6 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import sys
-import burnman_path  # adds the local burnman directory to the path
 
 import burnman
 import inspect
@@ -19,7 +18,6 @@ import inspect
 from burnman import minerals
 from burnman import tools
 
-assert burnman_path  # silence pyflakes warning
 
 if __name__ == "__main__":
 

--- a/test.sh
+++ b/test.sh
@@ -23,6 +23,11 @@ echo "Version numbers of required modules:"
 $PYTHON -m pip freeze | grep -f requirements.txt
 echo ""
 
+# Quietly install burnman in development mode
+echo "Installing BurnMan in development mode ..."
+python -m pip install -q -e .
+echo ""
+
 function testit {
 t=$1
 

--- a/tests/burnman_path.py
+++ b/tests/burnman_path.py
@@ -1,6 +1,0 @@
-import os
-import sys
-
-# hack to allow scripts to be placed in subdirectories next to burnman:
-if not os.path.exists('burnman') and os.path.exists('../burnman'):
-    sys.path.insert(1, os.path.abspath('..'))

--- a/tests/test_anisotropicmineral.py
+++ b/tests/test_anisotropicmineral.py
@@ -3,11 +3,9 @@ import unittest
 from util import BurnManTest
 import numpy as np
 
-import burnman_path
 from burnman import AnisotropicMineral
 from burnman.tools.eos import check_anisotropic_eos_consistency
 from burnman.minerals.SLB_2011 import periclase, forsterite
-assert burnman_path  # silence pyflakes warning
 
 
 class test_anisotropic_mineral(BurnManTest):

--- a/tests/test_anisotropy.py
+++ b/tests/test_anisotropy.py
@@ -3,10 +3,8 @@ import unittest
 from util import BurnManTest
 import numpy as np
 
-import burnman_path
 from burnman.classes import anisotropy
 
-assert burnman_path  # silence pyflakes warning
 
 
 class test_anisotropy(BurnManTest):

--- a/tests/test_averaging.py
+++ b/tests/test_averaging.py
@@ -3,12 +3,10 @@ import unittest
 from util import BurnManTest
 import warnings
 
-import burnman_path
 import burnman
 from burnman import minerals
 import burnman.classes.averaging_schemes as avg
 
-assert burnman_path  # silence pyflakes warning
 
 
 class mypericlase (burnman.Mineral):

--- a/tests/test_chemical_potentials.py
+++ b/tests/test_chemical_potentials.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 import unittest
 from util import BurnManTest
 
-import burnman_path
 from burnman import minerals
 from burnman import Composite
 from burnman import equilibrate
@@ -10,7 +9,6 @@ from burnman import equilibrate
 from burnman.tools.chemistry import relative_fugacity
 from burnman.tools.chemistry import fugacity
 
-assert burnman_path  # silence pyflakes warning
 
 
 class ChemicalPotentials(BurnManTest):

--- a/tests/test_composite.py
+++ b/tests/test_composite.py
@@ -3,11 +3,9 @@ from util import BurnManTest
 import warnings
 import unittest
 
-import burnman_path
 import burnman
 from burnman import minerals
 
-assert burnman_path  # silence pyflakes warning
 
 
 # TODO: test composite that changes number of entries

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -3,10 +3,8 @@ import unittest
 from util import BurnManTest
 import numpy as np
 
-import burnman_path
 from burnman.composition import Composition
 
-assert burnman_path  # silence pyflakes warning
 
 
 class composition(BurnManTest):

--- a/tests/test_debye.py
+++ b/tests/test_debye.py
@@ -2,10 +2,8 @@ from __future__ import absolute_import
 import unittest
 from util import BurnManTest
 
-import burnman_path
 import burnman
 
-assert burnman_path  # silence pyflakes warning
 
 
 class mypericlase(burnman.Mineral):

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,13 +1,11 @@
 import unittest
 from util import BurnManTest
 
-import burnman_path
 import burnman
 
 from burnman import material_property
 from burnman.tools.misc import copy_documentation
 
-assert burnman_path  # silence pyflakes warning
 
 
 class test_decorators__material_property(BurnManTest):

--- a/tests/test_endmembers.py
+++ b/tests/test_endmembers.py
@@ -4,12 +4,10 @@ from util import BurnManTest
 import copy
 import warnings
 
-import burnman_path
 import burnman
 from burnman import Mineral, CombinedMineral
 from burnman.tools.chemistry import dictionarize_formula, formula_mass
 
-assert burnman_path  # silence pyflakes warning
 
 
 class forsterite (Mineral):

--- a/tests/test_eos.py
+++ b/tests/test_eos.py
@@ -4,12 +4,10 @@ import unittest
 from util import BurnManTest
 import warnings
 
-import burnman_path
 import burnman
 from burnman import minerals
 from burnman.tools.chemistry import dictionarize_formula, formula_mass
 
-assert burnman_path  # silence pyflakes warning
 
 
 class mypericlase(burnman.Mineral):

--- a/tests/test_eos_consistency.py
+++ b/tests/test_eos_consistency.py
@@ -2,12 +2,10 @@ from __future__ import absolute_import
 import unittest
 from util import BurnManTest
 
-import burnman_path
 import burnman
 
 from burnman.tools.eos import check_eos_consistency
 
-assert burnman_path  # silence pyflakes warning
 
 
 class EosConsistency(BurnManTest):

--- a/tests/test_equilibration.py
+++ b/tests/test_equilibration.py
@@ -3,14 +3,12 @@ from __future__ import print_function
 import unittest
 from util import BurnManTest
 
-import burnman_path
 import burnman
 from burnman import equilibrate
 from burnman.minerals import HP_2011_ds62, SLB_2011
 
 import numpy as np
 
-assert burnman_path  # silence pyflakes warning
 
 
 class equilibration(BurnManTest):

--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -2,11 +2,9 @@ import unittest
 from util import BurnManTest
 import numpy as np
 
-import burnman_path
 import burnman
 from burnman.optimize.nonlinear_fitting import nonlinear_least_squares_fit
 
-assert burnman_path  # silence pyflakes warning
 
 
 class test_fitting(BurnManTest):

--- a/tests/test_geotherm.py
+++ b/tests/test_geotherm.py
@@ -2,10 +2,8 @@ from __future__ import absolute_import
 import unittest
 from util import BurnManTest
 
-import burnman_path
 import burnman
 
-assert burnman_path  # silence pyflakes warning
 
 
 class mypericlase(burnman.Mineral):

--- a/tests/test_helper_rock_switcher.py
+++ b/tests/test_helper_rock_switcher.py
@@ -3,11 +3,9 @@ import unittest
 from util import BurnManTest
 import numpy as np
 
-import burnman_path
 import burnman
 from burnman.classes import mineral_helpers
 
-assert burnman_path  # silence pyflakes warning
 
 
 class RockSwitcher(BurnManTest):

--- a/tests/test_layer.py
+++ b/tests/test_layer.py
@@ -3,11 +3,9 @@ import unittest
 from util import BurnManTest
 
 import numpy as np
-import burnman_path
 import burnman
 from burnman import Layer, BoundaryLayerPerturbation
 
-assert burnman_path  # silence pyflakes warning
 
 
 class min1 (burnman.Mineral):

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -3,10 +3,8 @@ import unittest
 from util import BurnManTest
 import numpy as np
 
-import burnman_path
 import burnman
 
-assert burnman_path  # silence pyflakes warning
 
 
 class test_material_name(BurnManTest):

--- a/tests/test_minerals.py
+++ b/tests/test_minerals.py
@@ -3,11 +3,9 @@ import unittest
 from util import BurnManTest
 import inspect
 
-import burnman_path
 import burnman
 from burnman import minerals
 
-assert burnman_path  # silence pyflakes warning
 
 
 # Instantiate every mineral in the mineral library

--- a/tests/test_modifiers.py
+++ b/tests/test_modifiers.py
@@ -2,12 +2,10 @@ from __future__ import absolute_import
 import unittest
 from util import BurnManTest
 
-import burnman_path
 import burnman.eos.property_modifiers as pm
 from burnman.minerals import SLB_2011, HP_2011_ds62
 from burnman.tools.eos import check_eos_consistency
 
-assert burnman_path  # silence pyflakes warning
 
 
 class Modifiers(BurnManTest):

--- a/tests/test_partitioning.py
+++ b/tests/test_partitioning.py
@@ -2,11 +2,9 @@ from __future__ import absolute_import
 import unittest
 from util import BurnManTest
 
-import burnman_path
 import burnman
 from burnman import minerals
 
-assert burnman_path  # silence pyflakes warning
 
 
 class test(BurnManTest):

--- a/tests/test_perplex.py
+++ b/tests/test_perplex.py
@@ -3,10 +3,8 @@ import unittest
 from util import BurnManTest
 import numpy as np
 
-import burnman_path
 import burnman
 
-assert burnman_path  # silence pyflakes warning
 
 # Predefine our rock
 rock = burnman.PerplexMaterial('../burnman/data/input_perplex/in23_1.tab')

--- a/tests/test_planet.py
+++ b/tests/test_planet.py
@@ -3,12 +3,10 @@ import unittest
 from util import BurnManTest
 import numpy as np
 
-import burnman_path
 import burnman
 from burnman import Planet
 from burnman import Layer
 
-assert burnman_path  # silence pyflakes warning
 
 
 def make_simple_planet():

--- a/tests/test_polytope.py
+++ b/tests/test_polytope.py
@@ -3,14 +3,12 @@ import unittest
 from util import BurnManTest
 import numpy as np
 
-import burnman_path
 from burnman import Composite
 from burnman.minerals import SLB_2011
 from burnman.tools.polytope import solution_polytope_from_charge_balance
 from burnman.tools.polytope import solution_polytope_from_endmember_occupancies
 from burnman.tools.polytope import simplify_composite_with_composition
 
-assert burnman_path  # silence pyflakes warning
 
 
 class polytope(BurnManTest):

--- a/tests/test_processchemistry.py
+++ b/tests/test_processchemistry.py
@@ -3,14 +3,12 @@ import unittest
 from util import BurnManTest
 import numpy as np
 
-import burnman_path
 from burnman.tools.chemistry import dictionarize_formula
 from burnman.tools.chemistry import sum_formulae
 from burnman.tools.chemistry import formula_mass
 from burnman.tools.chemistry import convert_formula
 from burnman.tools.chemistry import site_occupancies_to_strings
 
-assert burnman_path  # silence pyflakes warning
 
 
 class processchemistry(BurnManTest):

--- a/tests/test_seismic.py
+++ b/tests/test_seismic.py
@@ -2,10 +2,8 @@ from __future__ import absolute_import
 import unittest
 from util import BurnManTest
 
-import burnman_path
 import burnman
 
-assert burnman_path  # silence pyflakes warning
 
 
 class test_seismic(BurnManTest):

--- a/tests/test_solidsolution.py
+++ b/tests/test_solidsolution.py
@@ -5,14 +5,12 @@ import unittest
 import numpy as np
 import warnings
 
-import burnman_path
 import burnman
 from burnman import Mineral
 from burnman import CombinedMineral
 from burnman.tools.chemistry import dictionarize_formula, formula_mass
 from burnman.tools.chemistry import formula_to_string, sum_formulae
 from burnman.minerals import HGP_2018_ds633
-assert burnman_path  # silence pyflakes warning
 
 
 class forsterite (Mineral):

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -2,10 +2,8 @@ import unittest
 from util import BurnManTest
 import numpy as np
 
-import burnman_path
 from burnman.optimize.nonlinear_solvers import damped_newton_solve
 
-assert burnman_path  # silence pyflakes warning
 
 
 class test_solvers(BurnManTest):

--- a/tests/test_spin.py
+++ b/tests/test_spin.py
@@ -2,10 +2,8 @@ from __future__ import absolute_import
 import unittest
 from util import BurnManTest
 
-import burnman_path
 from burnman import minerals
 
-assert burnman_path  # silence pyflakes warning
 
 
 class spin_transition(BurnManTest):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2,7 +2,6 @@ import unittest
 from util import BurnManTest
 import numpy as np
 
-import burnman_path
 import burnman
 from burnman.tools.chemistry import equilibrium_temperature
 from burnman.tools.chemistry import equilibrium_pressure
@@ -13,7 +12,6 @@ from burnman.tools.math import smooth_array
 from burnman.tools.math import interp_smoothed_array_and_derivatives
 from burnman.tools.math import _pad_ndarray_inverse_mirror
 
-assert burnman_path  # silence pyflakes warning
 
 
 class test_tools(BurnManTest):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -4,7 +4,6 @@ from util import BurnManTest
 from util import *
 import sympy
 
-import burnman_path
 import burnman
 from burnman import minerals
 
@@ -37,7 +36,6 @@ from test_solvers import *
 from test_spin import *
 from test_tools import *
 
-assert burnman_path  # silence pyflakes warning
 
 
 class TestRock(BurnManTest):


### PR DESCRIPTION
I've been wanting to remove the awful path hacks for ages, and this seems like a good time to do it. 

The hacks existed to allow the user to always use the most recent version of the files in the BurnMan repository (without having to reinstall the repo with every commit). However, this can be done much more elegantly if the user installs from the top-level directory using `python -m pip install -e .` (the -e flag indicates the installation is in "editable" mode).

The `Readme.md`, `__init__.py` and `test.sh` have been modified to reflect these changes.