### PR TITLE
enable pycddlib3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on: [push, pull_request, workflow_dispatch]
 jobs:  
   indent:
     name: indent
-    runs-on: [ubuntu-20.04]
+    runs-on: [ubuntu-24.04]
 
     strategy:
       matrix:
@@ -34,7 +34,7 @@ jobs:
 
   linux:
     name: test
-    runs-on: [ubuntu-20.04]
+    runs-on: [ubuntu-24.04]
 
     strategy:
       matrix:
@@ -48,14 +48,11 @@ jobs:
         python-version: ${{ matrix.python-versions }}
     - name: setup
       run: |
-        # pycddlib requires libgmp3-dev
         sudo apt update && sudo apt install --yes \
          numdiff \
-         libgmp3-dev \
          texlive \
          texlive-latex-extra
         python -m pip install --upgrade pip
-        pip install pycddlib==2.1.7 # this is optional
         pip install autograd # this is optional
         python --version
     - name: test

--- a/burnman/classes/polytope.py
+++ b/burnman/classes/polytope.py
@@ -18,17 +18,13 @@ from .material import cached_property
 
 from ..utils.math import independent_row_indices
 
-cdd_gmp_loaded = False
 
 try:
     cdd_fraction = importlib.import_module("cdd.gmp")
     cdd_gmp_loaded = True
-except ImportError as err:
+except ImportError:
     cdd_fraction = importlib.import_module("cdd")
-    print(
-        f"Warning: {err}. Only pycddlib-standalone is installed."
-        "For precise fractional representations of polytopes, please install pycddlib."
-    )
+    cdd_gmp_loaded = False
 
 
 class SimplexGrid(object):

--- a/burnman/tools/chemistry.py
+++ b/burnman/tools/chemistry.py
@@ -284,16 +284,23 @@ def reactions_from_stoichiometric_matrix(stoichiometric_matrix):
     ]
     reactions = []
     for p in polys:
-        v = np.array([[value for value in v] for v in p.raw_vertices])
+        v = np.array(
+            [
+                [Rational(value).limit_denominator(1000000) for value in v]
+                for v in p.raw_vertices
+            ]
+        )
 
         if v is not []:
             reactions.extend(v)
 
-    reactions = np.unique(np.array(reactions, dtype=float), axis=0)
-
-    reactions = np.array(
-        [[Rational(value).limit_denominator(1000000) for value in v] for v in reactions]
+    # There are many duplicate reactions produced by the above procedure
+    # Here we pick out the unique values
+    reactions = np.array(reactions)
+    _, unique_indices = np.unique(
+        np.array(reactions, dtype=float), return_index=True, axis=0
     )
+    reactions = reactions[unique_indices]  # return as rationals
 
     assert np.max(reactions[:-1, 0]) == 0
     assert np.max(reactions[-1, 1:]) == 0

--- a/burnman/tools/polytope.py
+++ b/burnman/tools/polytope.py
@@ -164,9 +164,7 @@ def composite_polytope_at_constrained_composition(
     eoccs = block_diag(*eoccs)
     inequalities = np.concatenate((np.zeros((len(eoccs), 1)), eoccs), axis=1)
 
-    return MaterialPolytope(
-        equalities, inequalities, number_type="float", return_fractions=return_fractions
-    )
+    return MaterialPolytope(equalities, inequalities, return_fractions=return_fractions)
 
 
 def simplify_composite_with_composition(composite, composition):

--- a/examples/example_polytopetools.py
+++ b/examples/example_polytopetools.py
@@ -35,6 +35,7 @@ composite polytope.
 """
 from __future__ import absolute_import
 import numpy as np
+from sympy import Rational
 
 import burnman
 from burnman.minerals import SLB_2011
@@ -197,14 +198,21 @@ if __name__ == "__main__":
     )
     print([formula_to_string(f) for f in assemblage.endmember_formulae])
 
+    # The conversions from Fraction to Rational below
+    # are solely for pretty-printing purposes.
     print(
         "Which led to the following extreme vertices satifying "
         "the bulk compositional constraints:"
     )
-    print(old_polytope.endmember_occupancies)
+
+    print(
+        np.array([[Rational(v) for v in i] for i in old_polytope.endmember_occupancies])
+    )
 
     print("\nThe new assemblage has fewer endmembers, with compositions:")
     print([formula_to_string(f) for f in new_assemblage.endmember_formulae])
 
     print("The same vertices now look like this:")
-    print(new_polytope.endmember_occupancies)
+    print(
+        np.array([[Rational(v) for v in i] for i in new_polytope.endmember_occupancies])
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ sympy = "^1.12"
 cvxpy = "^1.3"
 matplotlib = "^3.7"
 numba = "^0.59"
+pycddlib-standalone = "^3.0"
 
 [tool.poetry.dev-dependencies]
 ipython = "^8.5"

--- a/test.sh
+++ b/test.sh
@@ -29,8 +29,8 @@ $PYTHON -m pipdeptree -p burnman -d 1 2> /dev/null
 echo ""
 
 # Quietly install optional modules after burnman
-echo "Installing optional cvxpy, pycddlib, autograd and jupyter modules ..."
-$PYTHON -m pip install -q cvxpy pycddlib==2.1.7 autograd jupyter
+echo "Installing optional autograd and jupyter modules ..."
+$PYTHON -m pip install -q autograd jupyter
 echo ""
 
 function testit {


### PR DESCRIPTION
The update of pycddlib to Version 3 comes with several improvements:
- a standalone package (pycddlib-standalone) for float representations of polytopes that doesn't require non-python dependencies that can be difficult to install
- a separation of float and fraction modules that makes it easier to type check.
- several new convenience functions.

One downside of the new version is that the old github workflow for installation of the full pycddlib is broken, and I can't figure out how to make the necessary changes.

In this PR, I've added pycddlib-standalone as a dependency, and changed the polytope functions to allow either pycddlib-standalone or the full pycddlib module. If cdd.gmp (the Fractions module) is not found, any calculations that would have used that module instead use cdd (the floats module).