### PR TITLE
added new reaction calculator

### DIFF
--- a/burnman/classes/composite.py
+++ b/burnman/classes/composite.py
@@ -16,6 +16,7 @@ from . import averaging_schemes
 
 from ..utils.reductions import independent_row_indices
 from ..utils.chemistry import sum_formulae, sort_element_list_to_IUPAC_order
+from ..utils.chemistry import reaction_matrix_as_strings
 
 
 def check_pairs(phases, fractions):
@@ -578,21 +579,7 @@ class Composite(Material):
         Returns a list of string representations of all the reactions in
         reaction_basis.
         """
-        reaction_strings = []
-        for reaction in self.reaction_basis:
-            lhs, rhs = ('', '')
-            for i, coefficient in enumerate(reaction):
-                if coefficient < -1.e-10:
-                    if len(lhs) > 0:
-                        lhs += ' + '
-                    lhs += f'{-coefficient} {self.endmember_names[i]}'
-                if coefficient > 1.e-10:
-                    if len(rhs) > 0:
-                        rhs += ' + '
-                    rhs += f'{coefficient} {self.endmember_names[i]}'
-            reaction_strings.append(f'{lhs} = {rhs}')
-
-        return reaction_strings
+        return reaction_matrix_as_strings(self.reaction_basis, self.endmember_names)
 
     @cached_property
     def n_reactions(self):

--- a/burnman/utils/chemistry.py
+++ b/burnman/utils/chemistry.py
@@ -610,3 +610,40 @@ def convert_fractions(composite, phase_fractions, input_type, output_type):
         output_fractions = molar_fractions
 
     return output_fractions
+
+
+def reaction_matrix_as_strings(reaction_matrix, compound_names):
+    """
+    Returns a list of string representations of all the reactions in
+    reaction_matrix.
+
+
+    Parameters
+    ----------
+    reaction_matrix : 2D numpy array
+        Matrix of stoichiometric amounts
+        of each compound j in reaction i
+
+    compound_names : list of strings
+        List of compound names
+
+    Returns
+    -------
+    reaction_strings : list of strings
+        List of strings corresponding to each reaction
+    """
+    reaction_strings = []
+    for reaction in reaction_matrix:
+        lhs, rhs = ('', '')
+        for i, coefficient in enumerate(reaction):
+            if coefficient < -1.e-10:
+                if len(lhs) > 0:
+                    lhs += ' + '
+                lhs += f'{-coefficient} {compound_names[i]}'
+            if coefficient > 1.e-10:
+                if len(rhs) > 0:
+                    rhs += ' + '
+                rhs += f'{coefficient} {compound_names[i]}'
+        reaction_strings.append(f'{lhs} = {rhs}')
+
+    return reaction_strings

--- a/docs/changelog/20221003_bobmyhill.rst
+++ b/docs/changelog/20221003_bobmyhill.rst
@@ -1,0 +1,10 @@
+* BurnMan now has two new helper functions:
+  :func:`burnman.tools.chemistry.reactions_from_stoichiometric_matrix` 
+  :func:`burnman.tools.chemistry.reactions_from_formulae`.
+  These functions generate a complete list of reactions
+  (forward and reverse) from either the stoichiometric matrix
+  (a 2D numpy array containing the amount of component j in phase i),
+  or from a list of formulae
+  (as strings or dictionaries of elemental amounts).
+
+  *Bob Myhill, 2022/10/03*

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -6,12 +6,13 @@ import burnman
 from burnman.tools.chemistry import equilibrium_temperature
 from burnman.tools.chemistry import equilibrium_pressure
 from burnman.tools.chemistry import hugoniot
+from burnman.tools.chemistry import reactions_from_stoichiometric_matrix
+from burnman.tools.chemistry import reactions_from_formulae
 from burnman.utils.chemistry import convert_fractions
 from burnman.utils.math import bracket
 from burnman.utils.math import smooth_array
 from burnman.utils.math import interp_smoothed_array_and_derivatives
 from burnman.utils.math import _pad_ndarray_inverse_mirror
-
 
 
 class test_tools(BurnManTest):
@@ -173,6 +174,20 @@ class test_tools(BurnManTest):
         self.assertArraysAlmostEqual([f(0., 1.)[0], dfdx(0., 1.)[0], dfdy(0., 1.)[0]],
                                      [array[1][0], 1., 0.])
 
+    def test_n_reactions_from_stoichiometry(self):
+        M = np.array([[1., 0.],
+                      [0., 1.],
+                      [1., 1.],
+                      [1., 1.]])
+        R = reactions_from_stoichiometric_matrix(M)
+        self.assertTrue(len(R) == 6.)
+
+    def test_reactions_from_formulae(self):
+        formulae = ['MgO', 'FeO', 'Fe2Si2O6', 'Fe2SiO4']
+        compound_names = ['per', 'fper', 'fs', 'fa']
+        R = sorted(reactions_from_formulae(formulae, compound_names,
+                                           return_strings=True))
+        self.assertTrue(R[0] == '2 fa = 2 fper + 1 fs')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR:
- Migrates `reaction_matrix_as_strings` from a method of `Composite` into `utils.chemistry`
- Uses this function in two new helper functions in `tools.chemistry`: `reactions_from_stoichiometric_matrix` and `reactions_from_formulae`, which generate a complete list of reactions (forward and reverse) from either the stoichiometric matrix (a 2D numpy array containing the amount of component j in phase i), or from a list of formulae (as strings or dictionaries of elemental amounts).

New tests are provided.