### PR TITLE
add .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,27 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+  jobs:
+    pre_build:
+      - python -m pip install -r docs/pip_requirements.txt
+      - python -m pip install .
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Enable reproducible builds, see
+# https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+  - requirements: docs/pip_requirements.txt
+  - method: pip
+    path: .

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,6 @@ sys.path.insert(0, os.path.abspath("../examples"))
 sys.path.insert(0, os.path.abspath("../tutorial"))
 
 import burnman
-import burnman.version
 import datetime
 
 today = datetime.date.today()
@@ -34,7 +33,8 @@ copyright = (
 author = "Robert Myhill, Sanne Cottaar, Timo Heister, Ian Rose, Cayman Unterborn"
 
 # The short X.Y version.
-version = burnman.version.short_version
+v = burnman.__version__.split('.')
+version = f'{v[0]}.{v[1]}'
 # The full version, including alpha/beta/rc tags
 release = burnman.__version__
 
@@ -106,7 +106,7 @@ pygments_style = "sphinx"
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "default"
+html_theme = "furo"
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = "BurnMandoc"
@@ -229,6 +229,7 @@ Robert Myhill\\Sanne Cottaar\\Timo Heister\\Ian Rose\\Cayman Unterborn\\
 language = "en"
 
 latex_logo = "burnjack-small.png"
+html_logo = "burnjack-small.png"
 
 latex_elements = {
     "sphinxsetup": "",

--- a/docs/materials.rst
+++ b/docs/materials.rst
@@ -7,18 +7,6 @@ most prominently in the form of minerals
 (:class:`~burnman.Mineral`) and composites (:class:`~burnman.Composite`).
 
 
-.. inheritance-diagram::
-  burnman.Material
-  burnman.Mineral
-  burnman.PerplexMaterial
-  burnman.Solution
-  burnman.ElasticSolution
-  burnman.Composite
-  burnman.CombinedMineral
-  burnman.AnisotropicMaterial
-  burnman.AnisotropicMineral
-
-
 Material Base Class
 -------------------
 

--- a/docs/pip_requirements.txt
+++ b/docs/pip_requirements.txt
@@ -3,6 +3,7 @@ numpydoc
 matplotlib
 scipy
 sympy
+furo
 sphinxcontrib.bibtex
 nbsphinx
 cvxpy


### PR DESCRIPTION
ReadTheDocs integration will soon only work with a yaml file. 
This PR adds the required file, and makes a couple of other changes required to continue using sphinx / ReST.