### PR TITLE
specify Reuss, consistently use isentropic rather than adiabatic

### DIFF
--- a/burnman/classes/anisotropicmineral.py
+++ b/burnman/classes/anisotropicmineral.py
@@ -418,7 +418,7 @@ class AnisotropicMineral(Mineral, AnisotropicMaterial):
         )
 
     @material_property
-    def isothermal_bulk_modulus(self):
+    def K_T(self):
         """
         Anisotropic minerals do not have a single isothermal bulk modulus.
         This function returns a NotImplementedError. Users should instead
@@ -427,16 +427,16 @@ class AnisotropicMineral(Mineral, AnisotropicMaterial):
         or directly querying the elements in the isothermal_stiffness_tensor.
         """
         raise NotImplementedError(
-            "isothermal_bulk_modulus is not "
+            "K_T is not "
             "sufficiently explicit for an "
             "anisotropic mineral. Did you mean "
             "isothermal_bulk_modulus_reuss?"
         )
 
-    isothermal_bulk_modulus_reuss = Mineral.isothermal_bulk_modulus
+    isothermal_bulk_modulus_reuss = Mineral.isothermal_bulk_modulus_reuss
 
     @material_property
-    def isentropic_bulk_modulus(self):
+    def K_S(self):
         """
         Anisotropic minerals do not have a single isentropic bulk modulus.
         This function returns a NotImplementedError. Users should instead
@@ -445,16 +445,16 @@ class AnisotropicMineral(Mineral, AnisotropicMaterial):
         or directly querying the elements in the isentropic_stiffness_tensor.
         """
         raise NotImplementedError(
-            "isentropic_bulk_modulus is not "
+            "K_S is not "
             "sufficiently explicit for an "
             "anisotropic mineral. Did you mean "
             "isentropic_bulk_modulus_reuss?"
         )
 
-    isentropic_bulk_modulus_reuss = Mineral.adiabatic_bulk_modulus
+    isentropic_bulk_modulus_reuss = Mineral.isentropic_bulk_modulus_reuss
 
     @material_property
-    def isothermal_compressibility(self):
+    def beta_T(self):
         """
         Anisotropic minerals do not have a single isentropic compressibility.
         This function returns a NotImplementedError. Users should instead
@@ -463,14 +463,14 @@ class AnisotropicMineral(Mineral, AnisotropicMaterial):
         or directly querying the elements in the isothermal_compliance_tensor.
         """
         raise NotImplementedError(
-            "isothermal_compressibility is not "
+            "beta_T is not "
             "sufficiently explicit for an "
             "anisotropic mineral. Did you mean "
             "isothermal_compressibility_reuss?"
         )
 
     @material_property
-    def isentropic_compressibility(self):
+    def beta_S(self):
         """
         Anisotropic minerals do not have a single isentropic compressibility.
         This function returns a NotImplementedError. Users should instead
@@ -479,7 +479,7 @@ class AnisotropicMineral(Mineral, AnisotropicMaterial):
         or directly querying the elements in the isentropic_compliance_tensor.
         """
         raise NotImplementedError(
-            "isentropic_compressibility is not "
+            "beta_S is not "
             "sufficiently explicit for an "
             "anisotropic mineral. Did you mean "
             "isentropic_compressibility_reuss?"
@@ -518,8 +518,6 @@ class AnisotropicMineral(Mineral, AnisotropicMaterial):
         :rtype: float
         """
         return 1.0 / self.isentropic_bulk_modulus_reuss
-
-    beta_S = isentropic_compressibility_reuss
 
     @material_property
     def isentropic_compressibility_voigt(self):

--- a/burnman/classes/combinedmineral.py
+++ b/burnman/classes/combinedmineral.py
@@ -98,12 +98,12 @@ class CombinedMineral(Mineral):
         return self.mixture.molar_entropy - self._property_modifiers["dGdT"]
 
     @material_property
-    def isothermal_bulk_modulus(self):
+    def isothermal_bulk_modulus_reuss(self):
         """
         Returns isothermal bulk modulus of the mineral [Pa]
         Aliased with self.K_T
         """
-        K_T_orig = self.mixture.isothermal_bulk_modulus
+        K_T_orig = self.mixture.isothermal_bulk_modulus_reuss
 
         return self.molar_volume / (
             (self._molar_volume_unmodified / K_T_orig)
@@ -197,37 +197,37 @@ class CombinedMineral(Mineral):
         return self.molar_gibbs + self.temperature * self.molar_entropy
 
     @material_property
-    def adiabatic_bulk_modulus(self):
+    def isentropic_bulk_modulus_reuss(self):
         """
         Returns adiabatic bulk modulus of the mineral [Pa]
         Aliased with self.K_S
         """
         if self.temperature < 1.0e-10:
-            return self.isothermal_bulk_modulus
+            return self.isothermal_bulk_modulus_reuss
         else:
             return (
-                self.isothermal_bulk_modulus
+                self.isothermal_bulk_modulus_reuss
                 * self.molar_heat_capacity_p
                 / self.molar_heat_capacity_v
             )
 
     @material_property
-    def isothermal_compressibility(self):
+    def isothermal_compressibility_reuss(self):
         """
         Returns isothermal compressibility of the mineral
         (or inverse isothermal bulk modulus) [1/Pa]
         Aliased with self.K_T
         """
-        return 1.0 / self.isothermal_bulk_modulus
+        return 1.0 / self.isothermal_bulk_modulus_reuss
 
     @material_property
-    def adiabatic_compressibility(self):
+    def isentropic_compressibility_reuss(self):
         """
         Returns adiabatic compressibility of the mineral
         (or inverse adiabatic bulk modulus) [1/Pa]
         Aliased with self.K_S
         """
-        return 1.0 / self.adiabatic_bulk_modulus
+        return 1.0 / self.isentropic_bulk_modulus_reuss
 
     @material_property
     def p_wave_velocity(self):
@@ -236,7 +236,7 @@ class CombinedMineral(Mineral):
         Aliased with self.v_p
         """
         return np.sqrt(
-            (self.adiabatic_bulk_modulus + 4.0 / 3.0 * self.shear_modulus)
+            (self.isentropic_bulk_modulus_reuss + 4.0 / 3.0 * self.shear_modulus)
             / self.density
         )
 
@@ -246,7 +246,7 @@ class CombinedMineral(Mineral):
         Returns bulk sound speed of the mineral [m/s]
         Aliased with self.v_phi
         """
-        return np.sqrt(self.adiabatic_bulk_modulus / self.density)
+        return np.sqrt(self.isentropic_bulk_modulus_reuss / self.density)
 
     @material_property
     def shear_wave_velocity(self):
@@ -267,7 +267,7 @@ class CombinedMineral(Mineral):
         else:
             return (
                 self.thermal_expansivity
-                * self.isothermal_bulk_modulus
+                * self.isothermal_bulk_modulus_reuss
                 * self.molar_volume
                 / self.molar_heat_capacity_v
             )
@@ -284,5 +284,5 @@ class CombinedMineral(Mineral):
             * self.temperature
             * self.thermal_expansivity
             * self.thermal_expansivity
-            * self.isothermal_bulk_modulus
+            * self.isothermal_bulk_modulus_reuss
         )

--- a/burnman/classes/composite.py
+++ b/burnman/classes/composite.py
@@ -317,7 +317,7 @@ class Composite(Material):
         return H
 
     @material_property
-    def isothermal_bulk_modulus(self):
+    def isothermal_bulk_modulus_reuss(self):
         """
         Returns isothermal bulk modulus of the composite [Pa]
         Aliased with self.K_T
@@ -328,13 +328,13 @@ class Composite(Material):
                 for (phase, molar_fraction) in zip(self.phases, self.molar_fractions)
             ]
         )
-        K_ph = np.array([phase.isothermal_bulk_modulus for phase in self.phases])
+        K_ph = np.array([phase.isothermal_bulk_modulus_reuss for phase in self.phases])
         G_ph = np.array([phase.shear_modulus for phase in self.phases])
 
         return self.averaging_scheme.average_bulk_moduli(V_frac, K_ph, G_ph)
 
     @material_property
-    def adiabatic_bulk_modulus(self):
+    def isentropic_bulk_modulus_reuss(self):
         """
         Returns adiabatic bulk modulus of the mineral [Pa]
         Aliased with self.K_S
@@ -345,28 +345,28 @@ class Composite(Material):
                 for (phase, molar_fraction) in zip(self.phases, self.molar_fractions)
             ]
         )
-        K_ph = np.array([phase.adiabatic_bulk_modulus for phase in self.phases])
+        K_ph = np.array([phase.isentropic_bulk_modulus_reuss for phase in self.phases])
         G_ph = np.array([phase.shear_modulus for phase in self.phases])
 
         return self.averaging_scheme.average_bulk_moduli(V_frac, K_ph, G_ph)
 
     @material_property
-    def isothermal_compressibility(self):
+    def isothermal_compressibility_reuss(self):
         """
         Returns isothermal compressibility of the composite
         (or inverse isothermal bulk modulus) [1/Pa]
         Aliased with self.beta_T
         """
-        return 1.0 / self.isothermal_bulk_modulus
+        return 1.0 / self.isothermal_bulk_modulus_reuss
 
     @material_property
-    def adiabatic_compressibility(self):
+    def isentropic_compressibility_reuss(self):
         """
         Returns isothermal compressibility of the composite
         (or inverse isothermal bulk modulus) [1/Pa]
         Aliased with self.beta_S
         """
-        return 1.0 / self.adiabatic_bulk_modulus
+        return 1.0 / self.isentropic_bulk_modulus_reuss
 
     @material_property
     def shear_modulus(self):
@@ -380,7 +380,7 @@ class Composite(Material):
                 for (phase, molar_fraction) in zip(self.phases, self.molar_fractions)
             ]
         )
-        K_ph = np.array([phase.adiabatic_bulk_modulus for phase in self.phases])
+        K_ph = np.array([phase.isentropic_bulk_modulus_reuss for phase in self.phases])
         G_ph = np.array([phase.shear_modulus for phase in self.phases])
 
         return self.averaging_scheme.average_shear_moduli(V_frac, K_ph, G_ph)
@@ -392,7 +392,7 @@ class Composite(Material):
         Aliased with self.v_p
         """
         return np.sqrt(
-            (self.adiabatic_bulk_modulus + 4.0 / 3.0 * self.shear_modulus)
+            (self.isentropic_bulk_modulus_reuss + 4.0 / 3.0 * self.shear_modulus)
             / self.density
         )
 
