### PR TITLE
replaced set_tight_layout(True) with set_layout_engine('tight')

### DIFF
--- a/contrib/CHRU2014/paper_incorrect_averaging.py
+++ b/contrib/CHRU2014/paper_incorrect_averaging.py
@@ -339,7 +339,7 @@ if __name__ == "__main__":
     plt.title(" V.-R.-H. on moduli")
     plt.xlabel("Pressure (GPa)")
     plt.ylabel("Shear Velocity Vs (km/s)")
-    fig.set_tight_layout(True)
+    fig.set_layout_engine("tight")
     if "RUNNING_TESTS" not in globals():
         plt.savefig("example_incorrect_averaging.pdf", bbox_inches="tight")
     plt.show()

--- a/contrib/CHRU2014/paper_opt_pv.py
+++ b/contrib/CHRU2014/paper_opt_pv.py
@@ -423,7 +423,7 @@ if __name__ == "__main__":
     #    plt.savefig("opt_pv_4.pdf",bbox_inches='tight')
     #    plt.show()
 
-    fig.set_tight_layout(True)
+    fig.set_layout_engine("tight")
     if "RUNNING_TESTS" not in globals():
         plt.savefig("paper_opt_pv.pdf", bbox_inches="tight")
     plt.show()

--- a/contrib/anisotropic_eos/cubic_fitting.py
+++ b/contrib/anisotropic_eos/cubic_fitting.py
@@ -218,9 +218,9 @@ ax[3].set_ylabel("$G$ (GPa)")
 for i in range(4):
     ax[i].legend()
 
-fig.set_tight_layout(True)
+fig.set_layout_engine("tight")
 fig.savefig("periclase_stiffness_tensor.pdf")
-fig2.set_tight_layout(True)
+fig2.set_layout_engine("tight")
 fig2.savefig("periclase_shear_modulus.pdf")
 plt.show()
 
@@ -270,6 +270,6 @@ print_table_for_mineral_constants(m, [(1, 1), (1, 2), (4, 4)])
 
 ax[0].legend()
 
-fig.set_tight_layout(True)
+fig.set_layout_engine("tight")
 fig.savefig("periclase_properties_1bar.pdf")
 plt.show()

--- a/contrib/anisotropic_eos/cubic_fitting_second_form.py
+++ b/contrib/anisotropic_eos/cubic_fitting_second_form.py
@@ -325,9 +325,9 @@ ax[3].set_ylabel("$G$ (GPa)")
 for i in range(4):
     ax[i].legend()
 
-fig.set_tight_layout(True)
+fig.set_layout_engine("tight")
 fig.savefig("periclase_stiffness_tensor.pdf")
-fig2.set_tight_layout(True)
+fig2.set_layout_engine("tight")
 fig2.savefig("periclase_shear_modulus.pdf")
 plt.show()
 
