### PR TITLE
allowed AnisotropicMineral initialisation with functions

### DIFF
--- a/contrib/anisotropic_eos/tools.py
+++ b/contrib/anisotropic_eos/tools.py
@@ -5,7 +5,7 @@ def print_table_for_mineral_constants(mineral, indices):
 
     constants = []
     for (i, j) in indices:
-        constants.append(mineral.c[i-1, j-1, :, :])
+        constants.append(mineral.anisotropic_params['c'][i-1, j-1, :, :])
 
     constants = np.array(constants)
 


### PR DESCRIPTION
This PR extends the new AnisotropicMineral so that it can accept a function that computes the Psi tensor and its derivatives as a function of f, Pth and the anisotropic parameters object.

The code is backwards compatible; there is no change to existing functionality.