### PR TITLE
simplified composition class

### DIFF
--- a/burnman/classes/composition.py
+++ b/burnman/classes/composition.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 # Copyright (C) 2012 - 2018 by the BurnMan team, released under the GNU
 # GPL v2 or later.
 
+from copy import deepcopy
 import numpy as np
 from scipy.optimize import nnls
 
@@ -11,35 +12,10 @@ from ..tools.chemistry import dictionarize_formula, formula_mass
 from ..tools.misc import OrderedCounter
 
 
-def composition_property(func):
-    """
-    Decorator @composition_property to be used for cached properties of compositions.
-
-    To be used on function in Composition or derived classes that should be exposed
-    as read-only properties that are cached.
-    """
-    class mat_obj():
-
-        def __init__(self, func):
-            self.func = func
-            self.varname = self.func.__name__
-
-        def get(self, obj):
-            if not hasattr(obj, "_cached"):
-                raise Exception("The composition_property decorator could not find class member _cached. "
-                                "Did you forget to call Composition.__init__(self) in __init___?")
-            cache_array = getattr(obj, "_cached")
-            if self.varname not in cache_array:
-                cache_array[self.varname] = self.func(obj)
-            return cache_array[self.varname]
-
-    return property(mat_obj(func).get, doc=func.__doc__)
-
-
 def file_to_composition_list(fname, unit_type, normalize):
     """
-    Takes an input file with a specific format and returns a list of compositions
-    (and associated comments) contained in that file.
+    Takes an input file with a specific format and returns a list of
+    compositions (and associated comments) contained in that file.
 
     Parameters
     ----------
@@ -47,38 +23,46 @@ def file_to_composition_list(fname, unit_type, normalize):
         Path to ascii file containing composition data.
         Lines beginning with a hash are not read.
         The first read-line of the datafile contains a list of tab or
-        space-separated components (e.g. FeO or SiO2), followed by the word Comment.
+        space-separated components (e.g. FeO or SiO2), followed by the
+        word Comment.
         Following lines are lists of floats with the amounts of each component.
         After the component amounts, the user can write anything they like
         in the Comment section.
-    unit_type : 'weight' or 'molar'
-        Specify whether the compositions in the file are given as weight or
-        molar amounts.
+    unit_type : 'mass', 'weight' or 'molar'
+        Specify whether the compositions in the file are given as
+        mass (weight) or molar amounts.
     normalize : boolean
         If False, absolute numbers of moles/grams of component are stored,
         otherwise the component amounts of returned compositions will
         sum to one (until Composition.renormalize() is used).
 
     """
-    lines = list(filter(None, [line.rstrip('\n').split() for line in open(fname) if line[0] != '#']))
+    lines = list(filter(None, [line.rstrip('\n').split()
+                               for line in open(fname) if line[0] != '#']))
     n_components = lines[0].index("Comment")
     components = lines[0][:n_components]
     comments = [line[n_components:] for line in lines[1:]]
-    compositions = np.array([map(float, l) for l in list(zip(*(list(zip(*lines[1:]))[:n_components])))])
-    return [Composition(OrderedCounter(dict(zip(components, c))), unit_type, normalize) for c in compositions], comments
+    compositions = np.array([map(float, ln)
+                             for ln in list(zip(*(list(zip(*lines[1:]))[:n_components])))])
+    return [Composition(OrderedCounter(dict(zip(components, c))),
+                        unit_type, normalize)
+            for c in compositions], comments
 
 
 class Composition(object):
     """
     Class for a composition object, which can be used
     to store, modify and renormalize compositions,
-    and also convert between molar, weight,
-    and atomic amounts.
+    and also convert between mass, molar
+    and atomic amounts. Weight is provided as an alias
+    for mass, as we assume that only Earthlings
+    will use this software.
 
     This class is available as ``burnman.Composition``.
     """
 