@@ -402,7 +402,7 @@ class Composite(Material):
         Returns bulk sound speed of the composite [m/s]
         Aliased with self.v_phi
         """
-        return np.sqrt(self.adiabatic_bulk_modulus / self.density)
+        return np.sqrt(self.isentropic_bulk_modulus_reuss / self.density)
 
     @material_property
     def shear_wave_velocity(self):
@@ -420,7 +420,7 @@ class Composite(Material):
         """
         return (
             self.thermal_expansivity
-            * self.isothermal_bulk_modulus
+            * self.isothermal_bulk_modulus_reuss
             * self.molar_volume
             / self.molar_heat_capacity_v
         )

--- a/burnman/classes/elasticsolution.py
+++ b/burnman/classes/elasticsolution.py
@@ -292,7 +292,7 @@ class ElasticSolution(Mineral):
         Returns the change in pressure with amount of each endmember
         at constant pressure.
         """
-        return self.molar_volume / self.isothermal_bulk_modulus * self._dPdX
+        return self.molar_volume / self.isothermal_bulk_modulus_reuss * self._dPdX
 
     @material_property
     def _dSdX_mod(self):
@@ -457,7 +457,9 @@ class ElasticSolution(Mineral):
 
             return sum(
                 [
-                    self.solution_model.endmembers[i][0].method.isothermal_bulk_modulus(
+                    self.solution_model.endmembers[i][
+                        0
+                    ].method.isothermal_bulk_modulus_reuss(
                         0.0,
                         self.temperature,
                         volume,
@@ -573,51 +575,51 @@ class ElasticSolution(Mineral):
         )
 
     @material_property
-    def isothermal_bulk_modulus(self):
+    def isothermal_bulk_modulus_reuss(self):
         """
         Returns isothermal bulk modulus of the solution [Pa].
         Aliased with self.K_T.
         """
         return sum(
             [
-                self.solution_model.endmembers[i][0].isothermal_bulk_modulus
+                self.solution_model.endmembers[i][0].isothermal_bulk_modulus_reuss
                 * self.molar_fractions[i]
                 for i in range(self.n_endmembers)
             ]
         )
 
     @material_property
-    def adiabatic_bulk_modulus(self):
+    def isentropic_bulk_modulus_reuss(self):
         """
         Returns adiabatic bulk modulus of the solution [Pa].
         Aliased with self.K_S.
         """
         if self.temperature < 1e-10:
-            return self.isothermal_bulk_modulus
+            return self.isothermal_bulk_modulus_reuss
         else:
             return (
-                self.isothermal_bulk_modulus
+                self.isothermal_bulk_modulus_reuss
                 * self.molar_heat_capacity_p
                 / self.molar_heat_capacity_v
             )
 
     @material_property
-    def isothermal_compressibility(self):
+    def isothermal_compressibility_reuss(self):
         """
         Returns isothermal compressibility of the solution.
         (or inverse isothermal bulk modulus) [1/Pa].
         Aliased with self.K_T.
         """
-        return 1.0 / self.isothermal_bulk_modulus
+        return 1.0 / self.isothermal_bulk_modulus_reuss
 
     @material_property
-    def adiabatic_compressibility(self):
+    def isentropic_compressibility_reuss(self):
         """
         Returns adiabatic compressibility of the solution.
         (or inverse adiabatic bulk modulus) [1/Pa].
         Aliased with self.K_S.
         """
-        return 1.0 / self.adiabatic_bulk_modulus
+        return 1.0 / self.isentropic_bulk_modulus_reuss
 
     @material_property
     def shear_modulus(self):
@@ -639,7 +641,7 @@ class ElasticSolution(Mineral):
         Aliased with self.v_p.
         """
         return np.sqrt(
-            (self.adiabatic_bulk_modulus + 4.0 / 3.0 * self.shear_modulus)
+            (self.isentropic_bulk_modulus_reuss + 4.0 / 3.0 * self.shear_modulus)
             / self.density
         )
 
@@ -649,7 +651,7 @@ class ElasticSolution(Mineral):
         Returns bulk sound speed of the solution [m/s].
         Aliased with self.v_phi.
         """
-        return np.sqrt(self.adiabatic_bulk_modulus / self.density)
+        return np.sqrt(self.isentropic_bulk_modulus_reuss / self.density)
 
     @material_property
     def shear_wave_velocity(self):
@@ -670,7 +672,7 @@ class ElasticSolution(Mineral):
         else:
             return (
                 self.thermal_expansivity
-                * self.isothermal_bulk_modulus
+                * self.isothermal_bulk_modulus_reuss
                 * self.molar_volume
                 / self.molar_heat_capacity_v
             )
@@ -684,13 +686,13 @@ class ElasticSolution(Mineral):
         """
         alphaKT = sum(
             [
-                self.solution_model.endmembers[i][0].isothermal_bulk_modulus
+                self.solution_model.endmembers[i][0].isothermal_bulk_modulus_reuss
                 * self.solution_model.endmembers[i][0].alpha
                 * self.molar_fractions[i]
                 for i in range(self.n_endmembers)
             ]
         )
-        return alphaKT / self.isothermal_bulk_modulus
+        return alphaKT / self.isothermal_bulk_modulus_reuss
 
     @material_property
     def molar_heat_capacity_v(self):
@@ -720,7 +722,7 @@ class ElasticSolution(Mineral):
             * self.temperature
             * self.thermal_expansivity
             * self.thermal_expansivity
-            * self.isothermal_bulk_modulus
+            * self.isothermal_bulk_modulus_reuss
         )
 
     @cached_property

--- a/burnman/classes/layer.py
+++ b/burnman/classes/layer.py
@@ -626,7 +626,7 @@ class Layer(object):
         )
 
     @material_property
-    def isothermal_bulk_modulus(self):
+    def isothermal_bulk_modulus_reuss(self):
         """
         Returns isothermal bulk moduli across the layer.
 
@@ -640,13 +640,13 @@ class Layer(object):
         """
         return np.array(
             [
-                self.sublayers[i].isothermal_bulk_modulus
+                self.sublayers[i].isothermal_bulk_modulus_reuss
                 for i in range(len(self.sublayers))
             ]
         )
 
     @material_property
-    def adiabatic_bulk_modulus(self):
+    def isentropic_bulk_modulus_reuss(self):
         """
         Returns the adiabatic bulk moduli across the layer.
 
@@ -658,13 +658,13 @@ class Layer(object):
         """
         return np.array(
             [
-                self.sublayers[i].adiabatic_bulk_modulus
+                self.sublayers[i].isentropic_bulk_modulus_reuss
                 for i in range(len(self.sublayers))
             ]
         )
 
     @material_property
-    def isothermal_compressibility(self):
+    def isothermal_compressibility_reuss(self):
         """
         Returns isothermal compressibilities across the layer
         (or inverse isothermal bulk moduli).
@@ -677,13 +677,13 @@ class Layer(object):
         """
         return np.array(
             [
-                self.sublayers[i].isothermal_compressibility
+                self.sublayers[i].isothermal_compressibility_reuss
                 for i in range(len(self.sublayers))
             ]
         )
 
     @material_property
-    def adiabatic_compressibility(self):
+    def isentropic_compressibility_reuss(self):
         """
         Returns adiabatic compressibilities across the layer
         (or inverse adiabatic bulk moduli).
@@ -696,7 +696,7 @@ class Layer(object):
         """
         return np.array(
             [
-                self.sublayers[i].adiabatic_compressibility
+                self.sublayers[i].isentropic_compressibility_reuss
                 for i in range(len(self.sublayers))
             ]
         )
@@ -875,23 +875,23 @@ class Layer(object):
 
     @property
     def K_T(self):
-        """Alias for :func:`~burnman.Layer.isothermal_bulk_modulus`"""
-        return self.isothermal_bulk_modulus
+        """Alias for :func:`~burnman.Layer.isothermal_bulk_modulus_reuss`"""
+        return self.isothermal_bulk_modulus_reuss
 
     @property
     def K_S(self):
-        """Alias for :func:`~burnman.Layer.adiabatic_bulk_modulus`"""
-        return self.adiabatic_bulk_modulus
+        """Alias for :func:`~burnman.Layer.isentropic_bulk_modulus_reuss`"""
+        return self.isentropic_bulk_modulus_reuss
 
     @property
     def beta_T(self):
-        """Alias for :func:`~burnman.Layer.isothermal_compressibility`"""
-        return self.isothermal_compressibility
+        """Alias for :func:`~burnman.Layer.isothermal_compressibility_reuss`"""
+        return self.isothermal_compressibility_reuss
 
     @property
     def beta_S(self):
-        """Alias for :func:`~burnman.Layer.adiabatic_compressibility`"""
-        return self.adiabatic_compressibility
+        """Alias for :func:`~burnman.Layer.isentropic_compressibility_reuss`"""
+        return self.isentropic_compressibility_reuss
 
     @property
     def G(self):

--- a/burnman/classes/material.py
+++ b/burnman/classes/material.py
@@ -436,7 +436,7 @@ class Material(object):
         )
 
     @material_property
-    def isothermal_bulk_modulus(self):
+    def isothermal_bulk_modulus_reuss(self):
         """
         Returns isothermal bulk modulus of the material.
 
@@ -447,11 +447,11 @@ class Material(object):
         :rtype: float
         """
         raise NotImplementedError(
-            "need to implement isothermal_bulk_moduls() in derived class!"
+            "need to implement isothermal_bulk_modulus_reuss() in derived class!"
         )
 
     @material_property
