### PR TITLE
added numba to pip reqs file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 numpy
+numba
 matplotlib
 scipy
 sympy


### PR DESCRIPTION
This PR adds numba to the pip requirements.txt file to ensure correct numpy dependencies. 

This also preserves the old tester output. Upgrading to numpy 1.23.0 (inconsistent with numba) negligibly degrades the fit_solution.py results (down at 8th decimal point in goodness of fit), but changes the rounded numbers in the covariance matrix sufficiently to cause the tester to fail. Not a bug, so not worthy of raising an issue, but we will probably need to deal with this when numba is updated.