@@ -390,6 +390,6 @@ print_table_for_mineral_constants_2(
 
 ax[0].legend()
 
-fig.set_tight_layout(True)
+fig.set_layout_engine("tight")
 fig.savefig("periclase_properties_1bar.pdf")
 plt.show()

--- a/contrib/anisotropic_eos/cubic_fitting_second_form_atherm.py
+++ b/contrib/anisotropic_eos/cubic_fitting_second_form_atherm.py
@@ -288,9 +288,9 @@ ax[3].set_ylabel("$G$ (GPa)")
 for i in range(4):
     ax[i].legend()
 
-fig.set_tight_layout(True)
+fig.set_layout_engine("tight")
 fig.savefig("periclase_stiffness_tensor.pdf")
-fig2.set_tight_layout(True)
+fig2.set_layout_engine("tight")
 fig2.savefig("periclase_shear_modulus.pdf")
 plt.show()
 
@@ -340,6 +340,6 @@ print_table_for_mineral_constants(m, [(1, 1), (1, 2), (4, 4)])
 
 ax[0].legend()
 
-fig.set_tight_layout(True)
+fig.set_layout_engine("tight")
 fig.savefig("periclase_properties_1bar.pdf")
 plt.show()

--- a/contrib/anisotropic_eos/cubic_fitting_second_form_only_therm.py
+++ b/contrib/anisotropic_eos/cubic_fitting_second_form_only_therm.py
@@ -352,9 +352,9 @@ ax[3].set_ylabel("$G$ (GPa)")
 for i in range(4):
     ax[i].legend()
 
-fig.set_tight_layout(True)
+fig.set_layout_engine("tight")
 fig.savefig("periclase_stiffness_tensor.pdf")
-fig2.set_tight_layout(True)
+fig2.set_layout_engine("tight")
 fig2.savefig("periclase_shear_modulus.pdf")
 plt.show()
 
@@ -404,6 +404,6 @@ ax[0].set_ylabel("Elastic modulus (GPa)")
 
 ax[0].legend()
 
-fig.set_tight_layout(True)
+fig.set_layout_engine("tight")
 fig.savefig("periclase_properties_1bar.pdf")
 plt.show()

--- a/contrib/anisotropic_eos/orthorhombic_fitting.py
+++ b/contrib/anisotropic_eos/orthorhombic_fitting.py
@@ -503,7 +503,7 @@ if do_plotting:
     ax[0].set_ylabel("Thermal expansivity (10$^{-5}$/K)")
     ax[1].set_ylabel("Relative length change ($10^{4} (x/x_0 - 1)$)")
 
-    fig.set_tight_layout(True)
+    fig.set_layout_engine("tight")
     fig.savefig("olivine_expansivities.pdf")
     plt.show()
 
@@ -573,7 +573,7 @@ if do_plotting:
         ax[i].set_ylabel(f"$C_{{N {p}{q}}}$ (GPa)")
         ax[i].legend()
 
-    fig.set_tight_layout(True)
+    fig.set_layout_engine("tight")
     fig.savefig("olivine_CNijs.pdf")
     plt.show()
 
@@ -597,6 +597,6 @@ if do_plotting:
         cbar = fig.colorbar(contour_sets[i], ax=ax[i], ticks=ticks[i], pad=0.1)
         cbar.add_lines(lines[i])
 
-    fig.set_tight_layout(True)
+    fig.set_layout_engine("tight")
     fig.savefig(f"olivine_seismic_properties_{P/1.e9:.2f}_GPa_{int(T)}_K.pdf")
     plt.show()

--- a/contrib/anisotropic_eos/orthorhombic_fitting_second_form.py
+++ b/contrib/anisotropic_eos/orthorhombic_fitting_second_form.py
@@ -501,7 +501,7 @@ if do_plotting:
     ax[0].set_ylabel("Thermal expansivity (10$^{-5}$/K)")
     ax[1].set_ylabel("Relative length change ($10^{4} (x/x_0 - 1)$)")
 
-    fig.set_tight_layout(True)
+    fig.set_layout_engine("tight")
     fig.savefig("olivine_expansivities.pdf")
     plt.show()
 
@@ -579,7 +579,7 @@ if do_plotting:
         ax[i].set_ylabel(f"$C_{{N {p}{q}}}$ (GPa)")
         ax[i].legend()
 
-    fig.set_tight_layout(True)
+    fig.set_layout_engine("tight")
     fig.savefig("olivine_CNijs.pdf")
     plt.show()
 
@@ -603,6 +603,6 @@ if do_plotting:
         cbar = fig.colorbar(contour_sets[i], ax=ax[i], ticks=ticks[i], pad=0.1)
         cbar.add_lines(lines[i])
 
-    fig.set_tight_layout(True)
+    fig.set_layout_engine("tight")
     fig.savefig(f"olivine_seismic_properties_{P/1.e9:.2f}_GPa_{int(T)}_K.pdf")
     plt.show()

--- a/contrib/anisotropic_plagioclase/plagioclase_model_plots.py
+++ b/contrib/anisotropic_plagioclase/plagioclase_model_plots.py
@@ -149,7 +149,7 @@ ax[1].set_ylabel("$K_{\\text{TR}}$ (GPa)")
 
 ax[0].legend()
 
-fig.set_tight_layout(True)
+fig.set_layout_engine("tight")
 fig.savefig("plag_V_KT.pdf")
 
 # Elastic stiffness data
@@ -229,7 +229,7 @@ for i in range(7):
     ax[i].set_xlabel("$p_{an}$")
     ax[i].set_ylabel("$C_{Nij}$ (GPa)")
 
-fig.set_tight_layout(True)
+fig.set_layout_engine("tight")
 fig.savefig("plag_stiffnesses.pdf")
 
 # psi
@@ -260,7 +260,7 @@ for i in range(7):
     ax[i].set_xlabel("$p_{an}$")
     ax[i].set_ylabel("$S_{Nij} / \\beta_{NR}$")
 
-fig.set_tight_layout(True)
+fig.set_layout_engine("tight")
 fig.savefig("plag_psi.pdf")
 
 # Cell parameters
@@ -309,7 +309,7 @@ for i, label in enumerate(labels):
         ax[i].set_ylabel(f"$\\{label}$ ($^{{\\circ}}$)")
     ax[i].set_xlabel("$p_{an}$")
 
-fig.set_tight_layout(True)
+fig.set_layout_engine("tight")
 fig.savefig("plag_cell_parameters.pdf")
 
 # Compressibilities
@@ -370,6 +370,6 @@ for axi, (i, j) in enumerate(inds):
     ax[axi].set_ylabel(f"$\\beta_{{T{axi+1}}}$ (GPa$^{{-1}}$)")
     ax[axi].set_xlabel("$p_{an}$")
 
-fig.set_tight_layout(True)
+fig.set_layout_engine("tight")
 fig.savefig("plag_compressibilities.pdf")
 plt.show()

--- a/contrib/anisotropic_stishovite/stishovite_model_Carpenter_2000.py
+++ b/contrib/anisotropic_stishovite/stishovite_model_Carpenter_2000.py
@@ -298,6 +298,6 @@ for i in range(3):
     ax[i].set_xlabel("Pressure (GPa)")
     ax[i].legend()
 
-fig.set_tight_layout(True)
+fig.set_layout_engine("tight")
 fig.savefig("figures/Carpenter_2000_model.pdf")
 plt.show()

--- a/contrib/anisotropic_stishovite/stishovite_model_Zhang_2021.py
+++ b/contrib/anisotropic_stishovite/stishovite_model_Zhang_2021.py
@@ -345,6 +345,6 @@ for i in range(3):
     ax[i].set_xlabel("Pressure (GPa)")
     ax[i].legend()
 
-fig.set_tight_layout(True)
+fig.set_layout_engine("tight")
 fig.savefig("figures/Zhang_2021_model.pdf")
 plt.show()

--- a/contrib/anisotropic_stishovite/stishovite_model_covariance_matrix.py
+++ b/contrib/anisotropic_stishovite/stishovite_model_covariance_matrix.py
@@ -93,6 +93,6 @@ ax.vlines(
 )
 
 
-fig.set_tight_layout(True)
+fig.set_layout_engine("tight")
 fig.savefig("figures/correlation_matrix.pdf")
 plt.show()

--- a/contrib/anisotropic_stishovite/stishovite_model_plots.py
+++ b/contrib/anisotropic_stishovite/stishovite_model_plots.py
@@ -130,7 +130,7 @@ if plot_Fischer_Andrault_splitting:
     ax[0].set_ylabel("Temperature (K)")
     ax[0].set_xlim(0.0, 125.0)
     ax[0].set_ylim(0.0, 4000.0)
-    fig.set_tight_layout(True)
+    fig.set_layout_engine("tight")
     fig.savefig("figures/Fischer_Andrault_splitting.pdf")
     plt.show()
 
@@ -434,7 +434,7 @@ if plot_cell_properties:
 
     ax[1].set_ylim(-1.0, 1.0)
     ax[1].legend(fontsize=8)
-    fig.set_tight_layout(True)
+    fig.set_layout_engine("tight")
     fig.savefig("figures/stv_cell_properties.pdf")
     plt.show()
 
@@ -545,7 +545,7 @@ if plot_isotropic_velocities:
     ax[0].set_xlabel("Depth (km)")
     ax[0].set_ylabel("Velocity (km/s)")
     ax[0].legend(fontsize=8.0)
-    fig.set_tight_layout(True)
+    fig.set_layout_engine("tight")
     fig.savefig("figures/stv_isotropic_velocities.pdf")
     if show_plots_one_by_one:
         plt.show()
@@ -611,7 +611,7 @@ if plot_seismic_properties:
             cbar = fig.colorbar(contour_sets[i], ax=ax[i], ticks=ticks[i], pad=0.1)
             cbar.add_lines(lines[i])
 
-        fig.set_tight_layout(True)
+        fig.set_layout_engine("tight")
         fig.savefig(
             f"figures/stishovite_seismic_properties_{P/1.e9:.2f}_GPa_{int(T)}_K.pdf"
         )
@@ -834,7 +834,7 @@ if plot_lnabc:
     ax_lnabc[1].set_ylabel("$\\ln(c)$ (cm/mol$^{\\frac{1}{3}}$)")
     handles, labels = ax_lnabc[1].get_legend_handles_labels()
     ax_lnabc[1].legend(handles[::-1], labels[::-1], fontsize=8)
-    fig_lnabc.set_tight_layout(True)
+    fig_lnabc.set_layout_engine("tight")
     fig_lnabc.savefig("figures/stv_lnabc.pdf")
     if show_plots_one_by_one:
         plt.show()
@@ -884,7 +884,7 @@ if plot_G:
     ax_G2.set_xlim(-1.5, 1.5)
     ax_G2.tick_params(axis="x")
     ax_G2.set_xlabel("$Q$")
-    fig_G.set_tight_layout(True)
+    fig_G.set_layout_engine("tight")
     fig_G.savefig("figures/stv_G.pdf")
     if show_plots_one_by_one:
         plt.show()
@@ -1066,9 +1066,9 @@ if plot_Q_V_abc:
     ax_abc[1].set_xlim(0.0, 150.0)
     ax_Q[0].set_xlim(0.0, 150.0)
 
-    fig_Q.set_tight_layout(True)
-    fig_V.set_tight_layout(True)
-    fig_abc.set_tight_layout(True)
+    fig_Q.set_layout_engine("tight")
+    fig_V.set_layout_engine("tight")
+    fig_abc.set_layout_engine("tight")
 
     fig_Q.savefig("figures/stv_Q.pdf")
     fig_V.savefig("figures/stv_V.pdf")
@@ -1185,8 +1185,8 @@ if plot_relaxed:
         ax_relaxed[i].set_ylabel("Modulus (GPa)")
         ax_Q0[i].set_ylabel("Modulus (GPa)")
 
-    fig_relaxed.set_tight_layout(True)
-    fig_Q0.set_tight_layout(True)
+    fig_relaxed.set_layout_engine("tight")
+    fig_Q0.set_layout_engine("tight")
 
     fig_relaxed.savefig("figures/stv_relaxed.pdf")
 
@@ -1295,8 +1295,8 @@ if plot_relaxed_SN:
         ax_relaxed[i].set_ylabel("Compliance (1/GPa)")
         ax_Q0[i].set_ylabel("Compliance (1/GPa)")
 
-    fig_relaxed.set_tight_layout(True)
-    fig_Q0.set_tight_layout(True)
+    fig_relaxed.set_layout_engine("tight")
+    fig_Q0.set_layout_engine("tight")
 
     fig_relaxed.savefig("figures/stv_relaxed_ST.pdf")
 

--- a/contrib/ipython/Create_1D_ASPECT_profile.ipynb
+++ b/contrib/ipython/Create_1D_ASPECT_profile.ipynb
@@ -409,7 +409,7 @@
     "\n",
     "ax_T.legend(loc='lower right',prop={'size':8})\n",
     "\n",
-    "fig.set_tight_layout(True)"
+    "fig.set_layout_engine('tight')"
    ]
   }
  ],

