### PR TITLE
Speed up set_state_with_volume for P(V, T) minerals

### DIFF
--- a/burnman/classes/material.py
+++ b/burnman/classes/material.py
@@ -186,10 +186,20 @@ class Material(object):
     ):
         """
         This function acts similarly to set_state, but takes volume and
-        temperature as input to find the pressure. In order to ensure
-        self-consistency, this function does not use any pressure functions
-        from the material classes, but instead finds the pressure using the
-        brentq root-finding method.
+        temperature as input to find the pressure.
+
+        In order to ensure self-consistency, this function does not
+        use any pressure functions from the material classes,
+        but instead finds the pressure using the brentq root-finding
+        method. To provide more context, even if a mineral is being
+        evaluated with a P(V, T) equation of state, there might be a
+        property modifier G_mod(P, T) added on top - which might then
+        introduce a pressure dependent V_mod(P, T).
+        Thus, we must solve for the volume iteratively:
+        V = V_i(P(V_i, T), T) + V_mod(P, T), where P(V_i, T) is
+        solved for iteratively.
+
+        This function is overloaded by the Mineral class.
 
         :param volume: The desired molar volume of the mineral [m^3].
         :type volume: float

--- a/burnman/tools/eos.py
+++ b/burnman/tools/eos.py
@@ -318,9 +318,6 @@ def check_anisotropic_eos_consistency(
     m.set_state(P + 0.5 * dP, T + 0.5 * dT)
     equilibration_function(m)
 
-    beta0 = -(logm(F3) - logm(F2)) / dP
-    alpha0 = (logm(F1) - logm(F0)) / dT
-
     Q = m.deformed_coordinate_frame
     beta1 = m.isothermal_compressibility_tensor
     alpha1 = m.thermal_expansivity_tensor
@@ -329,6 +326,9 @@ def check_anisotropic_eos_consistency(
     alpha1 = np.einsum("mi, nj, ij->mn", Q, Q, alpha1)
 
     if m.orthotropic:
+        beta0 = -(logm(F3) - logm(F2)) / dP
+        alpha0 = (logm(F1) - logm(F0)) / dT
+
         expr.extend(
             [f"SI = -d(lnm(F))/dP ({i}{j})" for i in range(3) for j in range(i, 3)]
         )

--- a/misc/benchmarks/ab_initio_solids.py
+++ b/misc/benchmarks/ab_initio_solids.py
@@ -58,7 +58,8 @@ for name, phase, PVT_range, EVT_range in phases:
     pressures = np.empty_like(volumes)
     for temperature in temperatures:
         for i, volume in enumerate(volumes):
-            pressures[i] = phase.method.pressure(temperature, volume, phase.params)
+            phase.set_state_with_volume(volume, temperature)
+            pressures[i] = phase.pressure
         ax_P.plot(
             volumes * 1e6,
             pressures / 1e9,
@@ -77,8 +78,7 @@ for name, phase, PVT_range, EVT_range in phases:
     energies = np.empty_like(volumes)
     for temperature in temperatures:
         for i, volume in enumerate(volumes):
-            P = phase.method.pressure(temperature, volume, phase.params)
-            phase.set_state(P, temperature)
+            phase.set_state_with_volume(volume, temperature)
             energies[i] = phase.molar_internal_energy
         ax_E.plot(
             volumes * 1e6,

--- a/test.sh
+++ b/test.sh
@@ -24,7 +24,7 @@ $PYTHON -m pip install -q -e .[dev]
 echo ""
 
 echo "Dependency tree:"
-$PYTHON -m pip install -q pipdeptree .
+$PYTHON -m pip install -q pipdeptree
 $PYTHON -m pipdeptree -p burnman -d 1 2> /dev/null
 pycddlib_version=`pip freeze | grep "pycddlib=" | awk -F"==" '{print $2}'`
 if [ ! -z "${pycddlib_version}" ]

--- a/test.sh
+++ b/test.sh
@@ -64,7 +64,7 @@ with open('$t') as f:
 EOF
 ) >$t.tmp 2>$t.tmp.error
 ret=$?
-cat $t.tmp.error >>$t.tmp
+grep -v "^$" $t.tmp.error >>$t.tmp #append non-empty error messages to output
 rm -f $t.tmp.error
 
 grep -v "which is a non-GUI backend" $t.tmp | grep -v "plt.show()" > tmpfile

--- a/tests/test_anisotropicsolution.py
+++ b/tests/test_anisotropicsolution.py
@@ -106,13 +106,13 @@ class test_two_member_solution(BurnManTest):
     def test_non_orthotropic_endmember_consistency(self):
         ss = make_nonorthotropic_solution()
         ss.set_composition([1.0, 0.0])
-        self.assertTrue(check_anisotropic_eos_consistency(ss, P=2.0e10, tol=1.0e-5))
+        self.assertTrue(check_anisotropic_eos_consistency(ss, P=2.0e10, tol=1.0e-6))
 
     def test_non_orthotropic_solution_consistency(self):
         ss = make_nonorthotropic_solution()
         ss.set_composition([0.8, 0.2])
         self.assertTrue(
-            check_anisotropic_eos_consistency(ss, P=2.0e10, T=1000.0, tol=1.0e-5)
+            check_anisotropic_eos_consistency(ss, P=2.0e10, T=1000.0, tol=1.0e-6)
         )
 
     def test_relaxed_non_orthotropic_solution_consistency(self):
@@ -122,7 +122,7 @@ class test_two_member_solution(BurnManTest):
         )
         ss.set_composition([0.8, 0.2], relaxed=False)
         self.assertTrue(
-            check_anisotropic_eos_consistency(ss, P=2.0e10, T=1000.0, tol=1.0e-5)
+            check_anisotropic_eos_consistency(ss, P=2.0e10, T=1000.0, tol=1.0e-6)
         )
 
     def test_non_orthotropic_solution_clone(self):

--- a/tests/test_anisotropicsolution.py
+++ b/tests/test_anisotropicsolution.py
@@ -106,13 +106,13 @@ class test_two_member_solution(BurnManTest):
     def test_non_orthotropic_endmember_consistency(self):
         ss = make_nonorthotropic_solution()
         ss.set_composition([1.0, 0.0])
-        self.assertTrue(check_anisotropic_eos_consistency(ss, P=2.0e10, tol=1.0e-6))
+        self.assertTrue(check_anisotropic_eos_consistency(ss, P=2.0e10, tol=1.0e-5))
 
     def test_non_orthotropic_solution_consistency(self):
         ss = make_nonorthotropic_solution()
         ss.set_composition([0.8, 0.2])
         self.assertTrue(
-            check_anisotropic_eos_consistency(ss, P=2.0e10, T=1000.0, tol=1.0e-6)
+            check_anisotropic_eos_consistency(ss, P=2.0e10, T=1000.0, tol=1.0e-5)
         )
 
     def test_relaxed_non_orthotropic_solution_consistency(self):
@@ -122,7 +122,7 @@ class test_two_member_solution(BurnManTest):
         )
         ss.set_composition([0.8, 0.2], relaxed=False)
         self.assertTrue(
-            check_anisotropic_eos_consistency(ss, P=2.0e10, T=1000.0, tol=1.0e-6)
+            check_anisotropic_eos_consistency(ss, P=2.0e10, T=1000.0, tol=1.0e-5)
         )
 
     def test_non_orthotropic_solution_clone(self):

--- a/tests/test_composite.py
+++ b/tests/test_composite.py
@@ -316,6 +316,20 @@ class composite(BurnManTest):
         self.assertFloatEqual(rock1.molar_heat_capacity_v, min1.C_v)
         self.assertFloatEqual(rock1.molar_heat_capacity_p, min1.C_p)
 
+    def test_set_state_with_volume(self):
+        min1 = minerals.SLB_2011.periclase()
+        rock1 = burnman.Composite([min1, min1], [0.5, 0.5])
+        P = 1.0e9
+        P2 = 2.0e9
+        T = 1000.0
+        rock1.set_state(P, T)
+        V = rock1.molar_volume
+        rock1.set_state(P2, T)  # reset state
+        _ = rock1.molar_volume
+        rock1.set_state_with_volume(V, T)  # try to find original state
+
+        self.assertFloatEqual(P, rock1.pressure)
+
     def test_stoichiometric_matrix_single_mineral(self):
         rock = burnman.Composite([minerals.SLB_2011.quartz()])
 


### PR DESCRIPTION
This PR allows minerals with P(V, T) EoSes to directly use their P(V, T) function when set_state_with_volume is called. This avoids an otherwise pointless call to brentq.

The mineral is checked to make sure that it is (a) an endmember, and that it (b) doesn't have property modifiers that might affect the equilibrium pressure.

There are a few other minor changes in this PR that are necessary to ensure that the tester still functions.