### PR TITLE
New: Calibrant class

### DIFF
--- a/burnman/__init__.py
+++ b/burnman/__init__.py
@@ -212,6 +212,7 @@ from .classes.combinedmineral import CombinedMineral
 from .classes.solutionmodel import SolutionModel
 from .classes.solidsolution import SolidSolution
 from .classes.composite import Composite
+from .classes.calibrant import Calibrant
 from .classes.anisotropy import AnisotropicMaterial
 from .classes.anisotropicmineral import AnisotropicMineral
 from .classes.anisotropicmineral import cell_parameters_to_vectors
@@ -233,6 +234,9 @@ from . import minerals
 
 # Equations of state
 from . import eos
+
+# Calibrants
+from . import calibrants
 
 # Tools
 from . import tools

--- a/burnman/calibrants/Decker_1971.py
+++ b/burnman/calibrants/Decker_1971.py
@@ -1,0 +1,56 @@
+# This file is part of BurnMan - a thermoelastic and thermodynamic toolkit for
+# the Earth and Planetary Sciences
+# Copyright (C) 2012 - 2022 by the BurnMan team, released under the GNU
+# GPL v2 or later.
+
+"""
+Decker_1971
+^^^^^^^^^^^
+"""
+
+import numpy as np
+from ..eos.birch_murnaghan import birch_murnaghan
+from ..eos import MGD2
+from ..eos import debye
+from ..classes.calibrant import Calibrant
+
+
+class NaCl_B1(Calibrant):
+    """
+    The NaCl (B1 structured) pressure standard reported by Decker (1971).
+
+    Note: This calibrant is not exactly the same as that proposed by Decker.
+    The cold compression curve has here been approximated by a
+    Birch-Murnaghan EoS.
+
+    TODO: Make the calibrant exactly match that published by Decker.
+    """
+    def __init__(self):
+
+        def _pressure_Decker_NaCl(volume, temperature, params):
+            p300 = birch_murnaghan(params['V_0'] / volume, params)
+            grueneisen = MGD2._grueneisen_parameter(0.,
+                                                    params['V_0'] / volume,
+                                                    params)
+            Debye_T = params['Debye_0'] * np.exp((params['grueneisen_0']
+                                                  - grueneisen)
+                                                 / params['q_0'])
+            Eqh = debye.thermal_energy(temperature, Debye_T, params['n'])
+            EqhR = debye.thermal_energy(params['refT'], Debye_T, params['n'])
+            dpqh = (Eqh - EqhR) * (grueneisen / volume)
+            pressure = p300 + dpqh
+            return pressure
+
+        _params_Decker_NaCl = {'V_0': 2.7015e-05,
+                               'K_0': 24.02e9,
+                               'Kprime_0': 4.7369,
+                               'Debye_0': 279,
+                               'grueneisen_0': 1.59,
+                               'q_0': 0.93,
+                               'n': 2.,
+                               'refT': 298.15,
+                               'P_0': 0,
+                               'Z': 4.}
+
+        Calibrant.__init__(self, _pressure_Decker_NaCl, 'pressure',
+                           _params_Decker_NaCl)

--- a/burnman/calibrants/__init__.py
+++ b/burnman/calibrants/__init__.py
@@ -1,0 +1,15 @@
+# This file is part of BurnMan - a thermoelastic and thermodynamic toolkit for
+# the Earth and Planetary Sciences
+# Copyright (C) 2012 - 2021 by the BurnMan team, released under the GNU
+# GPL v2 or later.
+
+
+"""
+Calibrant database
+
+  - :mod:`~burnman.calibrants.Decker_1971`
+"""
+
+
+from . import Decker_1971
+from . import tools

