### PR TITLE
correct typo in tutorial figure

### DIFF
--- a/tutorial/tutorial_04_fitting.ipynb
+++ b/tutorial/tutorial_04_fitting.ipynb
@@ -518,9 +518,9 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "fig = plt.figure(figsize=(6, 6))\n",
-        "ax = [fig.add_subplot(4, 1, 1)]\n",
-        "ax.append(fig.add_subplot(4, 1, (2, 4)))\n",
+        "fig = plt.figure(figsize=(6, 5))\n",
+        "ax = [fig.add_subplot(3, 1, 1)]\n",
+        "ax.append(fig.add_subplot(3, 1, (2, 4)))\n",
         "for i, phase in enumerate(phases):\n",
         "    ebar = plt.errorbar(pressures, weight_proportions[:, i],\n",
         "                        yerr=weight_proportion_uncertainties[:, i],\n",
@@ -535,7 +535,7 @@
         "ax[1].set_ylim(0., 1.)\n",
         "ax[0].set_ylabel('Residual')\n",
         "ax[1].set_xlabel('Pressure (GPa)')\n",
-        "ax[1].set_ylabel('Phase fraction (wt %)')\n",
+        "ax[1].set_ylabel('Phase fraction (wt)')\n",
         "ax[1].legend()\n",
         "fig.set_tight_layout(True)\n",
         "plt.show()"
@@ -559,11 +559,9 @@
       "name": "BurnMan_1.0_manuscript.ipynb",
       "provenance": []
     },
-    "interpreter": {
-      "hash": "d0e8ff0504fa29d441371c1f42f91c694e01f5e6e44698edccbd59f7213ffa15"
-    },
     "kernelspec": {
-      "display_name": "Python 3.9.2 64-bit ('3.9.2': pyenv)",
+      "display_name": "Python 3.10.5 ('base')",
+      "language": "python",
       "name": "python3"
     },
     "language_info": {
@@ -576,7 +574,12 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.9.2"
+      "version": "3.10.5"
+    },
+    "vscode": {
+      "interpreter": {
+        "hash": "c6e4e9f98eb68ad3b7c296f83d20e6de614cb42e90992a65aa266555a3137d0d"
+      }
     }
   },
   "nbformat": 4,


### PR DESCRIPTION
This PR slightly reformats the Martian phase proportions figure in Tutorial 4, and removes a stray percentage sign.