-    def adiabatic_bulk_modulus(self):
+    def isentropic_bulk_modulus_reuss(self):
         """
         Returns the adiabatic bulk modulus of the mineral.
 
@@ -462,11 +462,11 @@ class Material(object):
         :rtype: float
         """
         raise NotImplementedError(
-            "need to implement adiabatic_bulk_modulus() in derived class!"
+            "need to implement isentropic_bulk_modulus_reuss() in derived class!"
         )
 
     @material_property
-    def isothermal_compressibility(self):
+    def isothermal_compressibility_reuss(self):
         """
         Returns isothermal compressibility of the mineral
         (or inverse isothermal bulk modulus).
@@ -478,11 +478,11 @@ class Material(object):
         :rtype: float
         """
         raise NotImplementedError(
-            "need to implement compressibility() in derived class!"
+            "need to implement isothermal_compressibility_reuss() in derived class!"
         )
 
     @material_property
-    def adiabatic_compressibility(self):
+    def isentropic_compressibility_reuss(self):
         """
         Returns adiabatic compressibility of the mineral
         (or inverse adiabatic bulk modulus).
@@ -495,7 +495,7 @@ class Material(object):
         :rtype: float
         """
         raise NotImplementedError(
-            "need to implement compressibility() in derived class!"
+            "need to implement isentropic_compressibility_reuss() in derived class!"
         )
 
     @material_property
@@ -675,53 +675,23 @@ class Material(object):
 
     @property
     def K_T(self):
-        """Alias for :func:`~burnman.Material.isothermal_bulk_modulus`"""
-        return self.isothermal_bulk_modulus
+        """Alias for :func:`~burnman.Material.isothermal_bulk_modulus_reuss`"""
+        return self.isothermal_bulk_modulus_reuss
 
     @property
     def K_S(self):
-        """Alias for :func:`~burnman.Material.adiabatic_bulk_modulus`"""
-        return self.adiabatic_bulk_modulus
+        """Alias for :func:`~burnman.Material.isentropic_bulk_modulus_reuss`"""
+        return self.isentropic_bulk_modulus_reuss
 
     @property
     def beta_T(self):
-        """Alias for :func:`~burnman.Material.isothermal_compressibility`"""
-        return self.isothermal_compressibility
+        """Alias for :func:`~burnman.Material.isothermal_compressibility_reuss`"""
+        return self.isothermal_compressibility_reuss
 
     @property
     def beta_S(self):
-        """Alias for :func:`~burnman.Material.adiabatic_compressibility`"""
-        return self.adiabatic_compressibility
-
-    @property
-    def isothermal_bulk_modulus_reuss(self):
-        """Alias for :func:`~burnman.Material.isothermal_bulk_modulus`"""
-        return self.isothermal_bulk_modulus
-
-    @property
-    def adiabatic_bulk_modulus_reuss(self):
-        """Alias for :func:`~burnman.Material.adiabatic_bulk_modulus`"""
-        return self.adiabatic_bulk_modulus
-
-    @property
-    def isentropic_bulk_modulus_reuss(self):
-        """Alias for :func:`~burnman.Material.adiabatic_bulk_modulus_reuss`"""
-        return self.adiabatic_bulk_modulus_reuss
-
-    @property
-    def isothermal_compressibility_reuss(self):
-        """Alias for :func:`~burnman.Material.isothermal_compressibility`"""
-        return self.isothermal_compressibility
-
-    @property
-    def adiabatic_compressibility_reuss(self):
-        """Alias for :func:`~burnman.Material.adiabatic_compressibility`"""
-        return self.adiabatic_compressibility
-
-    @property
-    def isentropic_compressibility_reuss(self):
-        """Alias for :func:`~burnman.Material.adiabatic_compressibility_reuss`"""
-        return self.adiabatic_compressibility_reuss
+        """Alias for :func:`~burnman.Material.isentropic_compressibility_reuss`"""
+        return self.isentropic_compressibility_reuss
 
     @property
     def G(self):

--- a/burnman/classes/mineral.py
+++ b/burnman/classes/mineral.py
@@ -187,9 +187,9 @@ class Mineral(Material):
         )
 
     @material_property
-    @copy_documentation(Material.isothermal_bulk_modulus)
-    def isothermal_bulk_modulus(self):
-        K_T_orig = self.method.isothermal_bulk_modulus(
+    @copy_documentation(Material.isothermal_bulk_modulus_reuss)
+    def isothermal_bulk_modulus_reuss(self):
+        K_T_orig = self.method.isothermal_bulk_modulus_reuss(
             self.pressure, self.temperature, self._molar_volume_unmodified, self.params
         )
 
@@ -197,8 +197,6 @@ class Mineral(Material):
             (self._molar_volume_unmodified / K_T_orig)
             - self._property_modifiers["d2GdP2"]
         )
-
-    isothermal_bulk_modulus_reuss = isothermal_bulk_modulus
 
     @material_property
     @copy_documentation(Material.molar_heat_capacity_p)
@@ -307,39 +305,39 @@ class Mineral(Material):
         return self.molar_gibbs + self.temperature * self.molar_entropy
 
     @material_property
-    @copy_documentation(Material.adiabatic_bulk_modulus)
-    def adiabatic_bulk_modulus(self):
+    @copy_documentation(Material.isentropic_bulk_modulus_reuss)
+    def isentropic_bulk_modulus_reuss(self):
         if self.temperature < 1.0e-10:
-            return self.isothermal_bulk_modulus
+            return self.isothermal_bulk_modulus_reuss
         else:
             return (
-                self.isothermal_bulk_modulus
+                self.isothermal_bulk_modulus_reuss
                 * self.molar_heat_capacity_p
                 / self.molar_heat_capacity_v
             )
 
     @material_property
-    @copy_documentation(Material.isothermal_compressibility)
-    def isothermal_compressibility(self):
-        return 1.0 / self.isothermal_bulk_modulus
+    @copy_documentation(Material.isothermal_compressibility_reuss)
+    def isothermal_compressibility_reuss(self):
+        return 1.0 / self.isothermal_bulk_modulus_reuss
 
     @material_property
-    @copy_documentation(Material.adiabatic_compressibility)
-    def adiabatic_compressibility(self):
-        return 1.0 / self.adiabatic_bulk_modulus
+    @copy_documentation(Material.isentropic_compressibility_reuss)
+    def isentropic_compressibility_reuss(self):
+        return 1.0 / self.isentropic_bulk_modulus_reuss
 
     @material_property
     @copy_documentation(Material.p_wave_velocity)
     def p_wave_velocity(self):
         return np.sqrt(
-            (self.adiabatic_bulk_modulus_reuss + 4.0 / 3.0 * self.shear_modulus)
+            (self.isentropic_bulk_modulus_reuss + 4.0 / 3.0 * self.shear_modulus)
             / self.density
         )
 
     @material_property
     @copy_documentation(Material.bulk_sound_velocity)
     def bulk_sound_velocity(self):
-        return np.sqrt(self.adiabatic_bulk_modulus_reuss / self.density)
+        return np.sqrt(self.isentropic_bulk_modulus_reuss / self.density)
 
     @material_property
     @copy_documentation(Material.shear_wave_velocity)
@@ -353,7 +351,7 @@ class Mineral(Material):
         if np.abs(self.molar_heat_capacity_v) > eps:
             return (
                 self.thermal_expansivity
-                * self.isothermal_bulk_modulus
+                * self.isothermal_bulk_modulus_reuss
                 * self.molar_volume
                 / self.molar_heat_capacity_v
             )
@@ -380,7 +378,7 @@ class Mineral(Material):
             * self.temperature
             * self.thermal_expansivity
             * self.thermal_expansivity
-            * self.isothermal_bulk_modulus
+            * self.isothermal_bulk_modulus_reuss
         )
 
     @material_property

--- a/burnman/classes/mineral_helpers.py
+++ b/burnman/classes/mineral_helpers.py
@@ -79,20 +79,20 @@ class HelperRockSwitcher(Material):
         return self.current_rock.molar_enthalpy
 
     @material_property
-    def isothermal_bulk_modulus(self):
-        return self.current_rock.isothermal_bulk_modulus
+    def isothermal_bulk_modulus_reuss(self):
+        return self.current_rock.isothermal_bulk_modulus_reuss
 
     @material_property
-    def adiabatic_bulk_modulus(self):
-        return self.current_rock.adiabatic_bulk_modulus
+    def isentropic_bulk_modulus_reuss(self):
+        return self.current_rock.isentropic_bulk_modulus_reuss
 
     @material_property
-    def isothermal_compressibility(self):
-        return self.current_rock.isothermal_compressibility
+    def isothermal_compressibility_reuss(self):
+        return self.current_rock.isothermal_compressibility_reuss
 
     @material_property
-    def adiabatic_compressibility(self):
-        return self.current_rock.adiabatic_compressibility
+    def isentropic_compressibility_reuss(self):
+        return self.current_rock.isentropic_compressibility_reuss
 
     @material_property
     def shear_modulus(self):

--- a/burnman/classes/perplex.py
+++ b/burnman/classes/perplex.py
@@ -5,7 +5,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-import time
 import subprocess
 from os import rename
 
@@ -355,13 +354,13 @@ class PerplexMaterial(Material):
         return self._property_interpolators["S"]([self.pressure, self.temperature])[0]
 
     @material_property
-    @copy_documentation(Material.isothermal_bulk_modulus)
-    def isothermal_bulk_modulus(self):
+    @copy_documentation(Material.isothermal_bulk_modulus_reuss)
+    def isothermal_bulk_modulus_reuss(self):
         return self._property_interpolators["K_T"]([self.pressure, self.temperature])[0]
 
     @material_property
-    @copy_documentation(Material.adiabatic_bulk_modulus)
-    def adiabatic_bulk_modulus(self):
+    @copy_documentation(Material.isentropic_bulk_modulus_reuss)
+    def isentropic_bulk_modulus_reuss(self):
         return self._property_interpolators["K_S"]([self.pressure, self.temperature])[0]
 
     @material_property