--- a/burnman/calibrants/tools.py
+++ b/burnman/calibrants/tools.py
@@ -1,0 +1,46 @@
+import numpy as np
+
+
+def pressure_to_pressure(old_calibrant, new_calibrant,
+                         pressure, temperature, PT_covariance=None):
+    """
+    Convert from pressure defined by one calibrated equation of
+    state of a material to pressure defined by an independent
+    calibration of the same material.
+
+
+    Arguments
+    ---------
+    old_calibrant : Calibrant object
+        The original calibration used to estimate the pressure
+    new_calibrant : Calibrant object
+        The new calibration from which the pressure is desired
+    pressure : float
+        The pressure calculated using the old calibration
+    temperature : float
+        The temperature of the material
+
+    PT_covariance : 2x2 numpy array [optional]
+            The pressure-temperature
+            variance-covariance matrix
+
+
+    Returns
+    -------
+    pressure : float
+        The pressure of the calibrant [Pa]
+
+    PT_covariance : 2x2 numpy array (if PT_covariance is provided)
+        The pressure-temperature variance-covariance matrix.
+    """
+
+    if PT_covariance is None:
+        V = old_calibrant.volume(pressure, temperature)
+        P = new_calibrant.pressure(V, temperature)
+        return P
+    else:
+        V, var_VPT = old_calibrant.volume(pressure, temperature, PT_covariance)
+        VT_covariance = var_VPT[np.ix_([0, 2], [0, 2])]
+        P, var_PVT = new_calibrant.pressure(V, temperature, VT_covariance)
+        PT_covariance = var_PVT[np.ix_([0, 2], [0, 2])]
+        return P, PT_covariance

--- a/burnman/classes/__init__.py
+++ b/burnman/classes/__init__.py
@@ -19,3 +19,4 @@ from . import composite
 from . import anisotropy
 from . import anisotropicmineral
 from . import mineral_helpers
+from . import calibrant

