### PR TITLE
removed solution_formulae and renamed formulas to site_formulae

### DIFF
--- a/burnman/classes/elasticsolutionmodel.py
+++ b/burnman/classes/elasticsolutionmodel.py
@@ -227,7 +227,7 @@ class ElasticMechanicalSolution(ElasticSolutionModel):
     def __init__(self, endmembers):
         self.endmembers = endmembers
         self.n_endmembers = len(endmembers)
-        self.formulas = [e[1] for e in endmembers]
+        self.site_formulae = [e[1] for e in endmembers]
 
     def excess_helmholtz_energy(self, volume, temperature, molar_fractions):
         return 0.0
@@ -263,7 +263,7 @@ class ElasticIdealSolution(ElasticSolutionModel):
     def __init__(self, endmembers):
         self.endmembers = endmembers
         self.n_endmembers = len(endmembers)
-        self.formulas = [e[1] for e in endmembers]
+        self.site_formulae = [e[1] for e in endmembers]
 
         # Process solution chemistry
         process_solution_chemistry(self)

--- a/burnman/classes/solutionmodel.py
+++ b/burnman/classes/solutionmodel.py
@@ -374,7 +374,7 @@ class MechanicalSolution(SolutionModel):
     def __init__(self, endmembers):
         self.endmembers = endmembers
         self.n_endmembers = len(endmembers)
-        self.formulas = [e[1] for e in endmembers]
+        self.site_formulae = [e[1] for e in endmembers]
 
     def excess_gibbs_free_energy(self, pressure, temperature, molar_fractions):
         return 0.0
@@ -421,7 +421,7 @@ class IdealSolution(SolutionModel):
     def __init__(self, endmembers):
         self.endmembers = endmembers
         self.n_endmembers = len(endmembers)
-        self.formulas = [e[1] for e in endmembers]
+        self.site_formulae = [e[1] for e in endmembers]
 
         # Process solution chemistry
         process_solution_chemistry(self)

--- a/burnman/optimize/composition_fitting.py
+++ b/burnman/optimize/composition_fitting.py
@@ -36,7 +36,7 @@ class DummyCompositionSolution(Solution):
             dictionarize_formula(f) for f in endmember_element_formulae
         ]
         self.solution_model = type(
-            "Dimension", (object,), {"formulas": endmember_site_formulae}
+            "Dimension", (object,), {"site_formulae": endmember_site_formulae}
         )()
         self.solution_model.endmembers = [None for f in endmember_site_formulae]
         process_solution_chemistry(self.solution_model)

--- a/burnman/utils/chemistry.py
+++ b/burnman/utils/chemistry.py
@@ -1,6 +1,6 @@
 # This file is part of BurnMan - a thermoelastic and thermodynamic toolkit
 # for the Earth and Planetary Sciences
-# Copyright (C) 2012 - 2021 by the BurnMan team, released under the GNU
+# Copyright (C) 2012 - 2025 by the BurnMan team, released under the GNU
 # GPL v2 or later.
 
 # This module provides the functions required to process the
@@ -306,8 +306,6 @@ def process_solution_chemistry(solution_model):
     .. note:: Nothing is returned from this function, but the solution_model
         object gains the following attributes:
 
-        * solution_formulae [list of dictionaries]
-            List of endmember formulae in dictionary form.
         * empty_formula [string]
             Abbreviated chemical formula with sites denoted by empty
             square brackets.
@@ -351,7 +349,6 @@ def process_solution_chemistry(solution_model):
     if not np.all(np.array([f.count("[") for f in formulae]) == n_sites):
         raise Exception("All formulae must have the same " "number of distinct sites.")
 
-    solution_formulae = [{} for i in range(n_endmembers)]
     sites = [[] for i in range(n_sites)]
     list_occupancies = []
     list_multiplicities = np.empty(shape=(n_endmembers, n_sites))
@@ -384,12 +381,6 @@ def process_solution_chemistry(solution_model):
                 else:
                     proportion_species_on_site = Fraction(species_split[1])
 
-                solution_formulae[i_mbr][name_of_species] = solution_formulae[
-                    i_mbr
-                ].get(name_of_species, 0.0) + (
-                    list_multiplicities[i_mbr][i_site] * proportion_species_on_site
-                )
-
                 if name_of_species not in sites[i_site]:
                     n_occupancies += 1
                     sites[i_site].append(name_of_species)