-    def __init__(self, composition_dictionary, unit_type='weight', normalize=False):
+    def __init__(self, composition_dictionary, unit_type='mass',
+                 normalize=False):
         """
         Create a composition using a dictionary and unit type.
 
@@ -86,133 +70,106 @@ class Composition(object):
         ----------
         composition_dictionary : dictionary
             Dictionary of components (given as a string) and their amounts.
-        unit_type : 'weight' or 'molar' (optional, 'weight' as standard)
-            Specify whether the input composition is given as weight or
+        unit_type : 'mass', 'weight' or 'molar' (optional, 'mass' as default)
+            Specify whether the input composition is given as mass or
             molar amounts.
         normalize : boolean
-            If False, absolute numbers of moles/grams of component are stored,
-            otherwise the component amounts of returned compositions will
-            sum to one (until Composition.renormalize() is used).
+            If False, absolute numbers of kilograms/moles of component are
+            stored, otherwise the component amounts of returned compositions
+            will sum to one (until Composition.renormalize() is used).
         """
 
         self._cached = {}
 
         n_total = float(sum(composition_dictionary.values()))
 
-        normalized_dictionary = {}
-        for k in composition_dictionary.keys():
-            normalized_dictionary[k] = composition_dictionary[k]/n_total
+        # Create the input dictionary, normalize if requested
+        input_dictionary = OrderedCounter(deepcopy(composition_dictionary))
+        if normalize:
+            for k in composition_dictionary.keys():
+                input_dictionary[k] = composition_dictionary[k]/n_total
 
-        self.normalization_component = {'weight': 'total',
-                                        'molar': 'total',
-                                        'atomic': 'total'}
-
-        self.normalization_amount = {'weight': 1.,
-                                     'molar': 1.,
-                                     'atomic': 1.}
-
-
-        # component formulae
+        # Break component formulae into atomic dictionaries
         self.component_formulae = {c: dictionarize_formula(c)
                                    for c in composition_dictionary.keys()}
 
-        # elemental compositions of components
+        # Create lists of elemental compositions of components
         self.element_list = OrderedCounter()
         for component in self.component_formulae.values():
             self.element_list += OrderedCounter({element: n_atoms
-                                          for (element, n_atoms) in component.items()})
+                                                 for (element, n_atoms)
+                                                 in component.items()})
         self.element_list = list(self.element_list.keys())
 
-        if unit_type == 'weight':
-            if normalize:
-                self._cached['weight_composition'] = OrderedCounter(normalized_dictionary)
-            else:
-                self._cached['weight_composition'] = OrderedCounter(composition_dictionary)
-
-                mole_total = sum([composition_dictionary[c] /
-                                  formula_mass(self.component_formulae[c])
-                                  for c in composition_dictionary.keys()])
-                self.normalization_amount['weight'] = n_total
-                self.normalization_amount['molar'] = mole_total
-                self.normalization_amount['atomic'] = sum(self._moles_component_to_atoms(self.molar_composition).values())
-
+        if unit_type == 'mass' or unit_type == 'weight':
+            self.mass_composition = input_dictionary
         elif unit_type == 'molar':
-            if normalize:
-                self._cached['molar_composition'] = OrderedCounter(normalized_dictionary)
-            else:
-                self._cached['molar_composition'] = OrderedCounter(composition_dictionary)
-
-                weight_total = sum([composition_dictionary[c] *
-                                    formula_mass(self.component_formulae[c])
-                                    for c in composition_dictionary.keys()])
-
-                self.normalization_amount['weight'] = weight_total
-                self.normalization_amount['molar'] = n_total
-                self.normalization_amount['atomic'] = sum(self._moles_component_to_atoms(self.molar_composition).values())
-
+            self.mass_composition = self._mole_to_mass_composition(input_dictionary)
         else:
             raise Exception('Unit type not yet implemented. '
-                            'Should be either weight or molar.')
+                            'Should be either mass, weight or molar.')
 