--- a/burnman/classes/calibrant.py
+++ b/burnman/classes/calibrant.py
@@ -1,0 +1,171 @@
+# This file is part of BurnMan - a thermoelastic and thermodynamic toolkit for
+# the Earth and Planetary Sciences
+# Copyright (C) 2012 - 2022 by the BurnMan team, released under the GNU
+# GPL v2 or later.
+
+import numpy as np
+import scipy.optimize as opt
+from ..tools.math import bracket
+
+
+class Calibrant(object):
+    """
+    The base class for a pressure calibrant material.
+
+    Initialization of a Calibrant object requires the following parameters:
+
+    calibrant_function : Function
+        A function that takes either pressure, temperature and a params
+        object as arguments, returning the volume, or takes volume, temperature
+        and a params object, returning the pressure.
+
+    calibrant_function_return_type : 'pressure' or 'volume'
+        The return type of the calibrant function.
+
+    params : dictionary
+        A dictionary containing the parameters required by the
+        calibrant function.
+    """
+    def __init__(self, calibrant_function,
+                 calibrant_function_return_type,
+                 params):
+
+        if calibrant_function_return_type == 'pressure':
+            self.pressure_function = calibrant_function
+            self.volume_function = self._volume_using_pressure_function
+        elif calibrant_function_return_type == 'volume':
+            self.volume_function = calibrant_function
+            self.pressure_function = self._pressure_using_volume_function
+        else:
+            raise Exception('calibrant function return type must either '
+                            'be pressure or volume')
+
+        self.calibrant_function = calibrant_function
+
+        self.params = params
+
+    def _volume_using_pressure_function(self, pressure, temperature, params):
+        """
+        Helper function to compute volume iteratively by Brent's method using
+        a function of the form pressure(volume, temperature).
+        """
+        def func(x):
+            return (self.pressure_function(x, temperature, params) - pressure)
+        try:
+            sol = bracket(func, params['V_0'], 1.e-2 * params['V_0'])
+        except ValueError:
+            raise ValueError('Cannot find a volume, perhaps you are outside '
+                             'of the range of validity for the equation '
+                             'of state?')
+        return opt.brentq(func, sol[0], sol[1])
+
+    def _pressure_using_volume_function(self, volume, temperature, params):
+        """
+        Helper function to compute pressure iteratively by Brent's method using
+        a function of the form volume(pressure, temperature).
+        """
+        def func(x):
+            (self.volume_function(x, temperature, params) - volume)
+        try:
+            sol = bracket(func, 0., 300.e9)
+        except ValueError:
+            raise ValueError('Cannot find a pressure, perhaps you are outside '
+                             'of the range of validity for the equation '
+                             'of state?')
+        return opt.brentq(func, sol[0], sol[1])
+
+    def pressure(self, volume, temperature, VT_covariance=None):
+        """
+        Returns the pressure of the calibrant as a function of
+        volume, temperature and (optionally) a volume-temperature
+        variance-covariance matrix.
+
+        Parameters
+        ----------
+        volume : float
+            The volume of the calibrant [m^3/mol]
+        temperature : float
+            The temperature of the calibrant [K]
+        VT_covariance : 2x2 numpy array [optional]
+            The volume-temperature
+            variance-covariance matrix
+
+        Returns
+        -------
+        pressure : float
+            The pressure of the calibrant [Pa]
+
+        PVT_covariance : 3x3 numpy array (if PT_covariance is provided)
+            The pressure-volume-temperature variance-covariance matrix.
+        """
+        if VT_covariance is None:
+            return self.pressure_function(volume, temperature, self.params)
+        else:
+            # Here we take the centered differences
+            # We could alternatively use thermodynamic properties
+            # but these have not yet been implemented.
+            dV = volume / 1.e7
+            dT = 0.01
+            PdV0 = self.pressure_function(volume - dV/2., temperature,
+                                          self.params)
+            PdV1 = self.pressure_function(volume + dV/2., temperature,
+                                          self.params)
+            PdT0 = self.pressure_function(volume, temperature - dT/2.,
+                                          self.params)
+            PdT1 = self.pressure_function(volume, temperature + dT/2.,
+                                          self.params)
+            pressure = (PdV0 + PdV1 + PdT0 + PdT1)/4.
+
+            gradPVT = np.zeros((2, 3))
+            gradPVT[:, 1:] = np.eye(2)
+            gradPVT[:, 0] = [(PdV1 - PdV0)/dV, (PdT1 - PdT0)/dT]
+            PVT_covariance = gradPVT.T.dot(VT_covariance).dot(gradPVT)
+            return pressure, PVT_covariance
+
+    def volume(self, pressure, temperature, PT_covariance=None):
+        """
+        Returns the volume of the calibrant as a function of
+        pressure, temperature and (optionally) a pressure-temperature
+        variance-covariance matrix.
+
+        Parameters
+        ----------
+        pressure : float
+            The pressure of the calibrant [Pa]
+        temperature : float
+            The temperature of the calibrant [K]
+        PT_covariance : 2x2 numpy array [optional]
+            The pressure-temperature
+            variance-covariance matrix
+
+        Returns
+        -------
+        volume : float
+            The volume of the calibrant [m^3/mol]
+
+        VPT_covariance : 3x3 numpy array (if VT_covariance is provided)
+            The volume-pressure-temperature variance-covariance matrix.
+        """
+        if PT_covariance is None:
+            return self.volume_function(pressure, temperature, self.params)
+        else:
+            # Here we take the centered differences
+            # We could alternatively use thermodynamic properties
+            # but these have not yet been implemented.
+            dP = 100.
+            dT = 0.01
+            VdP0 = self.volume_function(pressure - dP/2., temperature,
+                                        self.params)
+            VdP1 = self.volume_function(pressure + dP/2., temperature,
+                                        self.params)
+            VdT0 = self.volume_function(pressure, temperature - dT/2.,
+                                        self.params)
+            VdT1 = self.volume_function(pressure, temperature + dT/2.,
+                                        self.params)
+            volume = (VdP0 + VdP1 + VdT0 + VdT1)/4.
+
+            gradVPT = np.zeros((2, 3))
+            gradVPT[:, 1:] = np.eye(2)
+            gradVPT[:, 0] = [(VdP1 - VdP0)/dP, (VdT1 - VdT0)/dT]
+            VPT_covariance = gradVPT.T.dot(PT_covariance).dot(gradVPT)
+            return volume, VPT_covariance

