### PR TITLE
Add fitting bounds and deltas

### DIFF
--- a/burnman/optimize/eos_fitting.py
+++ b/burnman/optimize/eos_fitting.py
@@ -39,13 +39,31 @@ def fit_PTp_data(mineral, fit_params, flags, data, data_covariances=[],
         Attribute names for the property to be fit for the whole
         dataset or each datum individually (e.g. 'V')
 
-    data : numpy array of observed P-T-property values
+    data : 2D numpy array of observed X-P-T-property values
 
-    data_covariances : numpy array of P-T-property covariances (optional)
+    data_covariances : 3D numpy array of X-P-T-property covariances (optional)
         If not given, all covariance matrices are chosen
-        such that C00 = 1, otherwise Cij = 0
-        In other words, all data points have equal weight,
-        with all error in the pressure
+        such that all data points have equal weight,
+        with all error in the pressure.
+
+    mle_tolerances : numpy array (optional)
+        Tolerances for termination of the maximum likelihood iterations.
+
+    param_tolerance : float (optional)
+        Fractional tolerance for termination of the nonlinear optimization.
+
+    delta_params : numpy array (optional)
+        Initial values for the change in parameters.
+
+    bounds : 2D numpy array (optional)
+        Minimum and maximum bounds for the parameters. The shape must be
+        (n_parameters, 2).
+
+    max_lm_iterations : integer (default : 50)
+        Maximum number of Levenberg-Marquardt iterations.
+
+    verbose : boolean (default : True)
+        Whether to print detailed information about the optimization to screen.
 
     Returns
     -------

--- a/docs/changelog/20220205_bobmyhill.rst
+++ b/docs/changelog/20220205_bobmyhill.rst
@@ -1,0 +1,6 @@
+* New: The EoS fitting functions now have additional (optional)
+  arguments. delta_params allows the user to set initial values for the
+  change in parameters (i.e. initial step size). bounds allows the user
+  to set hard bounds on the values of each of the parameters.
+
+  *Bob Myhill, 2022/02/05*

--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -118,11 +118,14 @@ class test_fitting(BurnManTest):
 
         PTV = np.empty((len(pressures), 3))
 
-        np.random.seed(10)
         for i in range(len(pressures)):
             fo.set_state(pressures[i], temperatures[i])
-            f = (1. + (np.random.normal() - 0.5)*5.e-4)
-            PTV[i] = [pressures[i], temperatures[i], fo.V*f]
+            PTV[i] = [pressures[i], temperatures[i], fo.V]
+
+        # Modify the lowest and highest pressure points
+        # to artificially reduce the value of K'0
+        PTV[0, 2] *= 1.01
+        PTV[-1, 2] *= 0.99
 
         params = ['V_0', 'K_0', 'Kprime_0']
         bounds = np.array([[0., np.inf], [0., np.inf], [3., 4.]])
@@ -130,7 +133,7 @@ class test_fitting(BurnManTest):
                                                       PTV, bounds=bounds,
                                                       verbose=False)
 
-        self.assertFloatEqual(4., fitted_eos.popt[2])
+        self.assertFloatEqual(3., fitted_eos.popt[2])
 
 
 if __name__ == '__main__':

--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -110,6 +110,28 @@ class test_fitting(BurnManTest):
 
         self.assertArraysAlmostEqual(fitted_eos.pcov[0], zeros)
 
+    def test_fit_bounded_PVT_data(self):
+        fo = burnman.minerals.HP_2011_ds62.fo()
+
+        pressures = np.linspace(0.e9, 10.e9, 8)
+        temperatures = np.ones_like(pressures) * fo.params['T_0']
+
+        PTV = np.empty((len(pressures), 3))
+
+        np.random.seed(10)
+        for i in range(len(pressures)):
+            fo.set_state(pressures[i], temperatures[i])
+            f = (1. + (np.random.normal() - 0.5)*5.e-4)
+            PTV[i] = [pressures[i], temperatures[i], fo.V*f]
+
+        params = ['V_0', 'K_0', 'Kprime_0']
+        bounds = np.array([[0., np.inf], [0., np.inf], [3., 4.]])
+        fitted_eos = burnman.eos_fitting.fit_PTV_data(fo, params,
+                                                      PTV, bounds=bounds,
+                                                      verbose=False)
+
+        self.assertFloatEqual(4., fitted_eos.popt[2])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The EoS fitting functions now have additional (optional) arguments. delta params allows the user to set initial values for the change in parameters (i.e. initial step size). bounds allows the user to set hard bounds on the values of each of the parameters.

A new test is added to the test suite.

This PR addresses #328.