-
-
-
-
-    def renormalize(self, unit_type, normalization_component, normalization_amount):
+    def renormalize(self, unit_type, normalization_component,
+                    normalization_amount):
         """
-        Change the normalization for a given unit type
-        (weight, molar, or atomic)
-        Resets cached composition only for that unit type
+        Change the total amount of material in the composition
+        to satisfy a given normalization condition
+        (mass, weight, molar, or atomic)
 
         Parameters
         ----------
-        unit_type : 'weight', 'molar' or 'atomic'
-            Unit type composition to be renormalised
+        unit_type : 'mass', 'weight', 'molar' or 'atomic'
+            Unit type with which to normalize the composition
         normalization_component: string
             Component/element on which to renormalize.
             String must either be one of the components/elements
-            already in composite, or have the value 'total'
+            already in the composition, or have the value 'total'
         normalization_amount: float
             Amount of component in the renormalised composition
         """
-        if unit_type == 'weight':
-            s = self.weight_composition
-        elif unit_type == 'molar':
-            s = self.molar_composition
-        elif unit_type == 'atomic':
-            s = self.atomic_composition
-        else:
-            raise Exception('Unit type not recognised. '
-                            'Should be one of weight, molar and atomic')
 
-        self.normalization_component[unit_type] = normalization_component
-        self.normalization_amount[unit_type] = normalization_amount
-        self._cached[unit_type+'_composition'] = self._normalize_to_basis(s, unit_type)
+        if unit_type not in ['mass', 'weight', 'molar', 'atomic']:
+            raise Exception('unit_type not yet implemented.'
+                            'Should be either mass, weight, molar or atomic.')
+
+        c = self.composition(unit_type)
+
+        if normalization_component == 'total':
+            f = normalization_amount / float(sum(c.values()))
+        else:
+            f = normalization_amount / c[normalization_component]
+
+        new_mass_composition = OrderedCounter()
+        for k in self.mass_composition.keys():
+            new_mass_composition[k] = self.mass_composition[k] * f
+
+        self.mass_composition = new_mass_composition
 
     def add_components(self, composition_dictionary, unit_type):
         """
         Add (or remove) components from the composition.
         The components are added to the current state of the
-        (weight or molar) composition; if the composition has
+        (mass, weight or molar) composition; if the composition has
         been renormalised, then this should be taken into account.
 
         Parameters
         ----------
         composition_dictionary : dictionary
             Components to add, and their amounts, in dictionary form
-        unit_type : 'weight' or 'molar'
+        unit_type : 'mass', 'weight' or 'molar'
             Unit type of the components to be added
         """
-        if unit_type == 'weight':
-            composition = self.weight_composition
+        if unit_type == 'mass' or unit_type == 'weight':
+            composition = self.mass_composition
         elif unit_type == 'molar':
             composition = self.molar_composition
         else:
             raise Exception('Unit type not recognised. '
-                            'Should be either weight or molar.')
+                            'Should be either mass, weight or molar.')
 
         composition += OrderedCounter(composition_dictionary)
 
+        # Reinitialize composition object
         self.__init__(composition, unit_type)
 
     def change_component_set(self, new_component_list):