@@ -443,14 +442,14 @@ class PerplexMaterial(Material):
         return self.molar_gibbs - self.pressure * self.molar_volume
 
     @material_property
-    @copy_documentation(Material.isothermal_compressibility)
-    def isothermal_compressibility(self):
-        return 1.0 / self.isothermal_bulk_modulus
+    @copy_documentation(Material.isothermal_compressibility_reuss)
+    def isothermal_compressibility_reuss(self):
+        return 1.0 / self.isothermal_bulk_modulus_reuss
 
     @material_property
-    @copy_documentation(Material.adiabatic_compressibility)
-    def adiabatic_compressibility(self):
-        return 1.0 / self.adiabatic_bulk_modulus
+    @copy_documentation(Material.isentropic_compressibility_reuss)
+    def isentropic_compressibility_reuss(self):
+        return 1.0 / self.isentropic_bulk_modulus_reuss
 
     @material_property
     @copy_documentation(Material.molar_heat_capacity_v)
@@ -461,7 +460,7 @@ class PerplexMaterial(Material):
             * self.temperature
             * self.thermal_expansivity
             * self.thermal_expansivity
-            * self.isothermal_bulk_modulus
+            * self.isothermal_bulk_modulus_reuss
         )
 
     @material_property
@@ -470,6 +469,6 @@ class PerplexMaterial(Material):
         return (
             self.thermal_expansivity
             * self.molar_volume
-            * self.adiabatic_bulk_modulus
+            * self.isentropic_bulk_modulus_reuss
             / self.molar_heat_capacity_p
         )

--- a/burnman/classes/planet.py
+++ b/burnman/classes/planet.py
@@ -537,7 +537,7 @@ class Planet(object):
         return self.evaluate(["molar_enthalpy"])
 
     @material_property
-    def isothermal_bulk_modulus(self):
+    def isothermal_bulk_modulus_reuss(self):
         """
         Returns isothermal bulk modulus of the planet.
 
@@ -547,10 +547,10 @@ class Planet(object):
         :returns: Isothermal bulk modulus in [Pa].
         :rtype: array of floats
         """
-        return self.evaluate(["isothermal_bulk_modulus"])
+        return self.evaluate(["isothermal_bulk_modulus_reuss"])
 
     @material_property
-    def adiabatic_bulk_modulus(self):
+    def isentropic_bulk_modulus_reuss(self):
         """
         Returns the adiabatic bulk modulus of the planet.
 
@@ -560,10 +560,10 @@ class Planet(object):
         :returns: Adiabatic bulk modulus in [Pa].
         :rtype: array of floats
         """
-        return self.evaluate(["adiabatic_bulk_modulus"])
+        return self.evaluate(["isentropic_bulk_modulus_reuss"])
 
     @material_property
-    def isothermal_compressibility(self):
+    def isothermal_compressibility_reuss(self):
         """
         Returns isothermal compressibility of the planet
         (or inverse isothermal bulk modulus).
@@ -577,7 +577,7 @@ class Planet(object):
         return self.evaluate(["istothermal_compressibility"])
 
     @material_property
-    def adiabatic_compressibility(self):
+    def isentropic_compressibility_reuss(self):
         """
         Returns adiabatic compressibility of the planet
         (or inverse adiabatic bulk modulus).
@@ -588,7 +588,7 @@ class Planet(object):
         :returns: Adiabatic compressibility in [1/Pa].
         :rtype: array of floats
         """
-        return self.evaluate(["adiabatic_compressibility"])
+        return self.evaluate(["isentropic_compressibility_reuss"])
 
     @material_property
     def shear_modulus(self):
@@ -743,23 +743,23 @@ class Planet(object):
 
     @property
     def K_T(self):
-        """Alias for :func:`~burnman.Material.isothermal_bulk_modulus`"""
-        return self.isothermal_bulk_modulus
+        """Alias for :func:`~burnman.Material.isothermal_bulk_modulus_reuss`"""
+        return self.isothermal_bulk_modulus_reuss
 
     @property
     def K_S(self):
-        """Alias for :func:`~burnman.Material.adiabatic_bulk_modulus`"""
-        return self.adiabatic_bulk_modulus
+        """Alias for :func:`~burnman.Material.isentropic_bulk_modulus_reuss`"""
+        return self.isentropic_bulk_modulus_reuss
 
     @property
     def beta_T(self):
-        """Alias for :func:`~burnman.Material.isothermal_compressibility`"""
-        return self.isothermal_compressibility
+        """Alias for :func:`~burnman.Material.isothermal_compressibility_reuss`"""
+        return self.isothermal_compressibility_reuss
 
     @property
     def beta_S(self):
-        """Alias for :func:`~burnman.Material.adiabatic_compressibility`"""
-        return self.adiabatic_compressibility
+        """Alias for :func:`~burnman.Material.isentropic_compressibility_reuss`"""
+        return self.isentropic_compressibility_reuss
 
     @property
     def G(self):

--- a/burnman/classes/solution.py
+++ b/burnman/classes/solution.py
@@ -421,7 +421,7 @@ class Solution(Mineral):
         )
 
     @material_property
-    def isothermal_bulk_modulus(self):
+    def isothermal_bulk_modulus_reuss(self):
         """
         Returns isothermal bulk modulus of the solution [Pa].
         Aliased with self.K_T.
@@ -433,7 +433,11 @@ class Solution(Mineral):
                 sum(
                     [
                         self.solution_model.endmembers[i][0].V
-                        / (self.solution_model.endmembers[i][0].K_T)
+                        / (
+                            self.solution_model.endmembers[i][
+                                0
+                            ].isothermal_bulk_modulus_reuss
+                        )
                         * self.molar_fractions[i]
                         for i in range(self.n_endmembers)
                     ]
@@ -442,42 +446,38 @@ class Solution(Mineral):
             )
         )
 
-    isothermal_bulk_modulus_reuss = isothermal_bulk_modulus
-
     @material_property
-    def adiabatic_bulk_modulus(self):
+    def isentropic_bulk_modulus_reuss(self):
         """
         Returns adiabatic bulk modulus of the solution [Pa].
         Aliased with self.K_S.
         """
         if self.temperature < 1e-10:
-            return self.isothermal_bulk_modulus
+            return self.isothermal_bulk_modulus_reuss
         else:
             return (
-                self.isothermal_bulk_modulus
+                self.isothermal_bulk_modulus_reuss
                 * self.molar_heat_capacity_p
                 / self.molar_heat_capacity_v
             )
 
-    adiabatic_bulk_modulus_reuss = adiabatic_bulk_modulus
-
     @material_property
-    def isothermal_compressibility(self):
+    def isothermal_compressibility_reuss(self):
         """
         Returns isothermal compressibility of the solution.
         (or inverse isothermal bulk modulus) [1/Pa].
         Aliased with self.K_T.
         """
-        return 1.0 / self.isothermal_bulk_modulus
+        return 1.0 / self.isothermal_bulk_modulus_reuss
 
     @material_property
-    def adiabatic_compressibility(self):
+    def isentropic_compressibility_reuss(self):
         """
         Returns adiabatic compressibility of the solution.
         (or inverse adiabatic bulk modulus) [1/Pa].
         Aliased with self.K_S.
         """
-        return 1.0 / self.adiabatic_bulk_modulus
+        return 1.0 / self.isentropic_bulk_modulus_reuss
 
     @material_property
     def shear_modulus(self):
@@ -499,7 +499,7 @@ class Solution(Mineral):
         Aliased with self.v_p.
         """
         return np.sqrt(
-            (self.adiabatic_bulk_modulus + 4.0 / 3.0 * self.shear_modulus)
+            (self.isentropic_bulk_modulus_reuss + 4.0 / 3.0 * self.shear_modulus)
             / self.density
         )
 
@@ -509,7 +509,7 @@ class Solution(Mineral):
         Returns bulk sound speed of the solution [m/s].
         Aliased with self.v_phi.
         """
-        return np.sqrt(self.adiabatic_bulk_modulus / self.density)
+        return np.sqrt(self.isentropic_bulk_modulus_reuss / self.density)
 
     @material_property
     def shear_wave_velocity(self):
@@ -530,7 +530,7 @@ class Solution(Mineral):
         else:
             return (
                 self.thermal_expansivity
-                * self.isothermal_bulk_modulus
+                * self.isothermal_bulk_modulus_reuss
                 * self.molar_volume
                 / self.molar_heat_capacity_v
             )
@@ -567,7 +567,7 @@ class Solution(Mineral):
             * self.temperature
             * self.thermal_expansivity
             * self.thermal_expansivity
-            * self.isothermal_bulk_modulus
+            * self.isothermal_bulk_modulus_reuss
         )
 
     @material_property

--- a/burnman/classes/solutionmodel.py
+++ b/burnman/classes/solutionmodel.py
@@ -1569,7 +1569,10 @@ class PolynomialSolution(IdealSolution):
     def VoverKT_excess(self):
         mbr_scalar = self.mbr_scalar_list
         mbr_d2gibbsdpdp = np.array(
-            [mbr.V / mbr.K_T for mbr in self.interaction_endmembers]
+            [
+                mbr.V / mbr.isothermal_bulk_modulus_reuss
+                for mbr in self.interaction_endmembers
+            ]
         )
         return np.einsum("i, i", mbr_scalar, mbr_d2gibbsdpdp)
 

--- a/burnman/eos/aa.py
+++ b/burnman/eos/aa.py
@@ -299,7 +299,7 @@ class AA(eos.EquationOfState):
 
         return gr
 
-    def isothermal_bulk_modulus(self, pressure, temperature, volume, params):
+    def isothermal_bulk_modulus_reuss(self, pressure, temperature, volume, params):
         """
         Returns isothermal bulk modulus :math:`[Pa]`
         """
