### PR TITLE
Non orthotropic anisotropy

### DIFF
--- a/burnman/classes/averaging_schemes.py
+++ b/burnman/classes/averaging_schemes.py
@@ -9,7 +9,6 @@ import warnings
 
 
 class AveragingScheme(object):
-
     """
     Base class defining an interface for determining average
     elastic properties of a rock.  Given a list of volume
@@ -144,7 +143,6 @@ class AveragingScheme(object):
 
 
 class VoigtReussHill(AveragingScheme):
-
     """
     Class for computing the Voigt-Reuss-Hill average for elastic properties.
     This derives from :class:`burnman.averaging_schemes.averaging_scheme`,
@@ -218,7 +216,6 @@ class VoigtReussHill(AveragingScheme):
 
 
 class Voigt(AveragingScheme):
-
     """
     Class for computing the Voigt (iso-strain) bound for elastic properties.
     This derives from :class:`burnman.averaging_schemes.averaging_scheme`,
@@ -277,7 +274,6 @@ class Voigt(AveragingScheme):
 
 
 class Reuss(AveragingScheme):
-
     """
     Class for computing the Reuss (iso-stress) bound for elastic properties.
     This derives from :class:`burnman.averaging_schemes.averaging_scheme`,
@@ -336,7 +332,6 @@ class Reuss(AveragingScheme):
 
 
 class HashinShtrikmanUpper(AveragingScheme):
-
     """
     Class for computing the upper Hashin-Shtrikman bound for elastic properties.
     This derives from :class:`burnman.averaging_schemes.averaging_scheme`,
@@ -423,7 +418,6 @@ class HashinShtrikmanUpper(AveragingScheme):
 
 
 class HashinShtrikmanLower(AveragingScheme):
-
     """
     Class for computing the lower Hashin-Shtrikman bound for elastic properties.
     This derives from :class:`burnman.averaging_schemes.averaging_scheme`,
@@ -510,7 +504,6 @@ class HashinShtrikmanLower(AveragingScheme):
 
 
 class HashinShtrikmanAverage(AveragingScheme):
-
     """
     Class for computing arithmetic mean of the Hashin-Shtrikman bounds on
     elastic properties.

--- a/burnman/classes/combinedmineral.py
+++ b/burnman/classes/combinedmineral.py
@@ -14,7 +14,6 @@ from .solutionmodel import MechanicalSolution
 
 
 class CombinedMineral(Mineral):
-
     """
     This is the base class for endmembers constructed from a
     linear combination of other minerals.

--- a/burnman/classes/composite.py
+++ b/burnman/classes/composite.py
@@ -38,7 +38,6 @@ def check_pairs(phases, fractions):
 
 # static composite of minerals/composites
 class Composite(Material):
-
     """
     Base class for a composite material.
     The static phases can be minerals or materials,

--- a/burnman/classes/elasticsolutionmodel.py
+++ b/burnman/classes/elasticsolutionmodel.py
@@ -26,7 +26,6 @@ except ImportError as err:
 
 
 class ElasticSolutionModel(object):
-
     """
     This is the base class for an Elastic solution model, intended for use
     in defining solutions and performing thermodynamic calculations
@@ -216,7 +215,6 @@ class ElasticSolutionModel(object):
 
 
 class ElasticMechanicalSolution(ElasticSolutionModel):
-
     """
     An extremely simple class representing a mechanical solution model.
     A mechanical solution experiences no interaction between endmembers.
@@ -251,7 +249,6 @@ class ElasticMechanicalSolution(ElasticSolutionModel):
 
 
 class ElasticIdealSolution(ElasticSolutionModel):
-
     """
     A class representing an ideal solution model.
     Calculates the excess Helmholtz energy and entropy due to configurational
@@ -382,7 +379,6 @@ class ElasticIdealSolution(ElasticSolutionModel):
 
 
 class ElasticAsymmetricRegularSolution(ElasticIdealSolution):
-
     """
     Solution model implementing the asymmetric regular solution model
     formulation as described in :cite:`HP2003`.
@@ -510,7 +506,6 @@ class ElasticAsymmetricRegularSolution(ElasticIdealSolution):
 
 
 class ElasticSymmetricRegularSolution(ElasticAsymmetricRegularSolution):
-
     """
     Solution model implementing the symmetric regular solution model.
     This is a special case of the
