### PR TITLE
migrate optional dependencies

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -16,3 +16,4 @@ dependencies:
     - mpl-interactions
     - pycddlib
     - cvxpy
+    - jupyter

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,7 @@ metadata = dict(name='burnman',
 # distutils.
 try:
     from setuptools import setup
-    metadata['install_requires'] = ['numpy', 'matplotlib', 'scipy', 'sympy',
-                                    'cvxpy', 'jupyter']
+    metadata['install_requires'] = ['numpy', 'matplotlib', 'scipy', 'sympy']
 except ImportError:
     from distutils.core import setup
 

--- a/test.sh
+++ b/test.sh
@@ -28,6 +28,11 @@ echo "Installing BurnMan in development mode ..."
 python -m pip install -q -e .
 echo ""
 
+# Quietly install optional modules after burnman
+echo "Installing optional cvxpy, pycddlib and jupyter modules ..."
+python -m pip install -q cvxpy pycddlib jupyter
+echo ""
+
 function testit {
 t=$1
 


### PR DESCRIPTION
The new binder environment means that we can now migrate the optional dependencies outside of setup.py (into test.sh and .binder/environment.yml).