@@ -311,11 +311,11 @@ class AA(eos.EquationOfState):
         K_T = -volume * (P1 - P0) / dV
         return K_T
 
-    def adiabatic_bulk_modulus(self, pressure, temperature, volume, params):
+    def isentropic_bulk_modulus_reuss(self, pressure, temperature, volume, params):
         """
         Returns adiabatic bulk modulus. :math:`[Pa]`
         """
-        K_T = self.isothermal_bulk_modulus(pressure, temperature, volume, params)
+        K_T = self.isothermal_bulk_modulus_reuss(pressure, temperature, volume, params)
         alpha = self.thermal_expansivity(pressure, temperature, volume, params)
         gr = self.grueneisen_parameter(pressure, temperature, volume, params)
         K_S = K_T * (1.0 + gr * alpha * temperature)

--- a/burnman/eos/birch_murnaghan.py
+++ b/burnman/eos/birch_murnaghan.py
@@ -129,14 +129,14 @@ class BirchMurnaghanBase(eos.EquationOfState):
     def pressure(self, temperature, volume, params):
         return birch_murnaghan(params["V_0"] / volume, params)
 
-    def isothermal_bulk_modulus(self, pressure, temperature, volume, params):
+    def isothermal_bulk_modulus_reuss(self, pressure, temperature, volume, params):
         """
         Returns isothermal bulk modulus :math:`K_T` :math:`[Pa]` as a function of pressure :math:`[Pa]`,
         temperature :math:`[K]` and volume :math:`[m^3]`.
         """
         return bulk_modulus(volume, params)
 
-    def adiabatic_bulk_modulus(self, pressure, temperature, volume, params):
+    def isentropic_bulk_modulus_reuss(self, pressure, temperature, volume, params):
         """
         Returns adiabatic bulk modulus :math:`K_s` of the mineral. :math:`[Pa]`.
         """

--- a/burnman/eos/birch_murnaghan_4th.py
+++ b/burnman/eos/birch_murnaghan_4th.py
@@ -95,14 +95,14 @@ class BM4(eos.EquationOfState):
     def pressure(self, temperature, volume, params):
         return birch_murnaghan_fourth(volume / params["V_0"], params)
 
-    def isothermal_bulk_modulus(self, pressure, temperature, volume, params):
+    def isothermal_bulk_modulus_reuss(self, pressure, temperature, volume, params):
         """
         Returns isothermal bulk modulus :math:`K_T` :math:`[Pa]` as a function of pressure :math:`[Pa]`,
         temperature :math:`[K]` and volume :math:`[m^3]`.
         """
         return bulk_modulus_fourth(volume, params)
 
-    def adiabatic_bulk_modulus(self, pressure, temperature, volume, params):
+    def isentropic_bulk_modulus_reuss(self, pressure, temperature, volume, params):
         """
         Returns adiabatic bulk modulus :math:`K_s` of the mineral. :math:`[Pa]`.
         """

--- a/burnman/eos/brosh_calphad.py
+++ b/burnman/eos/brosh_calphad.py
@@ -90,7 +90,7 @@ class BroshCalphad(eos.EquationOfState):
 
         return brentq(_delta_volume, sol[0], sol[1])
 
-    def isothermal_bulk_modulus(self, pressure, temperature, volume, params):
+    def isothermal_bulk_modulus_reuss(self, pressure, temperature, volume, params):
         """
         Returns the isothermal bulk modulus :math:`K_T` :math:`[Pa]`
         as a function of pressure :math:`[Pa]`,
@@ -103,15 +103,19 @@ class BroshCalphad(eos.EquationOfState):
 
         return -volume * dP / dV
 
-    def adiabatic_bulk_modulus(self, pressure, temperature, volume, params):
+    def isentropic_bulk_modulus_reuss(self, pressure, temperature, volume, params):
         """
         Returns the adiabatic bulk modulus of the mineral. :math:`[Pa]`.
         """
         if temperature < 1.0e-10:
-            return self.isothermal_bulk_modulus(pressure, temperature, volume, params)
+            return self.isothermal_bulk_modulus_reuss(
+                pressure, temperature, volume, params
+            )
         else:
             return (
-                self.isothermal_bulk_modulus(pressure, temperature, volume, params)
+                self.isothermal_bulk_modulus_reuss(
+                    pressure, temperature, volume, params
+                )
                 * self.molar_heat_capacity_p(pressure, temperature, volume, params)
                 / self.molar_heat_capacity_v(pressure, temperature, volume, params)
             )
@@ -405,7 +409,9 @@ class BroshCalphad(eos.EquationOfState):
         else:
             return (
                 self.thermal_expansivity(pressure, temperature, volume, params)
-                * self.isothermal_bulk_modulus(pressure, temperature, volume, params)
+                * self.isothermal_bulk_modulus_reuss(
+                    pressure, temperature, volume, params
+                )
                 * self.volume(pressure, temperature, params)
             ) / Cv
 

--- a/burnman/eos/cork.py
+++ b/burnman/eos/cork.py
@@ -49,7 +49,7 @@ class CORK(eos.EquationOfState):
         temperature, and volume.
         """
         alpha = self.thermal_expansivity(pressure, temperature, volume, params)
-        K_T = self.isothermal_bulk_modulus(pressure, temperature, volume, params)
+        K_T = self.isothermal_bulk_modulus_reuss(pressure, temperature, volume, params)
         C_V = self.molar_heat_capacity_v(pressure, temperature, volume, params)
         return alpha * K_T * volume / C_V
 
@@ -75,7 +75,7 @@ class CORK(eos.EquationOfState):
         )
         return V
 
-    def isothermal_bulk_modulus(self, pressure, temperature, volume, params):
+    def isothermal_bulk_modulus_reuss(self, pressure, temperature, volume, params):
         """
         Returns isothermal bulk modulus [Pa] as a function of pressure [Pa],
         temperature [K], and volume [m^3].  EQ 13+2
@@ -119,7 +119,7 @@ class CORK(eos.EquationOfState):
         C_p = self.molar_heat_capacity_p(pressure, temperature, volume, params)
         V = self.volume(pressure, temperature, params)
         alpha = self.thermal_expansivity(pressure, temperature, volume, params)
-        K_T = self.isothermal_bulk_modulus(pressure, temperature, volume, params)
+        K_T = self.isothermal_bulk_modulus_reuss(pressure, temperature, volume, params)
         return C_p - V * temperature * alpha * alpha * K_T
 
     def thermal_expansivity(self, pressure, temperature, volume, params):
@@ -215,12 +215,12 @@ class CORK(eos.EquationOfState):
 
         return Cp0 - temperature * d2RTlnfdTdT
 
-    def adiabatic_bulk_modulus(self, pressure, temperature, volume, params):
+    def isentropic_bulk_modulus_reuss(self, pressure, temperature, volume, params):
         """
         Returns adiabatic bulk modulus [Pa] as a function of pressure [Pa],
         temperature [K], and volume [m^3].
         """
-        K_T = self.isothermal_bulk_modulus(pressure, temperature, volume, params)
+        K_T = self.isothermal_bulk_modulus_reuss(pressure, temperature, volume, params)
         C_p = self.molar_heat_capacity_p(pressure, temperature, volume, params)
         C_v = self.molar_heat_capacity_v(pressure, temperature, volume, params)
         K_S = K_T * C_p / C_v

--- a/burnman/eos/dks_liquid.py
+++ b/burnman/eos/dks_liquid.py
@@ -606,7 +606,7 @@ class DKS_L(eos.EquationOfState):
             )
         return opt.brentq(_delta_pressure, sol[0], sol[1], args=args)
 
-    def isothermal_bulk_modulus(self, pressure, temperature, volume, params):
+    def isothermal_bulk_modulus_reuss(self, pressure, temperature, volume, params):
         """
         Returns isothermal bulk modulus :math:`[Pa]`
         """
@@ -618,11 +618,13 @@ class DKS_L(eos.EquationOfState):
         )
         return K_T
 
-    def adiabatic_bulk_modulus(self, pressure, temperature, volume, params):
+    def isentropic_bulk_modulus_reuss(self, pressure, temperature, volume, params):
         """
         Returns adiabatic bulk modulus. :math:`[Pa]`
         """
-        K_S = self.isothermal_bulk_modulus(pressure, temperature, volume, params) * (
+        K_S = self.isothermal_bulk_modulus_reuss(
+            pressure, temperature, volume, params
+        ) * (
             1.0
             + temperature
             * self.thermal_expansivity(pressure, temperature, volume, params)
@@ -676,9 +678,9 @@ class DKS_L(eos.EquationOfState):
         """
         Returns thermal expansivity. :math:`[1/K]`
         """
-        alpha = self._aK_T(temperature, volume, params) / self.isothermal_bulk_modulus(
-            0.0, temperature, volume, params
-        )
+        alpha = self._aK_T(
+            temperature, volume, params
+        ) / self.isothermal_bulk_modulus_reuss(0.0, temperature, volume, params)
         return alpha
 
     def gibbs_free_energy(self, pressure, temperature, volume, params):

--- a/burnman/eos/dks_solid.py
+++ b/burnman/eos/dks_solid.py
@@ -186,7 +186,7 @@ class DKS_S(eos.EquationOfState):
             params["V_0"], volume, params["grueneisen_0"], params["q_0"]
         )
 
-    def isothermal_bulk_modulus(self, pressure, temperature, volume, params):
+    def isothermal_bulk_modulus_reuss(self, pressure, temperature, volume, params):
         """
         Returns isothermal bulk modulus :math:`[Pa]`
         """
@@ -202,11 +202,11 @@ class DKS_S(eos.EquationOfState):
 
         return K
 
-    def adiabatic_bulk_modulus(self, pressure, temperature, volume, params):
+    def isentropic_bulk_modulus_reuss(self, pressure, temperature, volume, params):
         """
         Returns adiabatic bulk modulus. :math:`[Pa]`
         """
-        K_T = self.isothermal_bulk_modulus(pressure, temperature, volume, params)
+        K_T = self.isothermal_bulk_modulus_reuss(pressure, temperature, volume, params)
         alpha = self.thermal_expansivity(pressure, temperature, volume, params)
         gr = self.grueneisen_parameter(pressure, temperature, volume, params)
         K_S = K_T * (1.0 + gr * alpha * temperature)
@@ -246,7 +246,7 @@ class DKS_S(eos.EquationOfState):
         """
         C_v = self.molar_heat_capacity_v(pressure, temperature, volume, params)
         gr = self.grueneisen_parameter(pressure, temperature, volume, params)