@@ -536,7 +531,6 @@ class ElasticSymmetricRegularSolution(ElasticAsymmetricRegularSolution):
 
 
 class ElasticSubregularSolution(ElasticIdealSolution):
-
     """
     Solution model implementing the subregular solution model formulation
     as described in :cite:`HW1989`. The excess conconfigurational

--- a/burnman/classes/material.py
+++ b/burnman/classes/material.py
@@ -14,7 +14,6 @@ from scipy.optimize import brentq
 # TODO: When we require Python 3.8+, replace with
 # functools.cached_property decorator
 class cached_property(property):
-
     """A decorator that converts a function into a lazy property.  The
     function wrapped is called the first time to retrieve the result
     and then that calculated result is used the next time you access
@@ -87,7 +86,6 @@ def material_property(func):
 
 
 class Material(object):
-
     """
     Base class for all materials. The main functionality is unroll() which
     returns a list of objects of type :class:`~burnman.Mineral` and their molar

--- a/burnman/classes/mineral.py
+++ b/burnman/classes/mineral.py
@@ -15,7 +15,6 @@ from ..utils.misc import copy_documentation
 
 
 class Mineral(Material):
-
     """
     This is the base class for all minerals. States of the mineral
     can only be queried after setting the pressure and temperature

--- a/burnman/classes/mineral_helpers.py
+++ b/burnman/classes/mineral_helpers.py
@@ -168,7 +168,6 @@ class HelperLowHighPressureRockTransition(HelperRockSwitcher):
 
 
 class HelperSpinTransition(Composite):
-
     """
     Helper class that makes a mineral that switches between two materials
     (for low and high spin) based on some transition pressure [Pa]

--- a/burnman/classes/solutionmodel.py
+++ b/burnman/classes/solutionmodel.py
@@ -128,7 +128,6 @@ def inverseish(x, eps=1.0e-5):
 
 
 class SolutionModel(object):
-
     """
     This is the base class for a solution model,  intended for use
     in defining solutions and performing thermodynamic calculations
@@ -326,7 +325,6 @@ class SolutionModel(object):
 
 
 class MechanicalSolution(SolutionModel):
-
     """
     An extremely simple class representing a mechanical solution model.
     A mechanical solution experiences no interaction between endmembers.
@@ -372,7 +370,6 @@ class MechanicalSolution(SolutionModel):
 
 
 class IdealSolution(SolutionModel):
-
     """
     A class representing an ideal solution model.
     Calculates the excess gibbs free energy and entropy due to configurational
@@ -511,7 +508,6 @@ class IdealSolution(SolutionModel):
 
 
 class AsymmetricRegularSolution(IdealSolution):
-
     """
     Solution model implementing the asymmetric regular solution model
     formulation as described in :cite:`HP2003`.
@@ -657,7 +653,6 @@ class AsymmetricRegularSolution(IdealSolution):
 
 
 class SymmetricRegularSolution(AsymmetricRegularSolution):
-
     """
     Solution model implementing the symmetric regular solution model.
     This is a special case of the
@@ -683,7 +678,6 @@ class SymmetricRegularSolution(AsymmetricRegularSolution):
 
 
 class SubregularSolution(IdealSolution):
-
     """
     Solution model implementing the subregular solution model formulation
     as described in :cite:`HW1989`. The excess nonconfigurational

--- a/burnman/eos/birch_murnaghan.py
+++ b/burnman/eos/birch_murnaghan.py
@@ -114,7 +114,6 @@ def shear_modulus_third_order(volume, params):
 
 
 class BirchMurnaghanBase(eos.EquationOfState):
-
     """
     Base class for the isothermal Birch Murnaghan equation of state.  This is third order in strain, and
     has no temperature dependence.  However, the shear modulus is sometimes fit to a second order
@@ -258,7 +257,6 @@ class BirchMurnaghanBase(eos.EquationOfState):
 
 
 class BM3(BirchMurnaghanBase):
-
     """
     Third order Birch Murnaghan isothermal equation of state.
     This uses the third order expansion for shear modulus.
@@ -269,7 +267,6 @@ class BM3(BirchMurnaghanBase):
 
 
 class BM2(BirchMurnaghanBase):
-
     """
     Third order Birch Murnaghan isothermal equation of state.
     This uses the second order expansion for shear modulus.

