### PR TITLE
use logish in new function solutions

### DIFF
--- a/burnman/classes/elasticsolution.py
+++ b/burnman/classes/elasticsolution.py
@@ -254,7 +254,8 @@ class ElasticSolution(Mineral):
         Returns a list of endmember activity coefficients
         (gamma = activity / ideal activity) [unitless].
         """
-        return self.activities / IdealSolution._ideal_activities(self.solution_model, self.molar_fractions)
+        return np.exp(np.log(self.activities)
+                      - IdealSolution._log_ideal_activities(self.solution_model, self.molar_fractions))
 
     @material_property
     def molar_internal_energy(self):

--- a/tests/test_elasticsolution.py
+++ b/tests/test_elasticsolution.py
@@ -500,6 +500,23 @@ class test_ElasticSolution(BurnManTest):
         self.assertArraysAlmostEqual(ss[0].activity_coefficients,
                                      ss[1].activity_coefficients)
 
+    def test_function_solution_low_proportions(self):
+        ss = [two_site_ss(), two_site_ss_function()]
+        for s in ss:
+            s.set_state(1.e5, 300.)
+            s.set_composition([0.5, 0.0, 0.5])
+
+        self.assertArraysAlmostEqual(ss[0].partial_gibbs,
+                                     ss[1].partial_gibbs)
+        self.assertArraysAlmostEqual(ss[0].partial_entropies,
+                                     ss[1].partial_entropies)
+        self.assertArraysAlmostEqual(ss[0].partial_volumes,
+                                     ss[1].partial_volumes)
+        self.assertArraysAlmostEqual(ss[0].activities,
+                                     ss[1].activities)
+        self.assertArraysAlmostEqual(ss[0].activity_coefficients,
+                                     ss[1].activity_coefficients)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_solidsolution.py
+++ b/tests/test_solidsolution.py
@@ -699,6 +699,31 @@ class test_solidsolution(BurnManTest):
         self.assertArraysAlmostEqual(ss[0].activity_coefficients,
                                      ss[1].activity_coefficients)
 
+    def test_function_solution_low_proportions(self):
+        ss = [ppv_symmetric(), ppv_function()]
+        for s in ss:
+            s.set_state(1.e5, 300.)
+            s.set_composition([0.0, 0.5, 0.5])
+
+        self.assertArraysAlmostEqual(ss[0].excess_partial_gibbs,
+                                     ss[1].excess_partial_gibbs)
+        self.assertArraysAlmostEqual(ss[0].partial_gibbs,
+                                     ss[1].partial_gibbs)
+        self.assertArraysAlmostEqual(ss[0].partial_entropies,
+                                     ss[1].partial_entropies)
+        self.assertArraysAlmostEqual(ss[0].partial_volumes,
+                                     ss[1].partial_volumes)
+        self.assertArraysAlmostEqual(ss[0].gibbs_hessian.flatten(),
+                                     ss[1].gibbs_hessian.flatten())
+        self.assertArraysAlmostEqual(ss[0].entropy_hessian.flatten(),
+                                     ss[1].entropy_hessian.flatten(),
+                                     tol_zero=1.e-12)
+        self.assertArraysAlmostEqual(ss[0].volume_hessian.flatten(),
+                                     ss[1].volume_hessian.flatten())
+        self.assertArraysAlmostEqual(ss[0].activities,
+                                     ss[1].activities)
+        self.assertArraysAlmostEqual(ss[0].activity_coefficients,
+                                     ss[1].activity_coefficients)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR slightly modifies the new `FunctionSolution` and `ElasticFunctionSolution` classes so that configurational entropies are calculated using the existing `logish()` function, rather than `autograd.numpy.log()`. This ensures consistency with other solution models.