### PR TITLE
remove old import hacks from tutorials

### DIFF
--- a/tutorial/tutorial_01_material_classes.ipynb
+++ b/tutorial/tutorial_01_material_classes.ipynb
@@ -61,26 +61,16 @@
       "source": [
         "### Getting started with BurnMan\n",
         "\n",
-        "Our first task is to decide on the version of BurnMan to use for this session.\n",
-        "As this tutorial is stored within the BurnMan repository, it should always be consistent with the local version of BurnMan. Therefore, we have two choices. We could install this version using pip, allowing it to be used from any location (with the same version of python). Alternatively, we could just import locally, without installing."
+        "Our first task is to import BurnMan. If you haven't yet installed the current version, you can do this by typing `pip install -e .` from the top-level directory of the repository. Alternatively, you could just uncomment (remove the leading `#` from) the first line in the following code block. The second line in the code block imports the BurnMan module."
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 3,
       "metadata": {},
       "outputs": [],
       "source": [
-        "install = False\n",
-        "\n",
-        "if install:\n",
-        "    !pip install ..\n",
-        "else:\n",
-        "    import os\n",
-        "    import sys\n",
-        "    if not os.path.exists('burnman') and os.path.exists('../burnman'):\n",
-        "        sys.path.insert(1, os.path.abspath('../'))\n",
-        "\n",
+        "#!pip install -q -e ..\n",
         "import burnman"
       ]
     },

--- a/tutorial/tutorial_02_composition_class.ipynb
+++ b/tutorial/tutorial_02_composition_class.ipynb
@@ -42,34 +42,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "eFXuzpvW0rm2"
-      },
-      "source": [
-        "<b>Importing BurnMan</b>\n",
-        "\n",
-        "In the first part of this tutorial, we decided whether to install the version of BurnMan associated with the tutorial or use the local version. If you chose to install globally, or if you want to use a previously installed version, change the \"use_installed\" variable below to \"True\"."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "use_installed = False\n",
-        "\n",
-        "if not use_installed:\n",
-        "    import os\n",
-        "    import sys\n",
-        "    if not os.path.exists('burnman') and os.path.exists('../burnman'):\n",
-        "        sys.path.insert(1, os.path.abspath('../'))\n",
-        "\n",
-        "import burnman"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
         "id": "Ehh1BoufD5Ab"
       },
       "source": [

--- a/tutorial/tutorial_03_layers_and_planets.ipynb
+++ b/tutorial/tutorial_03_layers_and_planets.ipynb
@@ -43,34 +43,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "eFXuzpvW0rm2"
-      },
-      "source": [
-        "<b>Importing BurnMan</b>\n",
-        "\n",
-        "In the first part of this tutorial, we decided whether to install the version of BurnMan associated with the tutorial or use the local version. If you chose to install globally, or if you want to use a previously installed version, change the \"use_installed\" variable below to \"True\"."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "use_installed = False\n",
-        "\n",
-        "if not use_installed:\n",
-        "    import os\n",
-        "    import sys\n",
-        "    if not os.path.exists('burnman') and os.path.exists('../burnman'):\n",
-        "        sys.path.insert(1, os.path.abspath('../'))\n",
-        "\n",
-        "import burnman"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
         "id": "90v31CZNNw-m"
       },
       "source": [
@@ -108,6 +80,7 @@
       "source": [
         "import numpy as np\n",
         "import matplotlib.pyplot as plt\n",
+        "import burnman\n",
         "from burnman import Mineral, PerplexMaterial, Composite, Layer, Planet\n",
         "from burnman import minerals\n",
         "\n",

--- a/tutorial/tutorial_04_fitting.ipynb
+++ b/tutorial/tutorial_04_fitting.ipynb
@@ -41,30 +41,11 @@
       ]
     },
     {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "eFXuzpvW0rm2"
-      },
-      "source": [
-        "<b>Importing BurnMan</b>\n",
-        "\n",
-        "In the first part of this tutorial, we decided whether to install the version of BurnMan associated with the tutorial or use the local version. If you chose to install globally, or if you want to use a previously installed version, change the \"use_installed\" variable below to \"True\"."
-      ]
-    },
-    {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {},
       "outputs": [],
       "source": [
-        "use_installed = False\n",
-        "\n",
-        "if not use_installed:\n",
-        "    import os\n",
-        "    import sys\n",
-        "    if not os.path.exists('burnman') and os.path.exists('../burnman'):\n",
-        "        sys.path.insert(1, os.path.abspath('../'))\n",
-        "\n",
         "import burnman\n",
         "import numpy as np\n",
         "import matplotlib.pyplot as plt"

--- a/tutorial/tutorial_05_equilibrium.ipynb
+++ b/tutorial/tutorial_05_equilibrium.ipynb
@@ -42,34 +42,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "eFXuzpvW0rm2"
-      },
-      "source": [
-        "<b>Importing BurnMan</b>\n",
-        "\n",
-        "In the first part of this tutorial, we decided whether to install the version of BurnMan associated with the tutorial or use the local version. If you chose to install globally, or if you want to use a previously installed version, change the \"use_installed\" variable below to \"True\"."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "use_installed = False\n",
-        "\n",
-        "if not use_installed:\n",
-        "    import os\n",
-        "    import sys\n",
-        "    if not os.path.exists('burnman') and os.path.exists('../burnman'):\n",
-        "        sys.path.insert(1, os.path.abspath('../'))\n",
-        "\n",
-        "import burnman"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
         "id": "TZYWNOEVNsiW"
       },
       "source": [
@@ -108,6 +80,7 @@
       "source": [
         "import numpy as np\n",
         "import matplotlib.pyplot as plt\n",
+        "import burnman\n",
         "from burnman import equilibrate\n",
         "from burnman.minerals import SLB_2011\n",
         "\n",


### PR DESCRIPTION
This PR streamlines the start of each of the tutorials. Now that we require BurnMan to be installed, we no longer need any of the path hacks.