--- a/burnman/eos/birch_murnaghan_4th.py
+++ b/burnman/eos/birch_murnaghan_4th.py
@@ -81,7 +81,6 @@ def birch_murnaghan_fourth(x, params):
 
 
 class BM4(eos.EquationOfState):
-
     """
     Base class for the isothermal Birch Murnaghan equation of state.  This is fourth order in strain, and
     has no temperature dependence.

--- a/burnman/eos/cork.py
+++ b/burnman/eos/cork.py
@@ -34,7 +34,6 @@ def cork_variables(cork, cork_P, cork_T, temperature):
 
 
 class CORK(eos.EquationOfState):
-
     """
     Class for the CoRK equation of state detailed in :cite:`HP1991`. The
     CoRK EoS is a simple virial-type extension to the modified Redlich-Kwong

--- a/burnman/eos/dks_solid.py
+++ b/burnman/eos/dks_solid.py
@@ -61,7 +61,6 @@ def _delta_pressure(
 
 
 class DKS_S(eos.EquationOfState):
-
     """
     Base class for the finite strain solid equation of state detailed
     in :cite:`deKoker2013` (supplementary materials).

--- a/burnman/eos/equation_of_state.py
+++ b/burnman/eos/equation_of_state.py
@@ -5,7 +5,6 @@
 
 
 class EquationOfState(object):
-
     """
     This class defines the interface for an equation of state
     that a mineral uses to determine its properties at a

--- a/burnman/eos/hp.py
+++ b/burnman/eos/hp.py
@@ -17,7 +17,6 @@ from . import einstein
 
 
 class HP_TMT(eos.EquationOfState):
-
     """
     Base class for the thermal equation of state based on
     the generic modified Tait equation of state (class MT),
@@ -395,7 +394,6 @@ class HP_TMT(eos.EquationOfState):
 
 
 class HP_TMTL(eos.EquationOfState):
-
     """
     Base class for the thermal equation of state
     described in :cite:`HP1998`, but with the Modified Tait as the static part,
@@ -668,7 +666,6 @@ class HP_TMTL(eos.EquationOfState):
 
 
 class HP98(eos.EquationOfState):
-
     """
     Base class for the thermal equation of state
     described in :cite:`HP1998`.

--- a/burnman/eos/mie_grueneisen_debye.py
+++ b/burnman/eos/mie_grueneisen_debye.py
@@ -16,7 +16,6 @@ from ..utils.math import bracket
 
 
 class MGDBase(eos.EquationOfState):
-
     """
     Base class for a generic finite-strain Mie-Grueneisen-Debye
     equation of state.  References for this can be found in many
@@ -304,7 +303,6 @@ class MGDBase(eos.EquationOfState):
 
 
 class MGD3(MGDBase):
-
     """
     MGD equation of state with third order finite strain expansion for the
     shear modulus (this should be preferred, as it is more thermodynamically
@@ -316,7 +314,6 @@ class MGD3(MGDBase):
 
 
 class MGD2(MGDBase):
-
     """
     MGD equation of state with second order finite strain expansion for the
     shear modulus.  In general, this should not be used, but sometimes

--- a/burnman/eos/modified_tait.py
+++ b/burnman/eos/modified_tait.py
@@ -92,7 +92,6 @@ def intVdP(pressure, params):
 
 
 class MT(eos.EquationOfState):
-
     """
     Base class for the generic modified Tait equation of state.
     References for this can be found in :cite:`HC1974`

--- a/burnman/eos/morse_potential.py
+++ b/burnman/eos/morse_potential.py
@@ -75,7 +75,6 @@ def volume(pressure, params):
 
 
 class Morse(eos.EquationOfState):
-
     """
     Class for the isothermal Morse Potential equation of state
     detailed in :cite:`Stacey1981`.

--- a/burnman/eos/murnaghan.py
+++ b/burnman/eos/murnaghan.py
@@ -39,7 +39,6 @@ def intVdP(pressure, V_0, K_0, Kprime_0):
 
 
 class Murnaghan(eos.EquationOfState):
-
     """
     Base class for the isothermal Murnaghan equation of state,
     as described in :cite:`Murnaghan1944`.

--- a/burnman/eos/reciprocal_kprime.py
+++ b/burnman/eos/reciprocal_kprime.py
@@ -124,7 +124,6 @@ def shear_modulus(pressure, params):
 
 
 class RKprime(eos.EquationOfState):
-
     """
     Class for the isothermal reciprocal K-prime equation of state
     detailed in :cite:`StaceyDavis2004`.  This equation of state is

--- a/burnman/eos/slb.py
+++ b/burnman/eos/slb.py
@@ -63,7 +63,6 @@ def _delta_pressure(
 
 
 class SLBBase(eos.EquationOfState):
-
     """
     Base class for the finite strain-Mie-Grueneiesen-Debye equation of state
     detailed in :cite:`Stixrude2005`.  For the most part the equations are
@@ -468,7 +467,6 @@ class SLBBase(eos.EquationOfState):
 
 
 class SLB3(SLBBase):
-
     """
     SLB equation of state with third order finite strain expansion for the
     shear modulus (this should be preferred, as it is more thermodynamically
@@ -480,7 +478,6 @@ class SLB3(SLBBase):
 
 
 class SLB2(SLBBase):
-
     """
     SLB equation of state with second order finite strain expansion for the
     shear modulus.  In general, this should not be used, but sometimes

--- a/burnman/eos/vinet.py
+++ b/burnman/eos/vinet.py
@@ -56,7 +56,6 @@ def volume(pressure, params):
 
 
 class Vinet(eos.EquationOfState):
-
     """
     Base class for the isothermal Vinet equation of state.
     References for this equation of state are :cite:`vinet1986`

--- a/burnman/minerals/Murakami_2013.py
+++ b/burnman/minerals/Murakami_2013.py
@@ -36,7 +36,6 @@ class periclase(Mineral):
 
 
 class wuestite(Mineral):
-
     """
     Murakami 2013 and references therein
     """

--- a/burnman/minerals/other.py
+++ b/burnman/minerals/other.py
@@ -130,7 +130,6 @@ class Speziale_fe_periclase(helpers.HelperSpinTransition):
 
 
 class Speziale_fe_periclase_HS(Mineral):
-
     """
     Speziale et al. 2007, Mg#=83
     """
@@ -151,7 +150,6 @@ class Speziale_fe_periclase_HS(Mineral):
 
 
 class Speziale_fe_periclase_LS(Mineral):
-
     """
     Speziale et al. 2007, Mg#=83
     """
@@ -172,7 +170,6 @@ class Speziale_fe_periclase_LS(Mineral):
 
 
 class Liquid_Fe_Anderson(Mineral):
-
     """
     Anderson & Ahrens, 1994 JGR
     """
@@ -190,7 +187,6 @@ class Liquid_Fe_Anderson(Mineral):
 
 
 class Fe_Dewaele(Mineral):
-
     """
     Dewaele et al., 2006, Physical Review Letters
     """

--- a/burnman/tools/equilibration.py
+++ b/burnman/tools/equilibration.py
@@ -644,9 +644,11 @@ def get_equilibration_parameters(assemblage, composition, free_compositional_vec
         prm.free_compositional_vectors = np.array(
             [
                 [
-                    free_compositional_vectors[i][e]
-                    if e in free_compositional_vectors[i]
-                    else 0.0
+                    (
+                        free_compositional_vectors[i][e]
+                        if e in free_compositional_vectors[i]
+                        else 0.0
+                    )
                     for e in assemblage.elements
                 ]
                 for i in range(n_free_compositional_vectors)

--- a/contrib/CHRU2014/helper_solid_solution.py
+++ b/contrib/CHRU2014/helper_solid_solution.py
@@ -12,7 +12,6 @@ import burnman.minerals as minerals
 
 
 class HelperSolidSolution(burnman.Mineral):
-
     """
     This material is deprecated!
 

--- a/contrib/CHRU2014/paper_uncertain.py
+++ b/contrib/CHRU2014/paper_uncertain.py
@@ -28,7 +28,6 @@ import contrib.CHRU2014.colors as colors
 
 
 class my_perovskite(burnman.Mineral):
-
     """
     based on Stixrude & Lithgow-Bertelloni 2011 and references therein
     """

--- a/contrib/anisotropic_eos/tools.py
+++ b/contrib/anisotropic_eos/tools.py
@@ -42,9 +42,11 @@ def print_table_for_mineral_constants_2(mineral, param_list, indices):
         row = [f"{i}", f"{j}"]
         row.extend(
             [
-                f"{constants[ci, i]:.4e}"
-                if constants[ci, i] != 0 and constants[ci, i] != 1
-                else "-"
+                (
+                    f"{constants[ci, i]:.4e}"
+                    if constants[ci, i] != 0 and constants[ci, i] != 1
+                    else "-"
+                )
                 for i in range(len(param_list))
             ]
         )

--- a/examples/example_user_input_material.py
+++ b/examples/example_user_input_material.py
@@ -81,7 +81,7 @@ if __name__ == "__main__":
                 # See Stixrude & Lithgow-Bertelloni, 2005 for values
                 "q_0": 0.917,  # isotropic strain derivative of gruneisen
                 # parameter. Values in Stixrude & Lithgow-Bertelloni, 2005
-                "eta_s_0": 3.0  # full strain derivative of gruneisen parameter
+                "eta_s_0": 3.0,  # full strain derivative of gruneisen parameter
                 # parameter. Values in Stixrude & Lithgow-Bertelloni, 2005
             }
             burnman.Mineral.__init__(self)

--- a/misc/gen_doc.py
+++ b/misc/gen_doc.py
@@ -1,4 +1,5 @@
 """ generates a list with the examples """
+
 from __future__ import absolute_import
 from __future__ import print_function
 

--- a/test.sh
+++ b/test.sh
@@ -76,6 +76,7 @@ else
   sed -i.bak -e '/UserWarning: findfont: Font family/d' $t.tmp #remove font warning crap
   sed -i.bak -e '/tight_layout : falling back to Agg renderer/d' $t.tmp #remove font warning crap
   sed -i.bak -e '/cannot be converted with the encoding. Glyph may be wrong/d' $t.tmp #remove font warning crap
+  sed -i.bak -e '/UserWarning: FigureCanvasTemplate/d' $t.tmp #remove plotting nonsense
   sed -i.bak -e '/time old .* time new/d' $t.tmp #remove timing from tests/debye.py
   sed -i.bak -e '/  relative central core pressure error.*/d' $t.tmp #remove residuals from examples/example_build_planet
 

--- a/tests/test_anisotropicmineral.py
+++ b/tests/test_anisotropicmineral.py
@@ -8,28 +8,44 @@ from burnman.tools.eos import check_anisotropic_eos_consistency
 from burnman.minerals.SLB_2011 import periclase, forsterite
 
 
-def make_simple_forsterite():
+def make_forsterite(orthotropic=True):
     fo = forsterite()
     cell_lengths = np.array([4.7646, 10.2296, 5.9942])
     cell_lengths *= np.cbrt(fo.params["V_0"] / np.prod(cell_lengths))
-    cell_lengths *= 1.0710965273664157
+
+    if orthotropic:
+        alpha, beta, gamma, a, b, c = [90.0, 90.0, 90.0, 0.0, 0.0, 0.0]
+    else:
+        alpha, beta, gamma, a, b, c = [85.0, 80.0, 87.0, 0.4, -1.0, -0.6]
+        cell_lengths *= 1.006635538793111
+
     cell_parameters = np.array(
-        [cell_lengths[0], cell_lengths[1], cell_lengths[2], 60, 70, 80]
+        [cell_lengths[0], cell_lengths[1], cell_lengths[2], alpha, beta, gamma]
     )
 
-    constants = np.zeros((6, 6, 2, 1))
+    constants = np.zeros((6, 6, 3, 1))
     constants[:, :, 1, 0] = np.array(
         [
-            [0.44, -0.12, -0.1, 1.0, 0.5, 0.5],
+            [0.44, -0.12, -0.1, a, b, c],
             [-0.12, 0.78, -0.22, 0.0, 0.0, 0.0],
             [-0.1, -0.22, 0.66, 0.0, 0.0, 0.0],
-            [1.0, 0.0, 0.0, 1.97, 0.0, 0.0],
-            [0.5, 0.0, 0.0, 0.0, 1.61, 0.0],
-            [0.5, 0.0, 0.0, 0.0, 0.0, 1.55],
+            [a, 0.0, 0.0, 1.97, 0.0, 0.0],
+            [b, 0.0, 0.0, 0.0, 1.61, 0.0],
+            [c, 0.0, 0.0, 0.0, 0.0, 1.55],
+        ]
+    )
+    constants[:, :, 2, 0] = np.array(
+        [
+            [0.24, -0.12, -0.1, 0.0, 0.0, 0.0],
+            [-0.12, 0.38, -0.22, a, a, a],
+            [-0.1, -0.22, 0.26, c, b, a],
+            [0.0, a, c, 0.0, 0.0, 0.0],
+            [0.0, a, b, 0.0, 0.0, 0.0],
+            [0.0, a, a, 0.0, 0.0, 0.0],
         ]
     )
 
-    m = AnisotropicMineral(fo, cell_parameters, constants, orthotropic=True)
+    m = AnisotropicMineral(fo, cell_parameters, constants)
     return m
 
 
@@ -61,25 +77,30 @@ class test_anisotropic_mineral(BurnManTest):
         gr = per.grueneisen_parameter
         self.assertArraysAlmostEqual(np.diag(per2.grueneisen_tensor), [gr, gr, gr])
 
-    def test_orthorhombic_consistency(self):
-        m = make_simple_forsterite()
-        self.assertTrue(check_anisotropic_eos_consistency(m, verbose=True))
+    def test_orthotropic_consistency(self):
+        m = make_forsterite(orthotropic=True)
+        self.assertTrue(check_anisotropic_eos_consistency(m))
+
+    def test_non_orthotropic_consistency(self):
+        m = make_forsterite(orthotropic=False)
+        self.assertTrue(check_anisotropic_eos_consistency(m, P=2.0e10, tol=1.0e-6))
 
     def test_stiffness(self):
-        m = make_simple_forsterite()
-        m.set_state(1.0e9, 300.0)
-        Cijkl = m.full_isothermal_stiffness_tensor
-        Cij = m.isothermal_stiffness_tensor
+        for orthotropic in [True, False]:
+            m = make_forsterite(orthotropic)
+            m.set_state(1.0e9, 300.0)
+            Cijkl = m.full_isothermal_stiffness_tensor
+            Cij = m.isothermal_stiffness_tensor
 
-        self.assertFloatEqual(Cij[0, 0], Cijkl[0, 0, 0, 0])
-        self.assertFloatEqual(Cij[1, 1], Cijkl[1, 1, 1, 1])
-        self.assertFloatEqual(Cij[2, 2], Cijkl[2, 2, 2, 2])
-        self.assertFloatEqual(Cij[0, 1], Cijkl[0, 0, 1, 1])
-        self.assertFloatEqual(Cij[0, 2], Cijkl[0, 0, 2, 2])
-        self.assertFloatEqual(Cij[1, 2], Cijkl[1, 1, 2, 2])
-        self.assertFloatEqual(Cij[3, 3], Cijkl[1, 2, 1, 2])
-        self.assertFloatEqual(Cij[4, 4], Cijkl[0, 2, 0, 2])
-        self.assertFloatEqual(Cij[5, 5], Cijkl[0, 1, 0, 1])
+            self.assertFloatEqual(Cij[0, 0], Cijkl[0, 0, 0, 0])
+            self.assertFloatEqual(Cij[1, 1], Cijkl[1, 1, 1, 1])
+            self.assertFloatEqual(Cij[2, 2], Cijkl[2, 2, 2, 2])
+            self.assertFloatEqual(Cij[0, 1], Cijkl[0, 0, 1, 1])
+            self.assertFloatEqual(Cij[0, 2], Cijkl[0, 0, 2, 2])
+            self.assertFloatEqual(Cij[1, 2], Cijkl[1, 1, 2, 2])
+            self.assertFloatEqual(Cij[3, 3], Cijkl[1, 2, 1, 2])
+            self.assertFloatEqual(Cij[4, 4], Cijkl[0, 2, 0, 2])
+            self.assertFloatEqual(Cij[5, 5], Cijkl[0, 1, 0, 1])
 
 
 if __name__ == "__main__":

--- a/tests/test_anisotropicmineral.py
+++ b/tests/test_anisotropicmineral.py
@@ -29,7 +29,7 @@ def make_simple_forsterite():
         ]
     )
 
-    m = AnisotropicMineral(fo, cell_parameters, constants)
+    m = AnisotropicMineral(fo, cell_parameters, constants, orthotropic=True)
     return m
 
 
@@ -63,7 +63,7 @@ class test_anisotropic_mineral(BurnManTest):
 
     def test_orthorhombic_consistency(self):
         m = make_simple_forsterite()
-        self.assertTrue(check_anisotropic_eos_consistency(m))
+        self.assertTrue(check_anisotropic_eos_consistency(m, verbose=True))
 
     def test_stiffness(self):
         m = make_simple_forsterite()

--- a/tests/test_averaging.py
+++ b/tests/test_averaging.py
@@ -9,7 +9,6 @@ import burnman.classes.averaging_schemes as avg
 
 
 class mypericlase(burnman.Mineral):
-
     """
     Stixrude & Lithgow-Bertelloni 2005 and references therein
     """

--- a/tests/test_debye.py
+++ b/tests/test_debye.py
@@ -6,7 +6,6 @@ import burnman
 
 
 class mypericlase(burnman.Mineral):
-
     """
     Stixrude & Lithgow-Bertelloni 2005 and references therein
     """

--- a/tests/test_eos.py
+++ b/tests/test_eos.py
@@ -11,7 +11,6 @@ from burnman.utils.chemistry import dictionarize_formula, formula_mass
 
 
 class mypericlase(burnman.Mineral):
-
     """
     Stixrude & Lithgow-Bertelloni 2005 and references therein
     """
@@ -36,7 +35,6 @@ class mypericlase(burnman.Mineral):
 
 
 class Fe_Dewaele(burnman.Mineral):
-
     """
     Dewaele et al., 2006, Physical Review Letters
     """
@@ -54,7 +52,6 @@ class Fe_Dewaele(burnman.Mineral):
 
 
 class Liquid_Fe_Anderson(burnman.Mineral):
-
     """
     Anderson & Ahrens, 1994 JGR
     """
@@ -72,7 +69,6 @@ class Liquid_Fe_Anderson(burnman.Mineral):
 
 
 class outer_core_rkprime(burnman.Mineral):
-
     """
     Stacey and Davis, 2004 PEPI (Table 5)
     """
@@ -90,7 +86,6 @@ class outer_core_rkprime(burnman.Mineral):
 
 
 class periclase_morse(burnman.Mineral):
-
     """
     Periclase parameters from SLB dataset (which uses BM3)
     """

--- a/tests/test_geotherm.py
+++ b/tests/test_geotherm.py
@@ -6,7 +6,6 @@ import burnman
 
 
 class mypericlase(burnman.Mineral):
-
     """
     Stixrude & Lithgow-Bertelloni 2005 and references therein
     """

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -7,11 +7,9 @@ import burnman
 
 
 class test_material_name(BurnManTest):
-
     """test Material.name and that we can edit and override it in Mineral"""
 
     class min_no_name(burnman.Mineral):
-
         """
         Stixrude & Lithgow-Bertelloni 2005 and references therein
         """
@@ -36,7 +34,6 @@ class test_material_name(BurnManTest):
             burnman.Mineral.__init__(self)
 
     class min_with_name(burnman.Mineral):
-
         """
         Stixrude & Lithgow-Bertelloni 2005 and references therein
         """
@@ -62,7 +59,6 @@ class test_material_name(BurnManTest):
             burnman.Mineral.__init__(self)
 
     class min_with_name_manually(burnman.Mineral):
-
         """
         Stixrude & Lithgow-Bertelloni 2005 and references therein
         """


### PR DESCRIPTION
This PR modifies the functions in `AnisotropicMineral` for non-orthotropic materials. Specifically, in non-orthotropic materials, changes in the eigenvectors of deformation mean that the second order compressibility tensor $\boldsymbol{\beta}_T \neq \partial \ln(\boldsymbol{F}) / \partial P|T$, and instead $\boldsymbol{\beta}_T = 0.5( \boldsymbol{L}_P + \boldsymbol{L}^T_P)$, where $\boldsymbol{L}_P = (\partial \boldsymbol{F} / \partial P|T) \boldsymbol{F}^{-1}$.

This has a negligible effect on even non-orthotropic equations of state, but for the avoidance of confusion the correct expressions are implemented here.