--- a/contrib/solution_polytope/create_FMS_pyroxene_ordering_figure.py
+++ b/contrib/solution_polytope/create_FMS_pyroxene_ordering_figure.py
@@ -371,6 +371,6 @@ if __name__ == "__main__":
 
             ax[j_px].plot(pMg1s, pMg2s, linestyle=ls[k], c=cs[k], zorder=105)
 
-    fig.tight_layout()
+    fig.set_layout_engine("tight")
     fig.savefig("energy_entropy_2_site_ordering.pdf")
     plt.show()

--- a/contrib/spock_eos/Au_comparison.py
+++ b/contrib/spock_eos/Au_comparison.py
@@ -233,7 +233,7 @@ for i, label in enumerate(["d", "b", "a", "c"]):
     )
 
 ax[2].legend()
-fig.set_tight_layout(True)
+fig.set_layout_engine("tight")
 
 # Save and show the figure
 fig.savefig("figures/Au_comparison.pdf")

--- a/contrib/spock_eos/fit_spock.py
+++ b/contrib/spock_eos/fit_spock.py
@@ -287,7 +287,7 @@ for basename in ["Au", "Pt"]:
         )
 
     ax[0].legend()
-    fig.set_tight_layout(True)
+    fig.set_layout_engine("tight")
     fig.savefig(f"figures/{basename}_eos_fit.pdf")
 
     # Create a pandas dataframe from the data and print it