--- a/docs/changelog/20220128_bobmyhill.rst
+++ b/docs/changelog/20220128_bobmyhill.rst
@@ -1,0 +1,18 @@
+* BurnMan now has a Calibrant class. This class is a stripped-down
+  version of a Material that is initialised with a params dictionary
+  and a function to compute the pressure or volume at given conditions.
+
+  Objects derived from this class have the ability to output
+  pressure/volume as a function of volume/pressure and temperature.
+  The user can pass a V-T or P-T covariance matrix as an additional
+  optional argument, in which case BurnMan will propagate the errors
+  and output a full P-V-T or V-P-T covariance matrix.
+
+  A helper function is provided to convert from pressure calculated
+  using one calibration into pressure calculated using another
+  calibration of the same material.
+
+  This class is expected to be used by experimental petrologists and
+  those interpreting high pressure experimental data.
+
+  *Bob Myhill, 2022/01/28*

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -78,6 +78,9 @@ of BurnMan objects:
   .. automodule:: examples.example_mineral
 
 
+  .. automodule:: examples.example_calibrants
+
+
   .. automodule:: examples.example_anisotropy
 
   *Resulting figure:*

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -30,6 +30,7 @@ of BurnMan objects:
   - :mod:`~examples.example_gibbs_modifiers`,
   - :mod:`~examples.example_solid_solution`,
   - :mod:`~examples.example_composite`,
+  - :mod:`~examples.example_calibrants`,
   - :mod:`~examples.example_anisotropy`,
   - :mod:`~examples.example_anisotropic_mineral`,
   - :mod:`~examples.example_geotherms`, and
@@ -72,6 +73,9 @@ of BurnMan objects:
   .. image:: figures/example_composite_figure_1.png
 
   .. image:: figures/example_composite_figure_2.png
+
+
+  .. automodule:: examples.example_mineral
 
 
   .. automodule:: examples.example_anisotropy

--- a/docs/materials.rst
+++ b/docs/materials.rst
@@ -53,3 +53,9 @@ Composites
 ----------
 
 .. autoclass:: burnman.Composite
+
+
+Calibrants
+----------
+
+.. autoclass:: burnman.Calibrant

--- a/docs/mineral_database.rst
+++ b/docs/mineral_database.rst
@@ -56,5 +56,8 @@ Mineral databases
 Calibrant databases
 -------------------
 
+.. automodule:: burnman.calibrants
+  :no-inherited-members:
+
 .. automodule::  burnman.calibrants.Decker_1971
   :no-inherited-members:

--- a/docs/mineral_database.rst
+++ b/docs/mineral_database.rst
@@ -51,3 +51,10 @@ Mineral databases
 
 .. automodule::  burnman.minerals.other
   :no-inherited-members:
+
+
+Calibrant databases
+-------------------
+
+.. automodule::  burnman.calibrants.Decker_1971
+  :no-inherited-members:

