### PR TITLE
add internal equilibrate routine to check_eos_consistency functions

### DIFF
--- a/burnman/classes/material.py
+++ b/burnman/classes/material.py
@@ -691,6 +691,11 @@ class Material(object):
         return self.adiabatic_bulk_modulus
 
     @property
+    def isentropic_bulk_modulus_reuss(self):
+        """Alias for :func:`~burnman.Material.adiabatic_bulk_modulus_reuss`"""
+        return self.adiabatic_bulk_modulus_reuss
+
+    @property
     def isothermal_compressibility_reuss(self):
         """Alias for :func:`~burnman.Material.isothermal_compressibility`"""
         return self.isothermal_compressibility
@@ -699,6 +704,11 @@ class Material(object):
     def adiabatic_compressibility_reuss(self):
         """Alias for :func:`~burnman.Material.adiabatic_compressibility`"""
         return self.adiabatic_compressibility
+
+    @property
+    def isentropic_compressibility_reuss(self):
+        """Alias for :func:`~burnman.Material.adiabatic_compressibility_reuss`"""
+        return self.adiabatic_compressibility_reuss
 
     @property
     def G(self):

--- a/burnman/classes/mineral.py
+++ b/burnman/classes/mineral.py
@@ -329,14 +329,14 @@ class Mineral(Material):
     @copy_documentation(Material.p_wave_velocity)
     def p_wave_velocity(self):
         return np.sqrt(
-            (self.adiabatic_bulk_modulus + 4.0 / 3.0 * self.shear_modulus)
+            (self.adiabatic_bulk_modulus_reuss + 4.0 / 3.0 * self.shear_modulus)
             / self.density
         )
 
     @material_property
     @copy_documentation(Material.bulk_sound_velocity)
     def bulk_sound_velocity(self):
-        return np.sqrt(self.adiabatic_bulk_modulus / self.density)
+        return np.sqrt(self.adiabatic_bulk_modulus_reuss / self.density)
 
     @material_property
     @copy_documentation(Material.shear_wave_velocity)

--- a/burnman/classes/solution.py
+++ b/burnman/classes/solution.py
@@ -452,6 +452,8 @@ class Solution(Mineral):
             )
         )
 
+    isothermal_bulk_modulus_reuss = isothermal_bulk_modulus
+
     @material_property
     def adiabatic_bulk_modulus(self):
         """
@@ -466,6 +468,8 @@ class Solution(Mineral):
                 * self.molar_heat_capacity_p
                 / self.molar_heat_capacity_v
             )
+
+    adiabatic_bulk_modulus_reuss = adiabatic_bulk_modulus
 
     @material_property
     def isothermal_compressibility(self):

--- a/burnman/classes/solutionmodel.py
+++ b/burnman/classes/solutionmodel.py
@@ -1160,12 +1160,12 @@ class PolynomialSolution(IdealSolution):
             if not all(W[i] <= W[i + 1] for i in range(n_int, len(W) - 1)):
                 raise Exception(
                     f"Interaction parameter {i+1}/{n_Ws} must be "
-                    "upper triangular (i<=j<=k<=...<=z)"
+                    f"upper triangular (i<=j<=k<=...<=z)\n(value = {W})"
                 )
             if not W[n_int] < W[-1]:
                 raise Exception(
                     f"Interaction parameter {i+1}/{n_Ws} must not lie on the "
-                    "first diagonal (i=j=k=...=z)"
+                    f"first diagonal (i=j=k=...=z)\n(value = {W})"
                 )
 
         W_arrays = []


### PR DESCRIPTION
This PR adds an `equilibration_function` argument to the check_eos_consistency functions. This is so that equation of state consistency can be checked for solution model instances where there are explicit isochemical degrees of freedom (such as for order-disorder processes) that allow for relaxation of second-derivatives of the thermodynamic potentials (e.g. alphas, betas, heat capacities).

Implementation of these dynamic equations of state is coming in a future PR.