### PR TITLE
Ensure not_in_site is string and not filter

### DIFF
--- a/burnman/utils/chemistry.py
+++ b/burnman/utils/chemistry.py
@@ -402,7 +402,7 @@ def process_solution_chemistry(solution_model):
 
             # Loop over species after site
             if len(site_split) != 1:
-                not_in_site = str(filter(None, site_split[1]))
+                not_in_site = site_split[1].strip()
                 not_in_site = not_in_site.replace(mult, "", 1)
                 for enamenumber in re.findall("[A-Z][^A-Z]*", not_in_site):
                     sp = list(filter(None, re.split(r"(\d+)", enamenumber)))


### PR DESCRIPTION
This PR fixes issue #620. 
re.findall fails silently on a filter (returned by `str(filter(None, site_split[1]))`)
solution_formulae doesn't seem to be used anywhere else in the codebase, so section could be removed instead of merging this PR.