--- a/examples/example_calibrants.py
+++ b/examples/example_calibrants.py
@@ -1,0 +1,125 @@
+# This file is part of BurnMan - a thermoelastic and thermodynamic toolkit for
+# the Earth and Planetary Sciences
+# Copyright (C) 2012 - 2022 by the BurnMan team, released under the GNU
+# GPL v2 or later.
+
+
+"""
+example_calibrants
+------------------
+
+This example demonstrates the use of BurnMan's library of pressure calibrants.
+These calibrants are stripped-down versions of BurnMan's minerals, in that
+they are only designed to return pressure as a function of
+volume and temperature or volume as a function of pressure and temperature.
+
+*Uses:*
+
+* :class:`burnman.classes.calibrant.Calibrant`
+* :func:`burnman.calibrants.tools.pressure_to_pressure`
+* Decker (1971) calibration for NaCl
+
+*Demonstrates:*
+
+* Use of the Calibrant class
+* Conversion between pressures given by two different calibrations.
+"""
+
+import numpy as np
+from burnman.calibrants import decker_1971
+from burnman.calibrants.tools import pressure_to_pressure
+from burnman.tools.unitcell import molar_volume_from_unit_cell_volume
+
+
+# In this example, we'll be using the Decker (1971)
+# equation of state for NaCl.
+# The volume at any pressure and temperature can be calculated like so:
+V0 = decker_1971.B1_NaCl.volume(pressure=1.e5,
+                                temperature=293.15)
+
+# Bear in mind that volumes in BurnMan are usually calculated in molar units.
+# To convert from unit cell volumes in A^3/unit cell to molar volumes
+# in m^3/mol, you can use the BurnMan tool
+# "molar_volume_from_unit_cell_volume", e.g.:
+V0_std = molar_volume_from_unit_cell_volume(5.6404**3.,
+                                            decker_1971.B1_NaCl.params['Z'])
+
+
+# For the next part of the example,
+# we'll use the volume and temperature given in the last line
+# of Table II in Decker (1971):
+volume = V0*(1.-0.2950)  # m^3/mol
+temperature = 1073.15  # K
+
+# The Calibrant class in BurnMan also allows users to propagate
+# uncertainties in volume and temperature into a full
+# variance-covariance matrix.
+
+# Let's assume the uncertainty in volume is 1%,
+# the uncertainty in temperature is 1 K,
+# and the uncertainties are uncorrelated.
+sigma_volume = volume / 100.
+sigma_temperature = 10.
+
+print('Experimental observations:')
+print(f'Volume: {volume*1.e6:.4f} +/- {sigma_volume*1.e6:.4f} m^3/mol')
+print(f'Temperature: {temperature} +/- {sigma_temperature} K')
+print()
+
+# The calculated pressure can be calculated like so:
+pressure = decker_1971.B1_NaCl.pressure(volume, temperature)
+
+print('Pressure estimated using the Decker equation of state:')
+print(f'{pressure/1.e9:.4f} GPa')
+print()
+
+# The above command didn't do any error propagation.
+# Let's utilise the reported uncertainties in the volume and
+# temperature data to output a covariance matrix
+var_VT = np.array([[sigma_volume**2., 0.],
+                   [0., sigma_temperature**2.]])
+
+
+pressure, var_PVT = decker_1971.B1_NaCl.pressure(volume, temperature, var_VT)
+
+# Standard conversion from the covariance matrix to the
+# standard deviations and correlation matrix
+sigma_PVT = np.sqrt(np.diag(var_PVT))
+corr_PVT = np.einsum('i, ij, j -> ij', 1./sigma_PVT, var_PVT, 1./sigma_PVT)
+
+print('Pressure with propagated uncertainty\n'
+      'estimated using the Decker equation of state:')
+print(f'{pressure/1.e9:.4f} +/- {sigma_PVT[0]/1.e9:.4f} GPa')
+print('PVT correlation matrix:')
+print(f'{corr_PVT}')
+print('The uncertainties and correlation matrix only take into account ')
+print('the uncertainties in the measured volume and temperature, ')
+print('not the uncertainties in the calibrated equation of state.')
+print()
+
+
+# We can also check that the inverse operation (pressure -> volume)
+# produces the original covariance matrix is consistent
+var_PT = var_PVT[np.ix_([0, 2], [0, 2])]
+volume, var_VPT = decker_1971.B1_NaCl.volume(pressure, temperature, var_PT)
+
+sigma_VPT = np.sqrt(np.diag(var_VPT))
+corr_VPT = np.einsum('i, ij, j -> ij', 1./sigma_VPT, var_VPT, 1./sigma_VPT)
+
+print('Consistency checks:')
+print(f'Volume: {volume*1.e6:.4f} +/- {sigma_VPT[0]*1.e6:.4f} m^3/mol')
+print(f'Temperature: {temperature} +/- {sigma_VPT[2]:.4f} K')
+print(f'V-T correlation: {corr_VPT[0, 2]:.6f}')
+print()
+
+# Finally, let's convert from one calibration to another
+# Here, we convert from the Decker NaCl equation of state
+# to the same equation of state, so we should see no change
+# in the estimated pressure and covariance matrix.
+new_P, new_var_PT = pressure_to_pressure(decker_1971.B1_NaCl,
+                                         decker_1971.B1_NaCl,
+                                         pressure, temperature, var_PT)
+
+print('Result of conversion from Decker calibration to Decker calibration:')
+print(f'{new_P/1.e9:.4f} +/- {np.sqrt(new_var_PT[0, 0])/1.e9:.4f} GPa')
+print('(This should be the same as the pressures above)')

