### PR TITLE
allow storage of components in Composite

### DIFF
--- a/burnman/classes/composite.py
+++ b/burnman/classes/composite.py
@@ -441,17 +441,68 @@ class Composite(Material):
         return np.all(np.abs(self.reaction_affinities)
                       < self.equilibrium_tolerance)
 
-    def chemical_potential(self, components):
+    def set_components(self, components):
         """
-        Returns the chemical potential of one or more components in
-        a chemically equilibrated composite. Raises an exception if
-        the assemblage is not equilibrated, or if any of the
-        chemical potentials are undefined by the assemblage.
+        Sets the components and components_array attributes of the
+        composite material. The components attribute is a list of dictionaries
+        containing the chemical formulae of the components.
+        The components_array attribute is a 2D numpy array describing the
+        linear transformation between endmember amounts and component amounts.
+
+        The components do not need to be linearly independent, not do they need
+        to form a complete basis set for the composite.
+        However, it must be possible to obtain the composition of each
+        component from a linear sum of the endmember compositions of
+        the composite. For example, if the composite was composed of
+        MgSiO3 and Mg2SiO4, SiO2 would be a valid component, but Si would not.
+        The method raises an exception if any of the chemical potentials are
+        not defined by the assemblage.
 
         Parameters
         ----------
         components: list of dictionaries
-            List of formulae of the desired components.
+            List of formulae of the components.
+        """
+        n_components = len(components)
+
+        # Convert components into matrix form
+        def f(i, j):
+            e = self.elements[j]
+            if e in components[i]:
+                return nsimplify(components[i][e])
+            else:
+                return 0
+        b = np.array(Matrix(n_components, self.n_elements, f)).astype(float)
+
+        # Solve to find a set of endmember proportions that
+        # satisfy each of the component formulae
+        p = np.linalg.lstsq(self.stoichiometric_array.T, b.T, rcond=None)
+
+        res = np.abs((self.stoichiometric_array.T.dot(p[0]) - b.T).T)
+        res = np.sum(res, axis=1)
+        # Check that all components can be described by linear sums of
+        # the endmembers
+        if not np.all(res < 1.e-12):
+            bad_indices = np.argwhere(res > 1.e-12)
+
+            raise Exception(f'Components {bad_indices} not defined by '
+                            'prescribed assemblage')
+
+        self.components = components
+        self.component_array = p[0]
+
+    def chemical_potential(self, components=None):
+        """
+        Returns the chemical potentials of the currently defined components
+        in the composite. Raises an exception if
+        the assemblage is not equilibrated.
+
+        Parameters
+        ----------
+        components: list of dictionaries (optional)
+            List of formulae of the desired components. If not specified,
+            the method uses the components specified by a previous call to
+            set_components.
 
         Returns
         -------
@@ -459,37 +510,15 @@ class Composite(Material):
             The chemical potentials of the desired components in the
             equilibrium composite.
         """
-        n_components = len(components)
-        if self.equilibrated:
-            # Convert components into matrix form
-            def f(i, j):
-                e = self.elements[j]
-                if e in components[i]:
-                    return nsimplify(components[i][e])
-                else:
-                    return 0
-            b = np.array(Matrix(n_components, self.n_elements, f)).astype(float)
-
-            # Solve to find a set of endmember proportions that
-            # satisfy each of the component formulae
-            p = np.linalg.lstsq(self.stoichiometric_array.T, b.T, rcond=None)
-
-            res = np.abs((self.stoichiometric_array.T.dot(p[0]) - b.T).T)
-            res = np.sum(res, axis=1)
-            # Check that all components can be described by linear sums of
-            # the endmembers
-            if not np.all(res < 1.e-12):
-                bad_indices = np.argwhere(res > 1.e-12)
-
-                raise Exception(f'Components {bad_indices} not defined by '
-                                'prescribed assemblage')
-
-            # Return the chemical potential of each component
-            return np.dot(p[0].T, self.endmember_partial_gibbs)
-
-        else:
+        if not self.equilibrated:
             raise Exception('This composite is not equilibrated, so '
                             'it cannot have a defined chemical potential.')
+
+        if components is not None:
+            self.set_components(components)
+
+        # Return the chemical potential of each component
+        return np.dot(self.component_array.T, self.endmember_partial_gibbs)
 
     def _mass_to_molar_fractions(self, phases, mass_fractions):
         """

--- a/burnman/classes/composite.py
+++ b/burnman/classes/composite.py
@@ -463,22 +463,16 @@ class Composite(Material):
         components: list of dictionaries
             List of formulae of the components.
         """
-        n_components = len(components)
-
-        # Convert components into matrix form
-        def f(i, j):
-            e = self.elements[j]
-            if e in components[i]:
-                return nsimplify(components[i][e])
-            else:
-                return 0
-        b = np.array(Matrix(n_components, self.n_elements, f)).astype(float)
+        # Convert components into array form
+        b = np.array([[component[el] if el in component else 0.
+                       for component in components]
+                      for el in self.elements])
 
         # Solve to find a set of endmember proportions that
         # satisfy each of the component formulae
-        p = np.linalg.lstsq(self.stoichiometric_array.T, b.T, rcond=None)
+        p = np.linalg.lstsq(self.stoichiometric_array.T, b, rcond=None)
 
-        res = np.abs((self.stoichiometric_array.T.dot(p[0]) - b.T).T)
+        res = np.abs((self.stoichiometric_array.T.dot(p[0]) - b).T)
         res = np.sum(res, axis=1)
         # Check that all components can be described by linear sums of
         # the endmembers

--- a/tests/test_chemical_potentials.py
+++ b/tests/test_chemical_potentials.py
@@ -22,7 +22,8 @@ class ChemicalPotentials(BurnManTest):
         bdg.set_composition([1.0, 0.0, 0.0])
         assemblage.set_state(25.e9, 2000.)
 
-        mu_SiO2 = assemblage.chemical_potential([{'Si': 1., 'O': 2.}])[0]
+        assemblage.set_components([{'Si': 1., 'O': 2.}])
+        mu_SiO2 = assemblage.chemical_potential()[0]
 
         self.assertFloatEqual(bdg.gibbs - per.gibbs, mu_SiO2)
 


### PR DESCRIPTION
The chemical_potential method in Composite currently reads in a list of formula dictionaries and defines a mapping from endmember amounts to components via least squares. This is quite expensive. 

In most applications, users will only want to define components once. Therefore, it makes sense to create a set_components method that runs through the least squares procedure and stores the component_array as an attribute. The chemical_potential function can then use this attribute to calculate the chemical potential(s).

This PR adds the necessary functions, and modifies a pre-existing test to test the new functionality.