### PR TITLE
Improve set_state_with_volume

### DIFF
--- a/burnman/classes/material.py
+++ b/burnman/classes/material.py
@@ -209,8 +209,15 @@ class Material(object):
         """
 
         def _delta_volume(pressure, volume, temperature):
-            self.set_state(pressure, temperature)
-            return volume - self.molar_volume
+            # Try to set the state with this pressure,
+            # but if the pressure is too low most equations of state
+            # fail. In this case, treat the molar_volume as infinite
+            # and brentq will try a larger pressure.
+            try:
+                self.set_state(pressure, temperature)
+                return volume - self.molar_volume
+            except Exception:
+                return -np.inf
 
         # we need to have a sign change in [a,b] to find a zero.
         args = (volume, temperature)

--- a/burnman/classes/material.py
+++ b/burnman/classes/material.py
@@ -774,6 +774,26 @@ class Material(object):
         return self.adiabatic_compressibility
 
     @property
+    def isothermal_bulk_modulus_reuss(self):
+        """Alias for :func:`~burnman.Material.isothermal_bulk_modulus`"""
+        return self.isothermal_bulk_modulus
+
+    @property
+    def adiabatic_bulk_modulus_reuss(self):
+        """Alias for :func:`~burnman.Material.adiabatic_bulk_modulus`"""
+        return self.adiabatic_bulk_modulus
+
+    @property
+    def isothermal_compressibility_reuss(self):
+        """Alias for :func:`~burnman.Material.isothermal_compressibility`"""
+        return self.isothermal_compressibility
+
+    @property
+    def adiabatic_compressibility_reuss(self):
+        """Alias for :func:`~burnman.Material.adiabatic_compressibility`"""
+        return self.adiabatic_compressibility
+
+    @property
     def G(self):
         """Alias for :func:`~burnman.Material.shear_modulus`"""
         return self.shear_modulus


### PR DESCRIPTION
This PR adds a try/except to Material.set_state_with_volume that ensures that the root finding procedure doesn't fail just because brentq tries a pressure that is outside the range of validity of the EoS.

The tweak causes one of the existing tests to fail (because it was designed to test the failure case!). That test has now been replaced with one that would have previously failed. 