### PR TITLE
allow evaluation with varying composition

### DIFF
--- a/tests/test_averaging.py
+++ b/tests/test_averaging.py
@@ -175,10 +175,10 @@ class Reuss(BurnManTest):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             rho, v_p, v_s, v_phi, K, G = rock.evaluate(
-                ["rho", "v_p", "v_s", "v_phi", "K_S", "G"], [10.0e9], [300.0]
+                ["rho", "v_p", "v_s", "v_phi", "K_S", "G"], 10.0e9, 300.0
             )
-            assert len(w) == 1  # we expect one error to be thrown when p_nonrigid = 0
-        self.assertFloatEqual(150.901, G[0] / 1.0e9)
+            assert len(w) == 2  # we expect two errors to be thrown when p_nonrigid = 0
+        self.assertFloatEqual(150.901, G / 1.0e9)
 
     def test_present_non_rigid_phase(self):
         rock = burnman.Composite([mypericlase(), my_nonrigid_mineral()], [0.5, 0.5])
@@ -186,10 +186,12 @@ class Reuss(BurnManTest):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             rho, v_p, v_s, v_phi, K, G = rock.evaluate(
-                ["rho", "v_p", "v_s", "v_phi", "K_S", "G"], [10.0e9], [300.0]
+                ["rho", "v_p", "v_s", "v_phi", "K_S", "G"], 10.0e9, 300.0
             )
-            assert len(w) == 2  # we expect two errors to be thrown when p_nonrigid != 0
-        self.assertFloatEqual(0.0, G[0] / 1.0e9)
+            assert (
+                len(w) == 4
+            )  # we expect four errors to be thrown when p_nonrigid != 0
+        self.assertFloatEqual(0.0, G / 1.0e9)
 
 
 class Voigt(BurnManTest):

--- a/tests/test_solidsolution.py
+++ b/tests/test_solidsolution.py
@@ -1203,6 +1203,21 @@ class test_solidsolution(BurnManTest):
             ss[0].activity_coefficients, ss[1].activity_coefficients
         )
 
+    def test_evaluate(self):
+        ol = olivine_ideal_ss()
+        molar_fractions = np.array([[0.1, 0.9], [0.2, 0.8]])
+        pressures = [1.0e9, 2.0e9]
+        temperatures = [300.0, 600.0]
+        G1 = ol.evaluate(["gibbs"], pressures, temperatures, molar_fractions)[0]
+
+        G2 = []
+        for i in range(2):
+            ol.set_state(pressures[i], temperatures[i])
+            ol.set_composition(molar_fractions[i])
+            G2.append(ol.gibbs)
+
+        self.assertArraysAlmostEqual(G1, G2)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR enables the user to pass an array of molar fractions to the evaluate method, so that solid solutions can be interrogated at a range of compositions. The method can now also be used to return higher order tensor output.