### PR TITLE
added set_state_with_volume function

### DIFF
--- a/docs/changelog/20220216b_bobmyhill.rst
+++ b/docs/changelog/20220216b_bobmyhill.rst
@@ -1,0 +1,5 @@
+* New: The BurnMan Material classes now have a method
+  called set_state_with_volume that sets state using volume
+  and temperature rather than pressure and temperature.
+
+  *Bob Myhill, 2022/02/16*

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -6,7 +6,6 @@ import numpy as np
 import burnman
 
 
-
 class test_material_name(BurnManTest):
 
     """ test Material.name and that we can edit and override it in Mineral"""
@@ -120,6 +119,20 @@ class test_material_name(BurnManTest):
                         np.array([[1.e5, 1.e5, 1.e5], [1.e5, 1.e5, 1.e5]]),
                         np.array([[300., 300., 300], [300., 300., 300]]))
         self.assertEqual(Ss[0].shape, (2, 3))
+
+    def test_set_state_with_volume(self):
+        m = self.min_with_name()
+        P0 = 6.e9,
+        T0 = 1000.
+        T1 = 298.15
+
+        m.set_state(P0, T0)
+        V = m.V
+        m.set_state_with_volume(V, T1)
+        P1 = m.pressure
+        m.set_state(P0, T0)  # forget new state
+        m.set_state(P1, T1)  # return to new state
+        self.assertFloatEqual(V, m.V)
 
 
 if __name__ == '__main__':

--- a/tests/test_solidsolution.py
+++ b/tests/test_solidsolution.py
@@ -322,6 +322,22 @@ class test_solidsolution(BurnManTest):
                          fo_ss.C_p, fo_ss.C_v, fo_ss.alpha, fo_ss.K_T, fo_ss.K_S, fo_ss.gr]
         self.assertArraysAlmostEqual(endmember_properties, ss_properties)
 
+    def test_set_state_with_volume(self):
+        m = olivine_ss()
+        m.set_composition([0.5, 0.5])
+
+        P0 = 6.e9
+        T0 = 1000.
+        T1 = 298.15
+
+        m.set_state(P0, T0)
+        V = m.V
+        m.set_state_with_volume(V, T1)
+        P1 = m.pressure
+        m.set_state(P0, T0)  # forget new state
+        m.set_state(P1, T1)  # return to new state
+        self.assertFloatEqual(V, m.V)
+
     def test_ol_Wh(self):
         ol_ss = olivine_ss()
         H_excess = ol_ss.solution_model.excess_enthalpy(


### PR DESCRIPTION
This PR adds a new method to the Material classes called set_state_with_volume that sets state using volume and temperature rather than pressure and temperature.

Two additional tests have been added to check functionality.