@@ -399,21 +390,6 @@ def process_solution_chemistry(solution_model):
                 else:
                     i_el = sites[i_site].index(name_of_species)
                 list_occupancies[i_mbr][i_site][i_el] = proportion_species_on_site
-
-            # Loop over species after site
-            if len(site_split) != 1:
-                not_in_site = site_split[1].strip()
-                not_in_site = not_in_site.replace(mult, "", 1)
-                for enamenumber in re.findall("[A-Z][^A-Z]*", not_in_site):
-                    sp = list(filter(None, re.split(r"(\d+)", enamenumber)))
-                    # Look up number of atoms of element
-                    if len(sp) == 1:
-                        nel = 1.0
-                    else:
-                        nel = float(float(sp[1]))
-                    solution_formulae[i_mbr][sp[0]] = (
-                        solution_formulae[i_mbr].get(sp[0], 0.0) + nel
-                    )
 
     # Site occupancies and multiplicities
     endmember_occupancies = np.empty(shape=(n_endmembers, n_occupancies))
@@ -438,7 +414,6 @@ def process_solution_chemistry(solution_model):
             solution_model.site_names.append("{0}_{1}".format(sp, ucase[i]))
 
     # Finally, make attributes for solution model instance:
-    solution_model.solution_formulae = solution_formulae
     solution_model.n_sites = n_sites
     solution_model.sites = sites
     solution_model.site_multiplicities = site_multiplicities

--- a/burnman/utils/chemistry.py
+++ b/burnman/utils/chemistry.py
@@ -284,7 +284,7 @@ def convert_formula(formula, to_type="mass", normalize=False):
 
 def process_solution_chemistry(solution_model):
     """
-    This function parses a class instance with a "formulas"
+    This function parses a class instance with a "site_formulae"
     attribute containing site information, e.g.
 
         [ '[Mg]3[Al]2Si3O12', '[Mg]3[Mg1/2Si1/2]2Si3O12' ]
@@ -297,7 +297,7 @@ def process_solution_chemistry(solution_model):
     molar fractions of the phases and pressure
     and temperature where necessary.
 
-    :param solution_model: Class must have a "formulas" attribute,
+    :param solution_model: Class must have a "site_formulae" attribute,
         containing a list of chemical formulae with site information
     :type solution model: instance of class
 
@@ -341,7 +341,7 @@ def process_solution_chemistry(solution_model):
             containing the number of atoms of each species on each site
             per mole of endmember.
     """
-    formulae = solution_model.formulas
+    formulae = solution_model.site_formulae
     n_sites = formulae[0].count("[")
     n_endmembers = len(formulae)
 
@@ -424,7 +424,7 @@ def process_solution_chemistry(solution_model):
     )
 
     solution_model.empty_formula = re.sub(
-        "([\\[]).*?([\\]])", "\\g<1>\\g<2>", solution_model.formulas[0]
+        "([\\[]).*?([\\]])", "\\g<1>\\g<2>", solution_model.site_formulae[0]
     )
     split_empty = solution_model.empty_formula.split("[")
     solution_model.general_formula = split_empty[0]


### PR DESCRIPTION
Removes `SolutionModel().solution_formulae` object and renamed `SolutionModel().formulas` to `SolutionModel().site_formulae`. 

The `SolutionModel().solution_formulae` object was originally intended to strip the sites from each site formula in the `SolutionModel` and return the chemical formulae, e.g.:
`[Mg]3[Mg0.5Si0.5]2Si3O12 -> Mg4Si4O12`
This intended use is essentially a duplication of the `Solution().endmember_formulae` object, which is itself derived from `SolutionModel().endmembers`. So the intended functionality is provided by another object.

Since writing the function, solution models have been generalised to the point that `SolutionModel().solution_formulae` might look quite different from `Solution().endmember_formulae`, but would not be as readable or contain any information that is not already in `SolutionModel().formulas` (now `SolutionModel().site_formulae`). For example:
`Mg3Fef2Si3O12`  is no more useful than `[Mg]3[Fef]2Si3O12`.