@@ -230,7 +187,8 @@ class Composition(object):
         """
         composition = np.array([self.atomic_composition[element]
                                 for element in self.element_list])
-        component_matrix = np.zeros((len(new_component_list), len(self.element_list)))
+        component_matrix = np.zeros((len(new_component_list),
+                                     len(self.element_list)))
 
         for i, component in enumerate(new_component_list):
             formula = dictionarize_formula(component)
@@ -242,59 +200,77 @@ class Composition(object):
             component_amounts = sol[0]
         else:
             raise Exception('Failed to change component set. '
-                            'Could not find a non-negative least squares solution. '
-                            'Can the bulk composition be described with this set of components?')
+                            'Could not find a non-negative '
+                            'least squares solution. '
+                            'Can the bulk composition be described '
+                            'with this set of components?')
 
-        composition = OrderedCounter(dict(zip(new_component_list, component_amounts)))
+        composition = OrderedCounter(dict(zip(new_component_list,
+                                              component_amounts)))
+
+        # Reinitialize the object
         self.__init__(composition, 'molar')
 
-    def _normalize_to_basis(self, composition, unit_type):
-        if self.normalization_component[unit_type] == 'total':
-            n_orig = float(sum(composition.values()))
-        else:
-            n_orig = composition[self.normalization_component[unit_type]]
+    def _mole_to_mass_composition(self, molar_comp):
+        """
+        Hidden function to returns the mass composition as a counter [kg]
+        """
+        cf = self.component_formulae
+        mass_composition = OrderedCounter({c: molar_comp[c]
+                                             * formula_mass(cf[c])
+                                             for c in molar_comp.keys()})
 
-        for k in composition.keys():
-            composition[k] *= self.normalization_amount[unit_type]/n_orig
+        return mass_composition
 
-        return composition
+    @property
+    def weight_composition(self):
+        """
+        An alias for mass composition [kg].
+        """
+        return self.mass_composition
 
-    @composition_property
+    @property
     def molar_composition(self):
         """
         Returns the molar composition as a counter [moles]
         """
-        mole_compositions = OrderedCounter({c: self.weight_composition[c] /
-                                            formula_mass(self.component_formulae[c])
-                                            for c in self.weight_composition.keys()})
+        mass_comp = self.mass_composition
+        cf = self.component_formulae
 
-        return self._normalize_to_basis(mole_compositions, 'molar')
+        return OrderedCounter({c: mass_comp[c] / formula_mass(cf[c])
+                               for c in mass_comp.keys()})
 
-    @composition_property
-    def weight_composition(self):
-        """
-        Returns the weight composition as a counter [g]
-        """
-        weight_compositions = OrderedCounter({c: self.molar_composition[c] *
-                                              formula_mass(self.component_formulae[c])
-                                              for c in self.molar_composition.keys()})
-
-        return self._normalize_to_basis(weight_compositions, 'weight')
-
-    @composition_property
+    @property
     def atomic_composition(self):
         """
         Returns the atomic composition as a counter [moles]
         """
-        atom_compositions = self._moles_component_to_atoms(self.molar_composition)
 
-        return self._normalize_to_basis(atom_compositions, 'atomic')
+        return self._moles_to_atoms(self.molar_composition)
 
-    def _moles_component_to_atoms(self, molar_composition_dictionary):
-        component_matrix = np.zeros((len(self.component_formulae), len(self.element_list)))
-        molar_composition_vector = np.zeros(len(self.component_formulae))
-        for i, (component, formula) in enumerate(self.component_formulae.items()):
-            molar_composition_vector[i] = molar_composition_dictionary[component]
+    def composition(self, unit_type):
+        """
+        Helper function to return the composition in the
+        desired type.
+
+        Parameters
+        ----------
+        unit_type : string
+            One of 'mass', 'weight', 'molar' and 'atomic'.
+        """
+        return getattr(self, f'{unit_type}_composition')
+
+    def _moles_to_atoms(self, molar_comp_dictionary):
+        """
+        Hidden function that converts a molar component
+        dictionary into an atomic (elemental) dictionary
+        """
+        component_matrix = np.zeros((len(self.component_formulae),
+                                     len(self.element_list)))
+        cf = self.component_formulae
+        molar_composition_vector = np.zeros(len(cf))
+        for i, (component, formula) in enumerate(cf.items()):
+            molar_composition_vector[i] = molar_comp_dictionary[component]
 
             for element, n_atoms in formula.items():
                 component_matrix[i][self.element_list.index(element)] = n_atoms
@@ -302,16 +278,16 @@ class Composition(object):
         atom_compositions = np.dot(molar_composition_vector, component_matrix)
         return OrderedCounter(dict(zip(self.element_list, atom_compositions)))
 
-
     def print(self, unit_type, significant_figures=1,
-              normalization_component='total', normalization_amount=100.):
+              normalization_component='total', normalization_amount=None):
         """
         Pretty-print function for the composition
