### PR TITLE
loosened gr_0 and q_0 warnings for SLB model

### DIFF
--- a/burnman/eos/slb.py
+++ b/burnman/eos/slb.py
@@ -460,9 +460,9 @@ class SLBBase(eos.EquationOfState):
             warnings.warn("Unusual value for n", stacklevel=2)
         if params["Debye_0"] < 1.0 or params["Debye_0"] > 10000.0:
             warnings.warn("Unusual value for Debye_0", stacklevel=2)
-        if params["grueneisen_0"] < -0.005 or params["grueneisen_0"] > 10.0:
+        if params["grueneisen_0"] < -1.0 or params["grueneisen_0"] > 10.0:
             warnings.warn("Unusual value for grueneisen_0", stacklevel=2)
-        if params["q_0"] < -10.0 or params["q_0"] > 10.0:
+        if params["q_0"] < -20.0 or params["q_0"] > 20.0:
             warnings.warn("Unusual value for q_0", stacklevel=2)
         if params["eta_s_0"] < -10.0 or params["eta_s_0"] > 10.0:
             warnings.warn("Unusual value for eta_s_0", stacklevel=2)


### PR DESCRIPTION
This PR relaxes the SLB EoS warnings for the Grueneisen parameter and associated power law exponent. Turns out some minerals are weird.