-        K = self.isothermal_bulk_modulus(pressure, temperature, volume, params)
+        K = self.isothermal_bulk_modulus_reuss(pressure, temperature, volume, params)
         alpha = gr * C_v / K / volume
         return alpha
 

--- a/burnman/eos/equation_of_state.py
+++ b/burnman/eos/equation_of_state.py
@@ -103,7 +103,7 @@ class EquationOfState(object):
         """
         raise NotImplementedError("")
 
-    def isothermal_bulk_modulus(self, pressure, temperature, volume, params):
+    def isothermal_bulk_modulus_reuss(self, pressure, temperature, volume, params):
         """
         :param pressure: Pressure at which to evaluate the equation of state
             :math:`[Pa]`.
@@ -126,7 +126,7 @@ class EquationOfState(object):
         """
         raise NotImplementedError("")
 
-    def adiabatic_bulk_modulus(self, pressure, temperature, volume, params):
+    def isentropic_bulk_modulus_reuss(self, pressure, temperature, volume, params):
         """
         :param pressure: Pressure at which to evaluate the equation of state
             :math:`[Pa]`.

--- a/burnman/eos/hp.py
+++ b/burnman/eos/hp.py
@@ -51,11 +51,11 @@ class HP_TMT(eos.EquationOfState):
         temperature, and volume.
         """
         alpha = self.thermal_expansivity(pressure, temperature, volume, params)
-        K_T = self.isothermal_bulk_modulus(pressure, temperature, volume, params)
+        K_T = self.isothermal_bulk_modulus_reuss(pressure, temperature, volume, params)
         C_V = self.molar_heat_capacity_v(pressure, temperature, volume, params)
         return alpha * K_T * volume / C_V
 
-    def isothermal_bulk_modulus(self, pressure, temperature, volume, params):
+    def isothermal_bulk_modulus_reuss(self, pressure, temperature, volume, params):
         """
         Returns isothermal bulk modulus [Pa] as a function of pressure [Pa],
         temperature [K], and volume [m^3].  EQ 13+2
@@ -81,7 +81,7 @@ class HP_TMT(eos.EquationOfState):
         C_p = self.molar_heat_capacity_p(pressure, temperature, volume, params)
         V = self.volume(pressure, temperature, params)
         alpha = self.thermal_expansivity(pressure, temperature, volume, params)
-        K_T = self.isothermal_bulk_modulus(pressure, temperature, volume, params)
+        K_T = self.isothermal_bulk_modulus_reuss(pressure, temperature, volume, params)
         return C_p - V * temperature * alpha * alpha * K_T
 
     def thermal_expansivity(self, pressure, temperature, volume, params):
@@ -133,12 +133,12 @@ class HP_TMT(eos.EquationOfState):
         C_p = C_v * (1.0 + gr * alpha * temperature)
         return C_p
 
-    def adiabatic_bulk_modulus(self, pressure, temperature, volume, params):
+    def isentropic_bulk_modulus_reuss(self, pressure, temperature, volume, params):
         """
         Returns adiabatic bulk modulus [Pa] as a function of pressure [Pa],
         temperature [K], and volume [m^3].
         """
-        K_T = self.isothermal_bulk_modulus(pressure, temperature, volume, params)
+        K_T = self.isothermal_bulk_modulus_reuss(pressure, temperature, volume, params)
         C_p = self.molar_heat_capacity_p(pressure, temperature, volume, params)
         C_v = self.molar_heat_capacity_v(pressure, temperature, volume, params)
         K_S = K_T * C_p / C_v
@@ -436,11 +436,11 @@ class HP_TMTL(eos.EquationOfState):
         temperature, and volume.
         """
         alpha = self.thermal_expansivity(pressure, temperature, volume, params)
-        K_T = self.isothermal_bulk_modulus(pressure, temperature, volume, params)
+        K_T = self.isothermal_bulk_modulus_reuss(pressure, temperature, volume, params)
         C_V = self.molar_heat_capacity_v(pressure, temperature, volume, params)
         return alpha * K_T * volume / C_V
 
-    def isothermal_bulk_modulus(self, pressure, temperature, volume, params):
+    def isothermal_bulk_modulus_reuss(self, pressure, temperature, volume, params):
         """
         Returns isothermal bulk modulus [Pa] as a function of pressure [Pa],
         temperature [K], and volume [m^3].
@@ -467,7 +467,7 @@ class HP_TMTL(eos.EquationOfState):
         C_p = self.molar_heat_capacity_p(pressure, temperature, volume, params)
         V = self.volume(pressure, temperature, params)
         alpha = self.thermal_expansivity(pressure, temperature, volume, params)
-        K_T = self.isothermal_bulk_modulus(pressure, temperature, volume, params)
+        K_T = self.isothermal_bulk_modulus_reuss(pressure, temperature, volume, params)
         return C_p - V * temperature * alpha * alpha * K_T
 
     def thermal_expansivity(self, pressure, temperature, volume, params):
@@ -502,12 +502,12 @@ class HP_TMTL(eos.EquationOfState):
         )
         return Cp
 
-    def adiabatic_bulk_modulus(self, pressure, temperature, volume, params):
+    def isentropic_bulk_modulus_reuss(self, pressure, temperature, volume, params):
         """
         Returns adiabatic bulk modulus [Pa] as a function of pressure [Pa],
         temperature [K], and volume [m^3].
         """
-        K_T = self.isothermal_bulk_modulus(pressure, temperature, volume, params)
+        K_T = self.isothermal_bulk_modulus_reuss(pressure, temperature, volume, params)
         C_p = self.molar_heat_capacity_p(pressure, temperature, volume, params)
         C_v = self.molar_heat_capacity_v(pressure, temperature, volume, params)
         K_S = K_T * C_p / C_v
@@ -714,11 +714,11 @@ class HP98(eos.EquationOfState):
         temperature, and volume.
         """
         alpha = self.thermal_expansivity(pressure, temperature, volume, params)
-        K_T = self.isothermal_bulk_modulus(pressure, temperature, volume, params)
+        K_T = self.isothermal_bulk_modulus_reuss(pressure, temperature, volume, params)
         C_V = self.molar_heat_capacity_v(pressure, temperature, volume, params)
         return alpha * K_T * volume / C_V
 
-    def isothermal_bulk_modulus(self, pressure, temperature, volume, params):
+    def isothermal_bulk_modulus_reuss(self, pressure, temperature, volume, params):
         """
         Returns isothermal bulk modulus [Pa] as a function of pressure [Pa],
         temperature [K], and volume [m^3].
@@ -745,7 +745,7 @@ class HP98(eos.EquationOfState):
         C_p = self.molar_heat_capacity_p(pressure, temperature, volume, params)
         V = self.volume(pressure, temperature, params)
         alpha = self.thermal_expansivity(pressure, temperature, volume, params)
-        K_T = self.isothermal_bulk_modulus(pressure, temperature, volume, params)
+        K_T = self.isothermal_bulk_modulus_reuss(pressure, temperature, volume, params)
         return C_p - V * temperature * alpha * alpha * K_T
 
     def thermal_expansivity(self, pressure, temperature, volume, params):
@@ -782,12 +782,12 @@ class HP98(eos.EquationOfState):
         )
         return Cp
 
-    def adiabatic_bulk_modulus(self, pressure, temperature, volume, params):
+    def isentropic_bulk_modulus_reuss(self, pressure, temperature, volume, params):
         """
         Returns adiabatic bulk modulus [Pa] as a function of pressure [Pa],
         temperature [K], and volume [m^3].
         """
-        K_T = self.isothermal_bulk_modulus(pressure, temperature, volume, params)
+        K_T = self.isothermal_bulk_modulus_reuss(pressure, temperature, volume, params)
         C_p = self.molar_heat_capacity_p(pressure, temperature, volume, params)
         C_v = self.molar_heat_capacity_v(pressure, temperature, volume, params)
         K_S = K_T * C_p / C_v

--- a/burnman/eos/mie_grueneisen_debye.py
+++ b/burnman/eos/mie_grueneisen_debye.py
@@ -52,7 +52,7 @@ class MGDBase(eos.EquationOfState):
             )
         return opt.brentq(func, sol[0], sol[1])
 
-    def isothermal_bulk_modulus(self, pressure, temperature, volume, params):
+    def isothermal_bulk_modulus_reuss(self, pressure, temperature, volume, params):
         """
         Returns isothermal bulk modulus [Pa] as a function of pressure [Pa],
         temperature [K], and volume [m^3].  EQ B8
@@ -102,7 +102,7 @@ class MGDBase(eos.EquationOfState):
         """
         C_v = self.molar_heat_capacity_v(pressure, temperature, volume, params)
         gr = self._grueneisen_parameter(params["V_0"] / volume, params)
-        K = self.isothermal_bulk_modulus(pressure, temperature, volume, params)
+        K = self.isothermal_bulk_modulus_reuss(pressure, temperature, volume, params)
         alpha = gr * C_v / K / volume
         return alpha
 
@@ -117,12 +117,12 @@ class MGDBase(eos.EquationOfState):
         C_p = C_v * (1.0 + gr * alpha * temperature)
         return C_p
 
-    def adiabatic_bulk_modulus(self, pressure, temperature, volume, params):
+    def isentropic_bulk_modulus_reuss(self, pressure, temperature, volume, params):
         """
         Returns adiabatic bulk modulus [Pa] as a function of pressure [Pa],
         temperature [K], and volume [m^3].  EQ D6
         """
