### PR TITLE
added new modifiers

### DIFF
--- a/burnman/eos/debye.py
+++ b/burnman/eos/debye.py
@@ -168,11 +168,10 @@ def molar_heat_capacity_v(T, debye_T, n):
 @jit
 def helmholtz_free_energy(T, debye_T, n):
     """
-    Helmholtz free energy of lattice vibrations in the Debye model.
+    Helmholtz free energy of lattice vibrations in the Debye model [J].
     It is important to note that this does NOT include the zero
-    point energy of vibration for the lattice.  As long as you are
+    point energy for the lattice.  As long as you are
     calculating relative differences in F, this should cancel anyways.
-    In Joules.
     """
     if T <= eps:
         return 0.0
@@ -186,9 +185,10 @@ def helmholtz_free_energy(T, debye_T, n):
     return F
 
 
+@jit
 def entropy(T, debye_T, n):
     """
-    Entropy due to lattice vibrations in the Debye model [J/K]
+    Entropy due to lattice vibrations in the Debye model [J/K].
     """
     if T <= eps:
         return 0.0
@@ -199,3 +199,21 @@ def entropy(T, debye_T, n):
         * (4.0 * debye_fn_cheb(x) - 3.0 * np.log(1.0 - np.exp(-x)))
     )
     return S
+
+
+@jit
+def dmolar_heat_capacity_v_dT(T, debye_T, n):
+    """
+    First temperature derivative of the heat capacity at constant volume
+    [J/K^2/mol].
+    """
+    if T <= eps:
+        return 0.0
+    x = debye_T / T
+
+    C_v_over_T = molar_heat_capacity_v(T, debye_T, n) / T
+    E_over_Tsqr = thermal_energy(T, debye_T, n) / T / T
+
+    dCvdT = 3.0 * C_v_over_T + (C_v_over_T - 4.0 * E_over_Tsqr) * x / (1.0 - np.exp(-x))
+
+    return dCvdT

--- a/docs/changelog/20221023_bobmyhill.rst
+++ b/docs/changelog/20221023_bobmyhill.rst
@@ -1,0 +1,12 @@
+* Four new property modifier formulations are provided, 
+  which can be specified with the names "debye", "debye_delta", 
+  "einstein" and "einstein_delta". These 
+  are based on the Debye and Einstein models of thermal energy.
+  The heat capacity ("debye", "einstein")
+  or entropy ("debye_delta", "einstein_delta")
+  are based on the heat capacity of the respective thermal model,
+  and so reach a maximum at high temperature. The
+  excess energy, entropy and heat capacity are all zero
+  at 0 K. The excess volume is always zero.
+
+  *Bob Myhill, 2022/10/23*

--- a/tests/test_modifiers.py
+++ b/tests/test_modifiers.py
@@ -6,60 +6,65 @@ import burnman.eos.property_modifiers as pm
 from burnman.minerals import SLB_2011, HP_2011_ds62
 from burnman.tools.eos import check_eos_consistency
 
+linear_params = {"delta_E": 1200.0, "delta_S": 5.0, "delta_V": 1.0e-7}
+landau_params = {"Tc_0": 800.0, "S_D": 5.0, "V_D": 1.0e-7}
+landau_params_2 = {"Tc_0": 1200.0, "S_D": 5.0, "V_D": 1.0e-7}
+landau_hp_params = {
+    "P_0": 1.0e5,
+    "T_0": 298.15,
+    "Tc_0": 800.0,
+    "S_D": 5.0,
+    "V_D": 1.0e-7,
+}
+landau_hp_params_2 = {
+    "P_0": 1.0e5,
+    "T_0": 298.15,
+    "Tc_0": 1200.0,
+    "S_D": 5.0,
+    "V_D": 1.0e-7,
+}
+bragg_williams_params = {
+    "n": 1.0,
+    "factor": 0.8,
+    "Wh": 1000.0,
+    "Wv": 1.0e-7,
+    "deltaH": 1000.0,
+    "deltaV": 1.0e-7,
+}
+magnetic_params = {
+    "structural_parameter": 0.4,
+    "curie_temperature": [800.0, 1.0e-8],
+    "magnetic_moment": [2.2, 1.0e-10],
+}
+magnetic_params_2 = {
+    "structural_parameter": 0.4,
+    "curie_temperature": [1200.0, 1.0e-8],
+    "magnetic_moment": [2.2, 1.0e-10],
+}
+thermal_params = {"Theta_0": 1200.0, "Cv_inf": 1.0}
+thermal_delta_params = {"Theta_0": 1200.0, "S_inf": 1.0}
+
+
+fn_params = [
+    [pm._linear_excesses, "linear", linear_params],
+    [pm._landau_excesses, "landau", landau_params],
+    [pm._landau_excesses, "landau", landau_params_2],
+    [pm._landau_hp_excesses, "landau_hp", landau_hp_params],
+    [pm._landau_hp_excesses, "landau_hp", landau_hp_params_2],
+    [pm._bragg_williams_excesses, "bragg_williams", bragg_williams_params],
+    [pm._magnetic_excesses_chs, "magnetic_chs", magnetic_params],
+    [pm._magnetic_excesses_chs, "magnetic_chs", magnetic_params_2],
+    [pm._debye_excesses, "debye", thermal_params],
+    [pm._debye_delta_excesses, "debye_delta", thermal_delta_params],
+    [pm._einstein_excesses, "einstein", thermal_params],
+    [pm._einstein_delta_excesses, "einstein_delta", thermal_delta_params],
+]
+
 
 class Modifiers(BurnManTest):
     def test_excess_functions(self):
