### PR TITLE
replace K_T

### DIFF
--- a/burnman/classes/anisotropicmineral.py
+++ b/burnman/classes/anisotropicmineral.py
@@ -265,10 +265,10 @@ class AnisotropicMineral(Mineral, AnisotropicMaterial):
 
         self.isotropic_mineral.set_state(pressure, temperature)
         V2 = self.isotropic_mineral.V
-        KT2 = self.isotropic_mineral.K_T
+        KT2 = self.isotropic_mineral.isothermal_bulk_modulus_reuss
         self.isotropic_mineral.set_state_with_volume(V2, self.params["T_0"])
         P1 = self.isotropic_mineral.pressure
-        KT1 = self.isotropic_mineral.K_T
+        KT1 = self.isotropic_mineral.isothermal_bulk_modulus_reuss
         self.dPthdf = KT1 - KT2
         self.Pth = pressure - P1
 

--- a/burnman/optimize/eos_fitting.py
+++ b/burnman/optimize/eos_fitting.py
@@ -78,7 +78,7 @@ class MineralFit(object):
 
         if flag == "V":
             self.m.set_state(P, T)
-            dPdp = -self.m.K_T / self.m.V
+            dPdp = -self.m.isothermal_bulk_modulus_reuss / self.m.V
             dpdT = self.m.alpha * self.m.V
         elif flag == "H":
             self.m.set_state(P, T)
@@ -411,7 +411,7 @@ class SolutionFit(object):
 
         if flag == "V":
             self.m.set_state(P, T)
-            dPdp = -self.m.K_T / self.m.V
+            dPdp = -self.m.isothermal_bulk_modulus_reuss / self.m.V
             dpdT = self.m.alpha * self.m.V
         elif flag == "H":
             self.m.set_state(P, T)

--- a/burnman/tools/equilibration.py
+++ b/burnman/tools/equilibration.py
@@ -318,7 +318,9 @@ def jacobian(x, assemblage, equality_constraints, reduced_free_composition_vecto
         elif type_c == "V":  # dV/dx
             # dV/dP = -V/K_T, dV/dT = aV
             jacobian[ic, 0:2] = [
-                -assemblage.n_moles * assemblage.molar_volume / assemblage.K_T,
+                -assemblage.n_moles
+                * assemblage.molar_volume
+                / assemblage.isothermal_bulk_modulus_reuss,
                 assemblage.n_moles * assemblage.molar_volume,
             ]
             j = 2


### PR DESCRIPTION
In a couple of places in the code, `K_T` is used, but this is just an alias for `isothermal_bulk_modulus_reuss`.
This PR removes the use of the aliases in the code, as they are only meant to be convenience functions for the user.