-        K_T = self.isothermal_bulk_modulus(pressure, temperature, volume, params)
+        K_T = self.isothermal_bulk_modulus_reuss(pressure, temperature, volume, params)
         alpha = self.thermal_expansivity(pressure, temperature, volume, params)
         gr = self._grueneisen_parameter(params["V_0"] / volume, params)
         K_S = K_T * (1.0 + gr * alpha * temperature)

--- a/burnman/eos/modified_tait.py
+++ b/burnman/eos/modified_tait.py
@@ -115,13 +115,13 @@ class MT(eos.EquationOfState):
         """
         return modified_tait(params["V_0"] / volume, params)
 
-    def isothermal_bulk_modulus(self, pressure, temperature, volume, params):
+    def isothermal_bulk_modulus_reuss(self, pressure, temperature, volume, params):
         """
         Returns isothermal bulk modulus :math:`K_T` of the mineral. :math:`[Pa]`.
         """
         return bulk_modulus(pressure, params)
 
-    def adiabatic_bulk_modulus(self, pressure, temperature, volume, params):
+    def isentropic_bulk_modulus_reuss(self, pressure, temperature, volume, params):
         """
         Since this equation of state does not contain temperature effects, simply return a very large number. :math:`[Pa]`
         """

--- a/burnman/eos/morse_potential.py
+++ b/burnman/eos/morse_potential.py
@@ -90,14 +90,14 @@ class Morse(eos.EquationOfState):
     def pressure(self, temperature, volume, params):
         return morse_potential(volume / params["V_0"], params)
 
-    def isothermal_bulk_modulus(self, pressure, temperature, volume, params):
+    def isothermal_bulk_modulus_reuss(self, pressure, temperature, volume, params):
         """
         Returns isothermal bulk modulus :math:`K_T` :math:`[Pa]` as a function of pressure :math:`[Pa]`,
         temperature :math:`[K]` and volume :math:`[m^3]`.
         """
         return bulk_modulus(volume, params)
 
-    def adiabatic_bulk_modulus(self, pressure, temperature, volume, params):
+    def isentropic_bulk_modulus_reuss(self, pressure, temperature, volume, params):
         """
         Returns adiabatic bulk modulus :math:`K_s` of the mineral. :math:`[Pa]`.
         """

--- a/burnman/eos/murnaghan.py
+++ b/burnman/eos/murnaghan.py
@@ -53,7 +53,7 @@ class Murnaghan(eos.EquationOfState):
     def pressure(self, temperature, volume, params):
         return pressure(volume, params["V_0"], params["K_0"], params["Kprime_0"])
 
-    def isothermal_bulk_modulus(self, pressure, temperature, volume, params):
+    def isothermal_bulk_modulus_reuss(self, pressure, temperature, volume, params):
         """
         Returns isothermal bulk modulus :math:`K_T` :math:`[Pa]`
         as a function of pressure :math:`[Pa]`,
@@ -61,7 +61,7 @@ class Murnaghan(eos.EquationOfState):
         """
         return bulk_modulus(pressure, params["K_0"], params["Kprime_0"])
 
-    def adiabatic_bulk_modulus(self, pressure, temperature, volume, params):
+    def isentropic_bulk_modulus_reuss(self, pressure, temperature, volume, params):
         """
         Returns adiabatic bulk modulus :math:`K_s` of the mineral. :math:`[Pa]`.
         """

--- a/burnman/eos/reciprocal_kprime.py
+++ b/burnman/eos/reciprocal_kprime.py
@@ -175,14 +175,14 @@ class RKprime(eos.EquationOfState):
             )
         )
 
-    def isothermal_bulk_modulus(self, pressure, temperature, volume, params):
+    def isothermal_bulk_modulus_reuss(self, pressure, temperature, volume, params):
         """
         Returns isothermal bulk modulus :math:`K_T` :math:`[Pa]` as a function of pressure :math:`[Pa]`,
         temperature :math:`[K]` and volume :math:`[m^3]`.
         """
         return bulk_modulus(pressure, params)
 
-    def adiabatic_bulk_modulus(self, pressure, temperature, volume, params):
+    def isentropic_bulk_modulus_reuss(self, pressure, temperature, volume, params):
         """
         Returns adiabatic bulk modulus :math:`K_s` of the mineral. :math:`[Pa]`.
         """
@@ -231,7 +231,7 @@ class RKprime(eos.EquationOfState):
         Returns the Gibbs free energy :math:`\\mathcal{G}` of the mineral. :math:`[J/mol]`
         """
         # G = E0 + int VdP (when S = 0)