--- a/examples/example_anisotropic_mineral.py
+++ b/examples/example_anisotropic_mineral.py
@@ -159,7 +159,7 @@ if __name__ == "__main__":
     ax[0].set_ylabel("Thermal expansivity (10$^{-5}$/K)")
     ax[1].set_ylabel("Relative length change ($10^{4} (x/x_0 - 1)$)")
 
-    fig.set_tight_layout(True)
+    fig.set_layout_engine("tight")
     # fig.savefig('example_anisotropic_mineral_Figure_1.png')
     plt.show()
 
@@ -193,7 +193,7 @@ if __name__ == "__main__":
         ax[i].set_ylabel(f"$C_{{N {p}{q}}}$ (GPa)")
         ax[i].legend()
 
-    fig.set_tight_layout(True)
+    fig.set_layout_engine("tight")
     # fig.savefig('example_anisotropic_mineral_Figure_2.png')
     plt.show()
 
@@ -222,5 +222,5 @@ if __name__ == "__main__":
         cbar = fig.colorbar(contour_sets[i], ax=ax[i], ticks=ticks[i], pad=0.1)
         cbar.add_lines(lines[i])
 
-    fig.set_tight_layout(True)
+    fig.set_layout_engine("tight")
     plt.show()

--- a/examples/example_anisotropy.py
+++ b/examples/example_anisotropy.py
@@ -228,7 +228,7 @@ if __name__ == "__main__":
             cbar = fig.colorbar(im[i], ax=ax[i], ticks=ticks)
             cbar.add_lines(lines)
 
