### PR TITLE
added required frame_convention argument to cell parameter conversions

### DIFF
--- a/tests/test_anisotropicmineral.py
+++ b/tests/test_anisotropicmineral.py
@@ -45,7 +45,7 @@ def make_forsterite(orthotropic=True):
         ]
     )
 
-    m = AnisotropicMineral(fo, cell_parameters, constants)
+    m = AnisotropicMineral(fo, cell_parameters, constants, [0, 1, 2])
     return m
 
 

--- a/tests/test_anisotropicsolution.py
+++ b/tests/test_anisotropicsolution.py
@@ -19,7 +19,10 @@ def make_nonorthotropic_mineral(a, b, c, alpha, beta, gamma, d, e, f):
     cell_parameters = np.array(
         [cell_lengths[0], cell_lengths[1], cell_lengths[2], alpha, beta, gamma]
     )
-    fo.params["V_0"] = np.linalg.det(cell_parameters_to_vectors(cell_parameters))
+    frame_convention = [0, 1, 2]
+    fo.params["V_0"] = np.linalg.det(
+        cell_parameters_to_vectors(cell_parameters, frame_convention)
+    )
     constants = np.zeros((6, 6, 3, 1))
     constants[:, :, 1, 0] = np.array(
         [
@@ -42,7 +45,7 @@ def make_nonorthotropic_mineral(a, b, c, alpha, beta, gamma, d, e, f):
         ]
     )
 
-    m = AnisotropicMineral(fo, cell_parameters, constants)
+    m = AnisotropicMineral(fo, cell_parameters, constants, frame_convention)
     return m
 
 


### PR DESCRIPTION
This PR makes the functions `utils.unitcell.cell_parameters_to_vectors()` and `utils.unitcell.vectors_to_cell_parameters()` more flexible by adding an additional argument `frame_convention`. This required argument takes a list of three integers that define the order of axes and vectors.

The convention dictates that the c[0]th cell vector is colinear with the c[0]th-axis, the c[1]th cell vector is perpendicular to the c[2]th-axis, and the c[2]th cell vector is defined to give a right-handed coordinate system. In common crystallographic shorthand, $x_{c_0}$ // $a_{c_0}$, $x_{c_2}$ // $a_{c_2}^*$.

The new argument is set to be required, as there is no "default" option for non-orthotropic materials - different conventions are more suitable for different materials.