-        K = self.isothermal_bulk_modulus(pressure, temperature, volume, params)
+        K = self.isothermal_bulk_modulus_reuss(pressure, temperature, volume, params)
         return (
             params["E_0"]
             + params["P_0"] * params["V_0"]

--- a/burnman/eos/slb.py
+++ b/burnman/eos/slb.py
@@ -210,7 +210,7 @@ class SLBBase(eos.EquationOfState):
             # or (b) using that pressure to create a better bracket for
             # brentq.
             def _K_T(V, T, params):
-                return self.isothermal_bulk_modulus(0.0, T, V, params)
+                return self.isothermal_bulk_modulus_reuss(0.0, T, V, params)
 
             sol_K_T = bracket(_K_T, V_0, dV, args=(temperature, params))
             V_crit = opt.brentq(
@@ -268,7 +268,7 @@ class SLBBase(eos.EquationOfState):
             params["V_0"], volume, params["grueneisen_0"], params["q_0"]
         )
 
-    def isothermal_bulk_modulus(self, pressure, temperature, volume, params):
+    def isothermal_bulk_modulus_reuss(self, pressure, temperature, volume, params):
         """
         Returns isothermal bulk modulus :math:`[Pa]`
         """
@@ -296,11 +296,11 @@ class SLBBase(eos.EquationOfState):
 
         return K
 
-    def adiabatic_bulk_modulus(self, pressure, temperature, volume, params):
+    def isentropic_bulk_modulus_reuss(self, pressure, temperature, volume, params):
         """
         Returns adiabatic bulk modulus. :math:`[Pa]`
         """
-        K_T = self.isothermal_bulk_modulus(pressure, temperature, volume, params)
+        K_T = self.isothermal_bulk_modulus_reuss(pressure, temperature, volume, params)
         alpha = self.thermal_expansivity(pressure, temperature, volume, params)
         gr = self.grueneisen_parameter(pressure, temperature, volume, params)
         K_S = K_T * (1.0 + gr * alpha * temperature)
@@ -353,7 +353,7 @@ class SLBBase(eos.EquationOfState):
         """
         C_v = self.molar_heat_capacity_v(pressure, temperature, volume, params)
         gr = self.grueneisen_parameter(pressure, temperature, volume, params)
-        K = self.isothermal_bulk_modulus(pressure, temperature, volume, params)
+        K = self.isothermal_bulk_modulus_reuss(pressure, temperature, volume, params)
         alpha = gr * C_v / K / volume
         return alpha
 

--- a/burnman/eos/vinet.py
+++ b/burnman/eos/vinet.py
@@ -73,14 +73,14 @@ class Vinet(eos.EquationOfState):
     def pressure(self, temperature, volume, params):
         return vinet(volume / params["V_0"], params)
 
-    def isothermal_bulk_modulus(self, pressure, temperature, volume, params):
+    def isothermal_bulk_modulus_reuss(self, pressure, temperature, volume, params):
         """
         Returns isothermal bulk modulus :math:`K_T` :math:`[Pa]` as a function of pressure :math:`[Pa]`,
         temperature :math:`[K]` and volume :math:`[m^3]`.
         """
         return bulk_modulus(volume, params)
 
-    def adiabatic_bulk_modulus(self, pressure, temperature, volume, params):
+    def isentropic_bulk_modulus_reuss(self, pressure, temperature, volume, params):
         """
         Returns adiabatic bulk modulus :math:`K_s` of the mineral. :math:`[Pa]`.
         """

--- a/contrib/CHRU2014/paper_benchmark.py
+++ b/contrib/CHRU2014/paper_benchmark.py
@@ -92,9 +92,11 @@ def check_slb_fig7_txt():
         forsterite.set_state(pressure[i], temperature[i])
         rho_comp[i] = 100.0 * (forsterite.density / 1000.0 - rho[i]) / rho[i]
         Kt_comp[i] = (
-            100.0 * (forsterite.isothermal_bulk_modulus / 1.0e9 - Kt[i]) / Kt[i]
+            100.0 * (forsterite.isothermal_bulk_modulus_reuss / 1.0e9 - Kt[i]) / Kt[i]
         )
-        Ks_comp[i] = 100.0 * (forsterite.adiabatic_bulk_modulus / 1.0e9 - Ks[i]) / Ks[i]
+        Ks_comp[i] = (
+            100.0 * (forsterite.isentropic_bulk_modulus_reuss / 1.0e9 - Ks[i]) / Ks[i]
+        )
         G_comp[i] = 100.0 * (forsterite.shear_modulus / 1.0e9 - G[i]) / G[i]
         VB_comp[i] = 100.0 * (forsterite.v_phi / 1000.0 - VB[i]) / VB[i]
         VS_comp[i] = 100.0 * (forsterite.v_s / 1000.0 - VS[i]) / VS[i]

--- a/examples/example_add_shear_modulus.py
+++ b/examples/example_add_shear_modulus.py
@@ -50,7 +50,9 @@ if __name__ == "__main__":
             f = 0.5 * (np.power(x, 2.0 / 3.0) - 1.0)
             f2 = np.power(1.0 + 2.0 * f, 5.0 / 2.0)
             G_T = params["shear_modulus_0"] * np.exp(-gamma * phi)
-            K_PT = self.isothermal_bulk_modulus(pressure, temperature, volume, params)
+            K_PT = self.isothermal_bulk_modulus_reuss(
+                pressure, temperature, volume, params
+            )
             K_T = K_PT / ((1.0 - f * (5.0 - 3.0 * params["Kprime_0"])) * f2)
             G = G_T * f2 * (1.0 - f * (5.0 - 3.0 * params["Gprime_0"] * K_T / G_T))
             return G

--- a/examples/example_geodynamic_adiabat.py
+++ b/examples/example_geodynamic_adiabat.py
@@ -154,7 +154,7 @@ if __name__ == "__main__":
             "rho",
             "molar_heat_capacity_p",
             "thermal_expansivity",
-            "isothermal_compressibility",
+            "isothermal_compressibility_reuss",
             "p_wave_velocity",
             "shear_wave_velocity",
         ],

--- a/misc/benchmarks/benchmark.py
+++ b/misc/benchmarks/benchmark.py
@@ -558,9 +558,11 @@ def check_slb_fig7_txt():
         forsterite.set_state(pressure[i], temperature[i])
         rho_comp[i] = 100.0 * (forsterite.density / 1000.0 - rho[i]) / rho[i]
         Kt_comp[i] = (
-            100.0 * (forsterite.isothermal_bulk_modulus / 1.0e9 - Kt[i]) / Kt[i]
+            100.0 * (forsterite.isothermal_bulk_modulus_reuss / 1.0e9 - Kt[i]) / Kt[i]
         )
-        Ks_comp[i] = 100.0 * (forsterite.adiabatic_bulk_modulus / 1.0e9 - Ks[i]) / Ks[i]
+        Ks_comp[i] = (
+            100.0 * (forsterite.isentropic_bulk_modulus_reuss / 1.0e9 - Ks[i]) / Ks[i]
+        )
         G_comp[i] = 100.0 * (forsterite.shear_modulus / 1.0e9 - G[i]) / G[i]
         VB_comp[i] = 100.0 * (forsterite.v_phi / 1000.0 - VB[i]) / VB[i]
         VS_comp[i] = 100.0 * (forsterite.v_s / 1000.0 - VS[i]) / VS[i]
@@ -646,13 +648,13 @@ def check_slb_fig7():
 
     pressure = 1.0e5
     forsterite.set_state(pressure, 300.0)
-    Ks_0 = forsterite.adiabatic_bulk_modulus
+    Ks_0 = forsterite.isentropic_bulk_modulus_reuss
 
     # calculate its thermal properties
     for i in range(len(temperature)):
         forsterite.set_state(pressure, temperature[i])
         volume[i] = forsterite.molar_volume / forsterite.params["V_0"]
-        bulk_modulus[i] = forsterite.adiabatic_bulk_modulus / Ks_0
+        bulk_modulus[i] = forsterite.isentropic_bulk_modulus_reuss / Ks_0
         shear_modulus[i] = forsterite.shear_modulus / forsterite.params["G_0"]
         heat_capacity[i] = forsterite.molar_heat_capacity_p / forsterite.params["n"]
 

--- a/tests/test_composite.py
+++ b/tests/test_composite.py
@@ -303,12 +303,13 @@ class composite(BurnManTest):
 
         self.assertFloatEqual(rock1.molar_volume, min1.params["V_0"])
         self.assertFloatEqual(rock1.molar_mass, min1.params["molar_mass"])
-        self.assertFloatEqual(rock1.isothermal_bulk_modulus, min1.params["K_0"])
+        self.assertFloatEqual(rock1.isothermal_bulk_modulus_reuss, min1.params["K_0"])
         self.assertFloatEqual(
-            rock1.isothermal_compressibility, 1.0 / min1.params["K_0"]
+            rock1.isothermal_compressibility_reuss, 1.0 / min1.params["K_0"]
         )
         self.assertFloatEqual(
-            rock1.adiabatic_compressibility, 1.0 / rock1.adiabatic_bulk_modulus
+            rock1.isentropic_compressibility_reuss,
+            1.0 / rock1.isentropic_bulk_modulus_reuss,
         )
         self.assertFloatEqual(rock1.grueneisen_parameter, min1.params["grueneisen_0"])
         self.assertFloatEqual(rock1.thermal_expansivity, min1.alpha)

--- a/tests/test_endmembers.py
+++ b/tests/test_endmembers.py
@@ -93,14 +93,16 @@ class test_endmembers(BurnManTest):
         bdg = burnman.minerals.Matas_etal_2007.mg_perovskite()
         bdg.set_state(1.0e5, 300.0)
         self.assertFloatEqual(bdg.grueneisen_parameter, bdg.params["grueneisen_0"])
-        self.assertFloatEqual(bdg.isothermal_bulk_modulus, bdg.params["K_0"])
+        self.assertFloatEqual(bdg.isothermal_bulk_modulus_reuss, bdg.params["K_0"])
         self.assertFloatEqual(bdg.molar_volume, bdg.params["V_0"])
         self.assertFloatEqual(bdg.shear_modulus, bdg.params["G_0"])
         bdg.set_state(1.0e5, 0.0)
         self.assertFloatEqual(bdg.molar_heat_capacity_v, 0.0)
         self.assertFloatEqual(bdg.molar_heat_capacity_p, 0.0)
         self.assertFloatEqual(bdg.thermal_expansivity, 0.0)
-        self.assertFloatEqual(bdg.isothermal_bulk_modulus, bdg.adiabatic_bulk_modulus)
+        self.assertFloatEqual(
+            bdg.isothermal_bulk_modulus_reuss, bdg.isentropic_bulk_modulus_reuss
+        )
 
     def test_make_mbr(self):
         bdg = burnman.minerals.SLB_2011.mg_perovskite()

--- a/tests/test_eos.py
+++ b/tests/test_eos.py
@@ -152,15 +152,15 @@ class eos(BurnManTest):
         for i in eoses:
             Volume_test = i.volume(pressure, temperature, rock.params)
             self.assertFloatEqual(Volume_test, rock.params["V_0"])
-            Kt_test = i.isothermal_bulk_modulus(
+            Kt_test = i.isothermal_bulk_modulus_reuss(
                 pressure, 300.0, rock.params["V_0"], rock.params
             )
             self.assertFloatEqual(Kt_test, rock.params["K_0"])
             # K_S is based on 0 reference temperature:
-            Kt_test = i.isothermal_bulk_modulus(
+            Kt_test = i.isothermal_bulk_modulus_reuss(
                 pressure, 0.0, rock.params["V_0"], rock.params
             )
-            K_test = i.adiabatic_bulk_modulus(
+            K_test = i.isentropic_bulk_modulus_reuss(
                 pressure, 0.0, rock.params["V_0"], rock.params
             )
             self.assertFloatEqual(K_test, Kt_test)
@@ -212,7 +212,7 @@ class eos(BurnManTest):
 
         Volume_test = eos.volume(pressure, temperature, rock.params)
         self.assertFloatEqual(Volume_test, rock.params["V_0"])
-        Kt_test = eos.isothermal_bulk_modulus(
+        Kt_test = eos.isothermal_bulk_modulus_reuss(
             pressure, 300.0, rock.params["V_0"], rock.params
         )
         self.assertFloatEqual(Kt_test, rock.params["K_0"])
@@ -229,7 +229,7 @@ class eos(BurnManTest):
 
         Volume_test = eos.volume(pressure, temperature, rock.params)
         self.assertFloatEqual(Volume_test, rock.params["V_0"])
-        Kt_test = eos.isothermal_bulk_modulus(
+        Kt_test = eos.isothermal_bulk_modulus_reuss(
             pressure, 300.0, rock.params["V_0"], rock.params
         )
         self.assertFloatEqual(Kt_test, rock.params["K_0"])
@@ -245,7 +245,7 @@ class eos(BurnManTest):
         eos = burnman.eos.Morse()
         Volume_test = eos.volume(pressure, temperature, rock.params)
         self.assertFloatEqual(Volume_test, rock.params["V_0"])
-        Kt_test = eos.isothermal_bulk_modulus(
+        Kt_test = eos.isothermal_bulk_modulus_reuss(
             pressure, 300.0, rock.params["V_0"], rock.params
         )
         self.assertFloatEqual(Kt_test, rock.params["K_0"])
@@ -261,7 +261,7 @@ class eos(BurnManTest):
         eos = burnman.eos.RKprime()
         Volume_test = eos.volume(pressure, temperature, rock.params)
         self.assertFloatEqual(Volume_test, rock.params["V_0"])
-        Kt_test = eos.isothermal_bulk_modulus(
+        Kt_test = eos.isothermal_bulk_modulus_reuss(
             pressure, 300.0, rock.params["V_0"], rock.params
         )
         self.assertFloatEqual(Kt_test, rock.params["K_0"])
@@ -277,7 +277,7 @@ class eos(BurnManTest):
         eos = burnman.eos.AA()
         Volume_test = eos.volume(pressure, temperature, rock.params)
         self.assertFloatEqual(Volume_test, rock.params["V_0"])
-        Ks_test = eos.adiabatic_bulk_modulus(
+        Ks_test = eos.isentropic_bulk_modulus_reuss(
             pressure, temperature, rock.params["V_0"], rock.params
         )
         self.assertFloatEqual(Ks_test, rock.params["K_S"])

--- a/tests/test_perplex.py
+++ b/tests/test_perplex.py
@@ -24,7 +24,7 @@ class PerpleX(BurnManTest):
                 "grueneisen_parameter",
                 "alpha",
                 "V",
-                "adiabatic_bulk_modulus",
+                "isentropic_bulk_modulus_reuss",
                 "molar_heat_capacity_p",
             ],
             [10.0e9, 11.0e9],


### PR DESCRIPTION
Naming conventions for scalar bulk moduli and compressibilities in BurnMan were always vague, and the ambiguity has become relevant with the introduction of anisotropic models. 

To fix this, the primary functions for scalar bulk moduli have been appended with the word "_reuss" (i.e. these are isostress, or Reuss properties). 

Because this is a breaking change, I have also taken the opportunity to rename adiabatic properties to be isentropic. This is a more valid name.

Aliases (K_T, K_S, beta_T, beta_S) remain the same as before, but are overridden in the AnisotropicMineral class.