-        fig.set_tight_layout(True)
+        fig.set_layout_engine("tight")
         plt.savefig("output_figures/example_anisotropy.png")
         plt.show()
 

--- a/examples/example_elastic_solution.py
+++ b/examples/example_elastic_solution.py
@@ -219,6 +219,6 @@ if __name__ == "__main__":
     ax[4].set_ylabel("Volume - $d\\mu(0.4)/dP$ (cm$^3$/mol)")
     ax[5].set_ylabel("Entropy + $d\\mu(0.4)/dT$ (J/K/mol)")
 
-    fig.set_tight_layout(True)
+    fig.set_layout_engine("tight")
 
     plt.show()

--- a/examples/example_geodynamic_adiabat.py
+++ b/examples/example_geodynamic_adiabat.py
@@ -376,7 +376,7 @@ if __name__ == "__main__":
         ax_beta.plot(x, compressibilities_relaxed)
 
     ax_T.legend(loc="upper left")
-    fig.set_tight_layout(True)
+    fig.set_layout_engine("tight")
 
     plt.show()
 

--- a/examples/example_mineral.py
+++ b/examples/example_mineral.py
@@ -175,5 +175,5 @@ if __name__ == "__main__":
 
     ax[0].set_ylabel("Molar isobaric heat capacity (J/K/mol)")
     ax[1].set_ylabel("Molar volume (cm$^3$/mol)")
-    fig.tight_layout()
+    fig.set_layout_engine("tight")
     plt.show()

--- a/examples/example_seismic.py
+++ b/examples/example_seismic.py
@@ -120,7 +120,7 @@ if __name__ == "__main__":
         ax[variable_index].set_ylabel(units[variable_index])
         ax[variable_index].set_xticks([660, 2891, 5150])
 
-    fig.set_tight_layout(True)
+    fig.set_layout_engine("tight")
     plt.show()
 
     # Alternatively one is able to evaluate all the variables for a model in a

--- a/examples/example_spintransition_thermal.py
+++ b/examples/example_spintransition_thermal.py
@@ -224,5 +224,5 @@ if __name__ == "__main__":
     ax[0].set_ylim(7, 13)
 
     # Tidy the plot and show it