--- a/examples/example_calibrants.py
+++ b/examples/example_calibrants.py
@@ -26,100 +26,101 @@ volume and temperature or volume as a function of pressure and temperature.
 """
 
 import numpy as np
-from burnman.calibrants import decker_1971
+from burnman.calibrants import Decker_1971
 from burnman.calibrants.tools import pressure_to_pressure
 from burnman.tools.unitcell import molar_volume_from_unit_cell_volume
 
 
-# In this example, we'll be using the Decker (1971)
-# equation of state for NaCl.
-# The volume at any pressure and temperature can be calculated like so:
-V0 = decker_1971.B1_NaCl.volume(pressure=1.e5,
-                                temperature=293.15)
+if __name__ == "__main__":
 
-# Bear in mind that volumes in BurnMan are usually calculated in molar units.
-# To convert from unit cell volumes in A^3/unit cell to molar volumes
-# in m^3/mol, you can use the BurnMan tool
-# "molar_volume_from_unit_cell_volume", e.g.:
-V0_std = molar_volume_from_unit_cell_volume(5.6404**3.,
-                                            decker_1971.B1_NaCl.params['Z'])
+    # In this example, we'll be using the Decker (1971)
+    # equation of state for NaCl.
+    Decker_1971_NaCl = Decker_1971.NaCl_B1()
 
+    # The volume at any pressure and temperature can be calculated like so:
+    V0 = Decker_1971_NaCl.volume(pressure=1.e5, temperature=293.15)
 
-# For the next part of the example,
-# we'll use the volume and temperature given in the last line
-# of Table II in Decker (1971):
-volume = V0*(1.-0.2950)  # m^3/mol
-temperature = 1073.15  # K
+    # Remember, volumes in BurnMan are usually calculated in molar units.
+    # To convert from unit cell volumes in A^3/unit cell to molar volumes
+    # in m^3/mol, you can use the BurnMan tool
+    # "molar_volume_from_unit_cell_volume", e.g.:
+    V0_std = molar_volume_from_unit_cell_volume(5.6404**3.,
+                                                Decker_1971_NaCl.params['Z'])
 
-# The Calibrant class in BurnMan also allows users to propagate
-# uncertainties in volume and temperature into a full
-# variance-covariance matrix.
+    # For the next part of the example,
+    # we'll use the volume and temperature given in the last line
+    # of Table II in Decker (1971):
+    volume = V0*(1.-0.2950)  # m^3/mol
+    temperature = 1073.15  # K
 
-# Let's assume the uncertainty in volume is 1%,
-# the uncertainty in temperature is 1 K,
-# and the uncertainties are uncorrelated.
-sigma_volume = volume / 100.
-sigma_temperature = 10.
+    # The Calibrant class in BurnMan also allows users to propagate
+    # uncertainties in volume and temperature into a full
+    # variance-covariance matrix.
 
-print('Experimental observations:')
-print(f'Volume: {volume*1.e6:.4f} +/- {sigma_volume*1.e6:.4f} m^3/mol')
-print(f'Temperature: {temperature} +/- {sigma_temperature} K')
-print()
+    # Let's assume the uncertainty in volume is 1%,
+    # the uncertainty in temperature is 1 K,
+    # and the uncertainties are uncorrelated.
+    sigma_volume = volume / 100.
+    sigma_temperature = 10.
 
-# The calculated pressure can be calculated like so:
-pressure = decker_1971.B1_NaCl.pressure(volume, temperature)
+    print('Experimental observations:')
+    print(f'Volume: {volume*1.e6:.4f} +/- {sigma_volume*1.e6:.4f} m^3/mol')
+    print(f'Temperature: {temperature} +/- {sigma_temperature} K')
+    print()
 
-print('Pressure estimated using the Decker equation of state:')
-print(f'{pressure/1.e9:.4f} GPa')
-print()
+    # The calculated pressure can be calculated like so:
+    pressure = Decker_1971_NaCl.pressure(volume, temperature)
 
-# The above command didn't do any error propagation.
-# Let's utilise the reported uncertainties in the volume and
-# temperature data to output a covariance matrix
-var_VT = np.array([[sigma_volume**2., 0.],
-                   [0., sigma_temperature**2.]])
+    print('Pressure estimated using the Decker equation of state:')
+    print(f'{pressure/1.e9:.4f} GPa')
+    print()
 
+    # The above command didn't do any error propagation.
+    # Let's utilise the reported uncertainties in the volume and
+    # temperature data to output a covariance matrix
+    var_VT = np.array([[sigma_volume**2., 0.],
+                       [0., sigma_temperature**2.]])
 
-pressure, var_PVT = decker_1971.B1_NaCl.pressure(volume, temperature, var_VT)
+    pressure, var_PVT = Decker_1971_NaCl.pressure(volume, temperature, var_VT)
 
-# Standard conversion from the covariance matrix to the
-# standard deviations and correlation matrix
-sigma_PVT = np.sqrt(np.diag(var_PVT))
-corr_PVT = np.einsum('i, ij, j -> ij', 1./sigma_PVT, var_PVT, 1./sigma_PVT)
+    # Standard conversion from the covariance matrix to the
+    # standard deviations and correlation matrix
+    sigma_PVT = np.sqrt(np.diag(var_PVT))
+    corr_PVT = np.einsum('i, ij, j -> ij', 1./sigma_PVT, var_PVT, 1./sigma_PVT)
 
-print('Pressure with propagated uncertainty\n'
-      'estimated using the Decker equation of state:')
-print(f'{pressure/1.e9:.4f} +/- {sigma_PVT[0]/1.e9:.4f} GPa')
-print('PVT correlation matrix:')
-print(f'{corr_PVT}')
-print('The uncertainties and correlation matrix only take into account ')
-print('the uncertainties in the measured volume and temperature, ')
-print('not the uncertainties in the calibrated equation of state.')
-print()
+    print('Pressure with propagated uncertainty\n'
+          'estimated using the Decker equation of state:')
+    print(f'{pressure/1.e9:.4f} +/- {sigma_PVT[0]/1.e9:.4f} GPa')
+    print('PVT correlation matrix:')
+    print(f'{corr_PVT}')
+    print('The uncertainties and correlation matrix only take into account ')
+    print('the uncertainties in the measured volume and temperature, ')
+    print('not the uncertainties in the calibrated equation of state.')
+    print()
 
+    # We can also check that the inverse operation (pressure -> volume)
+    # produces the original covariance matrix is consistent
+    var_PT = var_PVT[np.ix_([0, 2], [0, 2])]
+    volume, var_VPT = Decker_1971_NaCl.volume(pressure, temperature, var_PT)
 
-# We can also check that the inverse operation (pressure -> volume)
-# produces the original covariance matrix is consistent
-var_PT = var_PVT[np.ix_([0, 2], [0, 2])]
-volume, var_VPT = decker_1971.B1_NaCl.volume(pressure, temperature, var_PT)
+    sigma_VPT = np.sqrt(np.diag(var_VPT))
+    corr_VPT = np.einsum('i, ij, j -> ij', 1./sigma_VPT, var_VPT, 1./sigma_VPT)
 
-sigma_VPT = np.sqrt(np.diag(var_VPT))
-corr_VPT = np.einsum('i, ij, j -> ij', 1./sigma_VPT, var_VPT, 1./sigma_VPT)
+    print('Consistency checks:')
+    print(f'Volume: {volume*1.e6:.4f} +/- {sigma_VPT[0]*1.e6:.4f} m^3/mol')
+    print(f'Temperature: {temperature} +/- {sigma_VPT[2]:.4f} K')
+    print(f'V-T correlation: {corr_VPT[0, 2]:.6f}')
+    print()
 
-print('Consistency checks:')
-print(f'Volume: {volume*1.e6:.4f} +/- {sigma_VPT[0]*1.e6:.4f} m^3/mol')
-print(f'Temperature: {temperature} +/- {sigma_VPT[2]:.4f} K')
-print(f'V-T correlation: {corr_VPT[0, 2]:.6f}')
-print()
+    # Finally, let's convert from one calibration to another
+    # Here, we convert from the Decker NaCl equation of state
+    # to the same equation of state, so we should see no change
+    # in the estimated pressure and covariance matrix.
+    new_P, new_var_PT = pressure_to_pressure(Decker_1971_NaCl,
+                                             Decker_1971_NaCl,
+                                             pressure, temperature, var_PT)
 
-# Finally, let's convert from one calibration to another
-# Here, we convert from the Decker NaCl equation of state
-# to the same equation of state, so we should see no change
-# in the estimated pressure and covariance matrix.
-new_P, new_var_PT = pressure_to_pressure(decker_1971.B1_NaCl,
-                                         decker_1971.B1_NaCl,
-                                         pressure, temperature, var_PT)
-
-print('Result of conversion from Decker calibration to Decker calibration:')
-print(f'{new_P/1.e9:.4f} +/- {np.sqrt(new_var_PT[0, 0])/1.e9:.4f} GPa')
-print('(This should be the same as the pressures above)')
+    print('Result of conversion from Decker calibration to '
+          'Decker calibration:')
+    print(f'{new_P/1.e9:.4f} +/- {np.sqrt(new_var_PT[0, 0])/1.e9:.4f} GPa')
+    print('(This should be the same as the pressures above)')

--- a/misc/ref/example_calibrants.py.out
+++ b/misc/ref/example_calibrants.py.out
@@ -1,0 +1,26 @@
+Experimental observations:
+Volume: 19.0344 +/- 0.1903 m^3/mol
+Temperature: 1073.15 +/- 10.0 K
+
+Pressure estimated using the Decker equation of state:
+21.7087 GPa
+
+Pressure with propagated uncertainty
+estimated using the Decker equation of state:
+21.7087 +/- 1.0263 GPa
+PVT correlation matrix:
+[[ 1.         -0.99957758  0.02906305]
+ [-0.99957758  1.          0.        ]
+ [ 0.02906305  0.          1.        ]]
+The uncertainties and correlation matrix only take into account 
+the uncertainties in the measured volume and temperature, 
+not the uncertainties in the calibrated equation of state.
+
+Consistency checks:
+Volume: 19.0344 +/- 0.1903 m^3/mol
+Temperature: 1073.15 +/- 10.0000 K
+V-T correlation: -0.000000
+
+Result of conversion from Decker calibration to Decker calibration:
+21.7087 +/- 1.0263 GPa
+(This should be the same as the pressures above)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ metadata = dict(name='burnman',
                 license='GPL',
                 long_description_content_type="text/x-rst",
                 long_description='BurnMan is a Python library for generating thermodynamic and thermoelastic models of planetary interiors.',
-                packages=['burnman', 'burnman.minerals', 'burnman.eos', 'burnman.tools', 'burnman.classes', 'burnman.optimize'],
+                packages=['burnman', 'burnman.minerals', 'burnman.eos', 'burnman.calibrants', 'burnman.tools', 'burnman.classes', 'burnman.optimize'],
                 package_data={'burnman': ['data/input_*/*']},
                 classifiers=[
                 'License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)',


### PR DESCRIPTION
This PR adds a new Calibrant class to BurnMan. This class is a stripped-down version of a Material that is initialised with a params dictionary and a function to compute the pressure or volume at given conditions.

Objects derived from this class have the ability to output pressure/volume as a function of volume/pressure and temperature. The user can pass a V-T or P-T covariance matrix as an additional optional argument, in which case BurnMan will propagate the errors and output a full P-V-T or V-P-T covariance matrix.

A helper function is provided to convert from pressure calculated using one calibration into pressure calculated using another calibration of the same material.

This class is expected to be used by experimental petrologists and those interpreting high pressure experimental data.