### PR TITLE
added jupyter to sphinx dependencies

### DIFF
--- a/docs/pip_requirements.txt
+++ b/docs/pip_requirements.txt
@@ -6,6 +6,7 @@ sympy
 sphinxcontrib.bibtex
 nbsphinx
 cvxpy
+jupyter
 
 # ReadTheDocs cannot build pycddlib successfully
 # because it requires gmp.h, installable only via sudo apt-get install.


### PR DESCRIPTION
This PR adds jupyter to the sphinx dependencies to allow ReadTheDocs to work.