-    fig.set_tight_layout(True)
+    fig.set_layout_engine("tight")
     plt.show()

--- a/tutorial/tutorial_01_material_classes.ipynb
+++ b/tutorial/tutorial_01_material_classes.ipynb
@@ -453,7 +453,7 @@
         "ax[1].set_ylabel('Bulk sound velocity (km/s)')\n",
         "ax[0].set_ylim(50., 150.)\n",
         "ax[1].set_ylim(1.5, 5.)\n",
-        "fig.tight_layout()\n",
+        "fig.set_layout_engine('tight')\n",
         "fig.subplots_adjust(top=0.88)"
       ]
     },
@@ -797,7 +797,7 @@
         "  ax[i].set_xlabel('Pressure (GPa)')\n",
         "ax[0].set_ylabel('Densities (kg/m^3)')\n",
         "ax[1].set_ylabel('P wave velocity (km/s)')\n",
-        "fig.tight_layout()\n"
+        "fig.set_layout_engine('tight')\n"
       ]
     },
     {
@@ -866,7 +866,7 @@
         "  ax[i].set_xlabel(\"Molar FeSiO$_3$ fraction\")\n",
         "  ax[i].legend(loc='lower left')\n",
         "\n",
-        "fig.tight_layout()\n",
+        "fig.set_layout_engine('tight')\n",
         "plt.show()"
       ]
     },
@@ -971,7 +971,7 @@
         "ax[0].set_ylabel('Density (kg/m$3$)')\n",
         "ax[1].set_ylabel('Velocities (km/s)')\n",
         "\n",
-        "fig.tight_layout()\n",
+        "fig.set_layout_engine('tight')\n",
         "plt.show()"
       ]
     },
@@ -991,7 +991,7 @@
       "provenance": []
     },
     "kernelspec": {
-      "display_name": "Python 3.10.5 ('base')",
+      "display_name": "3.11.4",
       "language": "python",
       "name": "python3"
     },
@@ -1006,11 +1006,6 @@
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
       "version": "3.11.4"
-    },
-    "vscode": {
-      "interpreter": {
-        "hash": "c6e4e9f98eb68ad3b7c296f83d20e6de614cb42e90992a65aa266555a3137d0d"
-      }
     }
   },
   "nbformat": 4,

--- a/tutorial/tutorial_03_layers_and_planets.ipynb
+++ b/tutorial/tutorial_03_layers_and_planets.ipynb
@@ -122,7 +122,7 @@
         "ax[2].set_xlabel('Gravity (m/s$^2$)')\n",
         "ax[3].set_xlabel('Bullen parameter')\n",
         "\n",
-        "fig.set_tight_layout(True)"
+        "fig.set_layout_engine('tight')"
       ]
     },
     {
@@ -588,7 +588,7 @@
         "    ax[i].set_xlim(0., max(planet_zog.radii) / 1.e3)\n",
         "    ax[i].set_ylim(0., maxy[i])\n",
         "\n",
-        "fig.set_tight_layout(True)\n",
+        "fig.set_layout_engine('tight')\n",
         "plt.show()"
       ]
     },
@@ -607,11 +607,9 @@
       "name": "BurnMan_1.0_manuscript.ipynb",
       "provenance": []
     },
-    "interpreter": {
-      "hash": "d0e8ff0504fa29d441371c1f42f91c694e01f5e6e44698edccbd59f7213ffa15"
-    },
     "kernelspec": {
-      "display_name": "Python 3.9.2 64-bit ('3.9.2': pyenv)",
+      "display_name": "base",
+      "language": "python",
       "name": "python3"
     },
     "language_info": {

--- a/tutorial/tutorial_04_fitting.ipynb
+++ b/tutorial/tutorial_04_fitting.ipynb
@@ -537,7 +537,7 @@
         "ax[1].set_xlabel('Pressure (GPa)')\n",
         "ax[1].set_ylabel('Phase fraction (wt)')\n",
         "ax[1].legend()\n",
-        "fig.set_tight_layout(True)\n",
+        "fig.set_layout_engine('tight')\n",
         "plt.show()"
       ]
     },


### PR DESCRIPTION
set_tight_layout() has been deprecated since matplotlib 3.6. This PR replaces it with the new method, set_layout_engine('tight').