-        linear_params = {"delta_E": 1200.0, "delta_S": 5.0, "delta_V": 1.0e-7}
-        landau_params = {"Tc_0": 800.0, "S_D": 5.0, "V_D": 1.0e-7}
-        landau_params_2 = {"Tc_0": 1200.0, "S_D": 5.0, "V_D": 1.0e-7}
-        landau_hp_params = {
-            "P_0": 1.0e5,
-            "T_0": 298.15,
-            "Tc_0": 800.0,
-            "S_D": 5.0,
-            "V_D": 1.0e-7,
-        }
-        landau_hp_params_2 = {
-            "P_0": 1.0e5,
-            "T_0": 298.15,
-            "Tc_0": 1200.0,
-            "S_D": 5.0,
-            "V_D": 1.0e-7,
-        }
-        bragg_williams_params = {
-            "n": 1.0,
-            "factor": 0.8,
-            "Wh": 1000.0,
-            "Wv": 1.0e-7,
-            "deltaH": 1000.0,
-            "deltaV": 1.0e-7,
-        }
-        magnetic_params = {
-            "structural_parameter": 0.4,
-            "curie_temperature": [800.0, 1.0e-8],
-            "magnetic_moment": [2.2, 1.0e-10],
-        }
-        magnetic_params_2 = {
-            "structural_parameter": 0.4,
-            "curie_temperature": [1200.0, 1.0e-8],
-            "magnetic_moment": [2.2, 1.0e-10],
-        }
-
         P = 1.0e11
         T = 1000.0
-
-        linear_excesses = pm._linear_excesses(P, T, linear_params)
-        landau_excesses = pm._landau_excesses(P, T, landau_params)
-        landau_excesses_2 = pm._landau_excesses(P, T, landau_params_2)
-        landau_hp_excesses = pm._landau_hp_excesses(P, T, landau_hp_params)
-        landau_hp_excesses_2 = pm._landau_hp_excesses(P, T, landau_hp_params_2)
-        bragg_williams_excesses = pm._bragg_williams_excesses(
-            P, T, bragg_williams_params
-        )
-        magnetic_excesses = pm._magnetic_excesses_chs(P, T, magnetic_params)
-        magnetic_excesses_2 = pm._magnetic_excesses_chs(P, T, magnetic_params_2)
-
-        self.assertFloatEqual(linear_excesses[0]["G"], 1200.0 - 5.0 * T + 1.0e-7 * P)
 
         gibbs_excesses = [
             6200.0,
@@ -70,19 +75,14 @@ class Modifiers(BurnManTest):
             -551.3463,
             -14069.1506,
             -21582.5564,
+            -565.3150,
+            -620.7977,
+            -358.3824,
+            -517.2153,
         ]
         gibbs_excesses_output = []
-        for excesses in [
-            linear_excesses,
-            landau_excesses,
-            landau_excesses_2,
-            landau_hp_excesses,
-            landau_hp_excesses_2,
-            bragg_williams_excesses,
-            magnetic_excesses,
-            magnetic_excesses_2,
-        ]:
-
+        for (fn, name, params) in fn_params:
+            excesses = fn(P, T, params)
             gibbs_excesses_output.append(round(excesses[0]["G"], 4))
 
         self.assertArraysAlmostEqual(gibbs_excesses_output, gibbs_excesses)
@@ -104,6 +104,22 @@ class Modifiers(BurnManTest):
         assert check_eos_consistency(
             qtz, 1.0e9, 1100.0, including_shear_properties=False
         )
+
+    def test_consistency(self):
+        per = SLB_2011.periclase()
+        for (fn, name, params) in fn_params:
+            per.property_modifiers = [[name, params]]
+            # Bragg-Williams currently calculates derivatives
+            # numerically, so the modifier derivatives aren't
+            # sufficiently accurate to test here.
+            # TODO: Fix this in property_modifiers.py
+            if name != "bragg_williams":
+                assert check_eos_consistency(
+                    per, 1.0e9, 200.0, including_shear_properties=False
+                )
+                assert check_eos_consistency(
+                    per, 1.0e9, 1100.0, including_shear_properties=False
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In this PR:
- Four new property modifier formulations are provided, which can be specified with the names "debye", "debye_delta", "einstein" and "einstein_delta". These are based on the Debye and Einstein models of thermal energy. The heat capacity ("debye", "einstein") or entropy ("debye_delta", "einstein_delta") are based on the heat capacity of the respective thermal model, and so reach a maximum at high temperature. The excess energy, entropy and heat capacity are all zero at 0 K. The excess volume is always zero.
- The Einstein thermal energy at 0 K is set to zero. This has no effect on any equations of state, which all use the relative thermal energy.