-        This does not renormalize the Composition internally
+        This does not renormalize the Composition object itself,
+        only the printed values.
 
         Parameters
         ----------
-        unit_type : 'weight', 'molar' or 'atomic'
+        unit_type : 'mass', 'weight', 'molar' or 'atomic'
             Unit type in which to print the composition
         significant_figures : integer
             Number of significant figures for each amount
@@ -322,40 +298,23 @@ class Composition(object):
             (default = 'total')
         normalization_amount: float
             Amount of component in the renormalised composition.
-            (default = '100.')
+            If not explicitly set, no renormalization will be applied.
+            (default = None)
         """
-        if unit_type == 'weight':
-            print('Weight composition')
 
-            if normalization_component == 'total':
-                total_stored = float(sum(self.weight_composition.values()))
-            else:
-                total_stored = self.weight_composition[normalization_component]
-            f = normalization_amount/total_stored
+        if unit_type not in ['mass', 'weight', 'molar', 'atomic']:
+            raise Exception('unit_type not yet implemented.'
+                            'Should be either mass, weight, molar or atomic.')
 
-            for (key, value) in sorted(self.weight_composition.items()):
-                print('{0}: {1:0.{sf}f}'.format(key, value*f, sf=significant_figures))
-        elif unit_type == 'molar':
-            print('Molar composition')
+        c = self.composition(unit_type)
+        print(f'{unit_type.capitalize()} composition')
 
-            if normalization_component == 'total':
-                total_stored = float(sum(self.molar_composition.values()))
-            else:
-                total_stored = self.molar_composition[normalization_component]
-            f = normalization_amount/total_stored
-
-            for (key, value) in sorted(self.molar_composition.items()):
-                print('{0}: {1:0.{sf}f}'.format(key, value*f, sf=significant_figures))
-        elif unit_type == 'atomic':
-            print('Atomic composition')
-
-            if normalization_component == 'total':
-                total_stored = float(sum(self.atomic_composition.values()))
-            else:
-                total_stored = self.atomic_composition[normalization_component]
-            f = normalization_amount/total_stored
-
-            for (key, value) in sorted(self.atomic_composition.items()):
-                print('{0}: {1:0.{sf}f}'.format(key, value*f, sf=significant_figures))
+        if normalization_amount is None:
+            f = 1
+        elif normalization_component == 'total':
+            f = normalization_amount / float(sum(c.values()))
         else:
-            raise Exception('unit_type not yet implemented. Should be either weight,  molar or atomic.')
+            f = normalization_amount / c[normalization_component]
+
+        for (key, value) in sorted(c.items()):
+            print(f'{key}: {value*f:0.{significant_figures}f}')

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -3,8 +3,7 @@ import unittest
 from util import BurnManTest
 import numpy as np
 
-from burnman.composition import Composition
-
+from burnman.classes.composition import Composition
 
 
 class composition(BurnManTest):
@@ -13,14 +12,16 @@ class composition(BurnManTest):
 
         c_dict = {'MgO': 1., 'SiO2': 1.}
         c = Composition(c_dict, unit_type='molar', normalize=False)
-        self.assertArraysAlmostEqual(
-            c_dict.values(), c.molar_composition.values())
+        self.assertArraysAlmostEqual(list(c_dict.values()),
+                                     c.molar_composition.values())
 
     def test_molar_normalize(self):
         c_dict = {'MgO': 1., 'SiO2': 1.}
         c = Composition(c_dict, unit_type='molar', normalize=True)
 
-        self.assertArraysAlmostEqual(np.array(c_dict.values())/sum(c_dict.values()),
+        c_fractions = (np.array(list(c_dict.values()))
+                       / sum(list(c_dict.values())))
+        self.assertArraysAlmostEqual(c_fractions,
                                      c.molar_composition.values())
 
     def test_weight_no_normalize(self):
@@ -34,26 +35,27 @@ class composition(BurnManTest):
         c_dict = {'MgO': 1., 'SiO2': 1.}
         c = Composition(c_dict, unit_type='weight', normalize=True)
 
-        self.assertArraysAlmostEqual(np.array(c_dict.values())/sum(c_dict.values()),
+        c_fractions = (np.array(list(c_dict.values()))
+                       / sum(list(c_dict.values())))
+        self.assertArraysAlmostEqual(c_fractions,
                                      c.weight_composition.values())
 
     def test_moles_to_atoms_no_normalize(self):
         c_dict = {'MgO': 1., 'SiO2': 1.}
         c = Composition(c_dict, unit_type='molar', normalize=False)
-
         self.assertFloatEqual(sum(c.atomic_composition.values()), 5.)
 
     def test_moles_to_atoms_normalize(self):
         c_dict = {'MgO': 1., 'SiO2': 1.}
         c = Composition(c_dict, unit_type='molar', normalize=True)
-        self.assertFloatEqual(c.atomic_composition['O'], 0.6)
+        self.assertFloatEqual(c.atomic_composition['O'], 1.5)
 
     def test_add_component_molar(self):
         c_dict = {'MgO': 1., 'SiO2': 1.}
         c = Composition(c_dict, unit_type='molar', normalize=False)
         c.add_components(c_dict, unit_type='molar')
 
-        self.assertArraysAlmostEqual(np.array(c_dict.values())*2.,
+        self.assertArraysAlmostEqual(np.array(list(c_dict.values()))*2.,
                                      c.molar_composition.values())
 
     def test_add_component_weight(self):
@@ -61,15 +63,14 @@ class composition(BurnManTest):
         c = Composition(c_dict, unit_type='weight', normalize=False)
         c.add_components(c_dict, unit_type='weight')
 
-        self.assertArraysAlmostEqual(np.array(c_dict.values())*2.,
+        self.assertArraysAlmostEqual(np.array(list(c_dict.values()))*2.,
                                      c.weight_composition.values())
 
     def test_add_component_mixed(self):
         c_dict = {'MgO': 1., 'SiO2': 1.}
         c = Composition(c_dict, unit_type='molar', normalize=False)
         c.add_components(c.weight_composition, unit_type='weight')
-
-        self.assertArraysAlmostEqual(np.array(c_dict.values())*2.,
+        self.assertArraysAlmostEqual(np.array(list(c_dict.values()))*2.,
                                      c.molar_composition.values())
 
     def test_add_component_mixed_inv(self):
@@ -77,7 +78,7 @@ class composition(BurnManTest):
         c = Composition(c_dict, unit_type='weight', normalize=False)
         c.add_components(c.molar_composition, unit_type='molar')
 
-        self.assertArraysAlmostEqual(np.array(c_dict.values())*2.,
+        self.assertArraysAlmostEqual(np.array(list(c_dict.values()))*2.,
                                      c.weight_composition.values())
 
     def test_change_component_set(self):
@@ -85,7 +86,7 @@ class composition(BurnManTest):
         c = Composition(c_dict, unit_type='molar', normalize=False)
         c.change_component_set(['MgO2', 'SiO'])
 
-        self.assertArraysAlmostEqual(np.array(c_dict.values()),
+        self.assertArraysAlmostEqual(np.array(list(c_dict.values())),
                                      c.molar_composition.values())
 
 


### PR DESCRIPTION
This PR simplifies the composition class by removing separate renormalization values for the weight, molar and atomic composition attributes. 

This means that when the user renormalizes the composition, they renormalize the stored composition for the object, rather than a stored renormalization value for the given unit type. This removes confusing behaviour and provides additional functionality (the user can more easily see how many moles of X there are in Y grams of the composition, for example).

This PR does have a small effect on existing behaviour when renormalize is used, but this never affects the ratios of components/elements; only their absolute amounts, and only when not defined by the user. 