### PR TITLE
used analytical derivative in anisotropic eos

### DIFF
--- a/burnman/tools/eos.py
+++ b/burnman/tools/eos.py
@@ -284,7 +284,14 @@ def check_anisotropic_eos_consistency(m, P=1.0e9, T=2000.0, tol=1.0e-4, verbose=
 
     # Consistent Phi
     expr.extend(["dPsidf_Voigt[:3,:3] == 1"])
-    eq.extend([[np.sum(m.dPsidf_Voigt[:3, :3]), 1.0]])
+    eq.extend(
+        [
+            [
+                np.sum(m.isothermal_compliance_tensor[:3, :3]),
+                m.isothermal_compressibility_reuss,
+            ]
+        ]
+    )
 
     # Consistent inverses
     expr.extend([f"S_T = inv(C_T) ({i}{j})" for i in range(6) for j in range(i, 6)])

--- a/contrib/anisotropic_eos/orthorhombic_fitting.py
+++ b/contrib/anisotropic_eos/orthorhombic_fitting.py
@@ -519,7 +519,6 @@ if do_plotting:
     betaN = np.empty_like(pressures)
     ST = np.empty((len(pressures), 6, 6))
     betaT = np.empty_like(pressures)
-    dpsidf = np.empty((len(pressures), 6, 6))
 
     f = np.empty_like(pressures)
     dXdf = np.empty_like(pressures)
@@ -536,7 +535,6 @@ if do_plotting:
             betaN[i] = 1.0 / m.isentropic_bulk_modulus_reuss
             ST[i] = m.isothermal_compliance_tensor
             betaT[i] = 1.0 / m.isothermal_bulk_modulus_reuss
-            dpsidf[i] = m.dPsidf_Voigt
             f[i] = np.log(rho0 / m.rho)
 
         # TK, PGPa, rho, rhoerr = d[:4]

--- a/contrib/anisotropic_eos/orthorhombic_fitting_second_form.py
+++ b/contrib/anisotropic_eos/orthorhombic_fitting_second_form.py
@@ -517,7 +517,6 @@ if do_plotting:
     betaN = np.empty_like(pressures)
     ST = np.empty((len(pressures), 6, 6))
     betaT = np.empty_like(pressures)
-    dpsidf = np.empty((len(pressures), 6, 6))
 
     f = np.empty_like(pressures)
     dXdf = np.empty_like(pressures)
@@ -535,7 +534,6 @@ if do_plotting:
             betaN[i] = 1.0 / m.isentropic_bulk_modulus_reuss
             ST[i] = m.isothermal_compliance_tensor
             betaT[i] = 1.0 / m.isothermal_bulk_modulus_reuss
-            dpsidf[i] = m.dPsidf_Voigt
             f[i] = np.log(rho0 / m.rho)
         # TK, PGPa, rho, rhoerr = d[:4]
         # C11, C11err = d[4:6]


### PR DESCRIPTION
This PR replaces the numerical derivative used to calculate dPthdf in the anisotropic eos with the analytical equivalent.