### PR TITLE
assert Phi=0 at standard state

### DIFF
--- a/burnman/classes/anisotropicmineral.py
+++ b/burnman/classes/anisotropicmineral.py
@@ -204,6 +204,14 @@ class AnisotropicMineral(Mineral, AnisotropicMaterial):
             self.anisotropic_params = anisotropic_parameters
             self.psi_function = psi_function
 
+        Psi_Voigt0 = self.psi_function(0.0, 0.0, self.anisotropic_params)[0]
+        if not np.all(Psi_Voigt0 == 0.0):
+            raise ValueError(
+                "All elements of Psi should evaluate to zero at "
+                "standard state. The current array evaluates to: "
+                f"{Psi_Voigt0}"
+            )
+
         # cell_vectors is the transpose of the cell tensor M
         self.cell_vectors_0 = cell_parameters_to_vectors(cell_parameters)
 

--- a/burnman/tools/plot.py
+++ b/burnman/tools/plot.py
@@ -124,7 +124,7 @@ def plot_projected_elastic_properties(
         ticks.append(np.linspace(tmin, tmax, nt))
         contour_sets.append(
             axes[i].contourf(
-                theta, r, values, n_divs, cmap="rainbow", vmin=vmin, vmax=vmax
+                theta, r, values, n_divs, cmap=plt.cm.jet_r, vmin=vmin, vmax=vmax
             )
         )
         lines.append(

--- a/burnman/tools/plot.py
+++ b/burnman/tools/plot.py
@@ -102,12 +102,12 @@ def plot_projected_elastic_properties(
     ticks = []
     lines = []
     for i, prp in enumerate(prps):
-        title, item = prp
+        title, values = prp
 
         axes[i].set_title(title)
 
-        vmin = np.min(item)
-        vmax = np.max(item)
+        vmin = np.min(values)
+        vmax = np.max(values)
         spacing = np.power(10.0, np.floor(np.log10(vmax - vmin)))
         nt = int((vmax - vmin - vmax % spacing + vmin % spacing) / spacing)
         if nt == 1:
@@ -124,14 +124,14 @@ def plot_projected_elastic_properties(
         ticks.append(np.linspace(tmin, tmax, nt))
         contour_sets.append(
             axes[i].contourf(
-                theta, r, item, n_divs, cmap=plt.cm.jet_r, vmin=vmin, vmax=vmax
+                theta, r, values, n_divs, cmap="rainbow", vmin=vmin, vmax=vmax
             )
         )
         lines.append(
             axes[i].contour(
-                theta, r, item, ticks[-1], colors=("black",), linewidths=(1,)
+                theta, r, values, ticks[-1], colors=("black",), linewidths=(1,)
             )
         )
-        axes[i].set_yticks([100])
+        axes[i].set_yticks([])
 
     return contour_sets, ticks, lines

--- a/contrib/anisotropic_eos/cubic_fitting_second_form.py
+++ b/contrib/anisotropic_eos/cubic_fitting_second_form.py
@@ -61,8 +61,8 @@ def psi_func(f, Pth, params):
     Psi = (
         0.0
         + params["a"] * f
-        + params["b_1"] * np.exp(params["c_1"] * f)
-        + params["b_2"] * np.exp(params["c_2"] * f)
+        + params["b_1"] * (np.exp(params["c_1"] * f) - 1.0)
+        + params["b_2"] * (np.exp(params["c_2"] * f) - 1.0)
     )
     Psi = Psi + Pth / 1.0e9 * (
         params["b_3"] * np.exp(params["c_3"] * f)
@@ -379,8 +379,8 @@ print(
     f'the isotropic model: $V_0$: {m.params["V_0"]*1.e6:.5f} cm$^3$/mol, '
     f'$K_0$: {m.params["K_0"]/1.e9:.5f} GPa, '
     f'$K\'_0$: {m.params["Kprime_0"]:.5f}, '
-    f'$\Theta_0$: {m.params["Debye_0"]:.5f} K, '
-    f'$\gamma_0$: {m.params["grueneisen_0"]:.5f}, '
+    f'$\\Theta_0$: {m.params["Debye_0"]:.5f} K, '
+    f'$\\gamma_0$: {m.params["grueneisen_0"]:.5f}, '
     f'and $q_0$: {m.params["q_0"]:.5f}.'
 )
 

--- a/contrib/anisotropic_eos/cubic_fitting_second_form_atherm.py
+++ b/contrib/anisotropic_eos/cubic_fitting_second_form_atherm.py
@@ -53,8 +53,8 @@ def psi_func(f, Pth, params):
     Psi = (
         0.0
         + params["a"] * f
-        + params["b_1"] * np.exp(params["c_1"] * f)
-        + params["b_2"] * np.exp(params["c_2"] * f)
+        + params["b_1"] * (np.exp(params["c_1"] * f) - 1.0)
+        + params["b_2"] * (np.exp(params["c_2"] * f) - 1.0)
     )
     dPsidPth = 0.0 * params["b_1"]
     return (Psi, dPsidf, dPsidPth)

--- a/contrib/anisotropic_eos/cubic_fitting_second_form_only_therm.py
+++ b/contrib/anisotropic_eos/cubic_fitting_second_form_only_therm.py
@@ -114,8 +114,8 @@ def psi_func(f, Pth, params):
     Psi = (
         0.0
         + params["a"] * f
-        + params["b_1"] * np.exp(params["c_1"] * f)
-        + params["b_2"] * np.exp(params["c_2"] * f)
+        + params["b_1"] * (np.exp(params["c_1"] * f) - 1.0)
+        + params["b_2"] * (np.exp(params["c_2"] * f) - 1.0)
     )
     Psi = Psi + Pth / 1.0e9 * (
         params["b_3"] * np.exp(params["c_3"] * f)

--- a/contrib/anisotropic_eos/orthorhombic_fitting_second_form.py
+++ b/contrib/anisotropic_eos/orthorhombic_fitting_second_form.py
@@ -100,8 +100,8 @@ def psi_func(f, Pth, params):
     Psi = (
         0.0
         + params["a"] * f
-        + params["b_1"] * np.exp(params["c_1"] * f)
-        + params["b_2"] * np.exp(params["c_2"] * f)
+        + params["b_1"] * (np.exp(params["c_1"] * f) - 1.0)
+        + params["b_2"] * (np.exp(params["c_2"] * f) - 1.0)
         + params["d"] * Pth / 1.0e9
     )
     dPsidPth = params["d"] / 1.0e9
@@ -393,8 +393,8 @@ if do_plotting:
         f'the isotropic model: $V_0$: {m.params["V_0"]*1.e6:.5f} cm$^3$/mol, '
         f'$K_0$: {m.params["K_0"]/1.e9:.5f} GPa, '
         f'$K\'_0$: {m.params["Kprime_0"]:.5f}, '
-        f'$\Theta_0$: {m.params["Debye_0"]:.5f} K, '
-        f'$\gamma_0$: {m.params["grueneisen_0"]:.5f}, '
+        f'$\\Theta_0$: {m.params["Debye_0"]:.5f} K, '
+        f'$\\gamma_0$: {m.params["grueneisen_0"]:.5f}, '
         f'and $q_0$: {m.params["q_0"]:.5f}.'
     )
 


### PR DESCRIPTION
This PR asserts that Phi=0 in anisotropic minerals at standard state.
Also fixes a new bug in anisotropic properties plotting arising from an update to matplotlib (which now scales polar plots to the largest tick value).