### PR TITLE
Nonlinear priors

### DIFF
--- a/burnman/optimize/eos_fitting.py
+++ b/burnman/optimize/eos_fitting.py
@@ -11,10 +11,10 @@ import numpy as np
 from . import nonlinear_fitting
 from ..utils.misc import flatten
 from ..utils.math import unit_normalize
-from .nonlinear_fitting import nonlinear_least_squares_fit
+from .nonlinear_fitting import NonLinearModel, nonlinear_least_squares_fit
 
 
-class MineralFit(object):
+class MineralFit(NonLinearModel):
     """
     Class for fitting mineral parameters to experimental data.
     Instances of this class are passed to
@@ -119,6 +119,8 @@ def fit_PTp_data(
     delta_params=None,
     bounds=None,
     max_lm_iterations=50,
+    param_priors=None,
+    param_prior_inv_cov_matrix=None,
     verbose=True,
 ):
     """
@@ -221,6 +223,8 @@ def fit_PTp_data(
         model,
         max_lm_iterations=max_lm_iterations,
         param_tolerance=param_tolerance,
+        param_priors=param_priors,
+        param_prior_inv_cov_matrix=param_prior_inv_cov_matrix,
         verbose=verbose,
     )
 
@@ -265,6 +269,8 @@ def fit_PTV_data(
     bounds=None,
     param_tolerance=1.0e-5,
     max_lm_iterations=50,
+    param_priors=None,
+    param_prior_inv_cov_matrix=None,
     verbose=True,
 ):
     """
@@ -281,11 +287,13 @@ def fit_PTV_data(
         delta_params=delta_params,
         bounds=bounds,
         max_lm_iterations=max_lm_iterations,
+        param_priors=param_priors,
+        param_prior_inv_cov_matrix=param_prior_inv_cov_matrix,
         verbose=verbose,
     )
 
 
-class SolutionFit(object):
+class SolutionFit(NonLinearModel):
     """
     Class for fitting mineral parameters to experimental data.
     Instances of this class are passed to
@@ -460,6 +468,8 @@ def fit_XPTp_data(
     delta_params=None,
     bounds=None,
     max_lm_iterations=50,
+    param_priors=None,
+    param_prior_inv_cov_matrix=None,
     verbose=True,
 ):
     """
@@ -570,6 +580,8 @@ def fit_XPTp_data(
         model,
         max_lm_iterations=max_lm_iterations,
         param_tolerance=param_tolerance,
+        param_priors=param_priors,
+        param_prior_inv_cov_matrix=param_prior_inv_cov_matrix,
         verbose=verbose,
     )
 

--- a/examples/example_fit_eos_with_priors.py
+++ b/examples/example_fit_eos_with_priors.py
@@ -1,0 +1,197 @@
+# This file is part of BurnMan - a thermoelastic and thermodynamic toolkit for
+# the Earth and Planetary Sciences
+# Copyright (C) 2012 - 2025 by the BurnMan team, released under the GNU
+# GPL v2 or later.
+
+
+"""
+example_fit_eos_with_priors
+---------------------------
+
+This example demonstrates BurnMan's functionality to fit data to
+an EoS of the user's choice with (potentially correlated)
+Gaussian priors on the parameters.
+
+This provides an alternative to artificially fixing the parameters.
+
+teaches:
+- least squares fitting with Gaussian priors on the parameter values.
+
+"""
+from __future__ import absolute_import
+from __future__ import print_function
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+import burnman
+
+from burnman.utils.unitcell import molar_volume_from_unit_cell_volume
+from burnman.utils.misc import attribute_function
+from burnman.utils.misc import pretty_print_values
+
+if __name__ == "__main__":
+    print("Least squares equation of state fitting with Gaussian priors\n")
+
+    # Let's fit some of the high pressure stishovite data from Andrault et al. (2003)
+    PV = np.array(
+        [
+            [0.0001, 46.5126, 0.0061],
+            [1.168, 46.3429, 0.0053],
+            [2.299, 46.1756, 0.0043],
+            [3.137, 46.0550, 0.0051],
+            [4.252, 45.8969, 0.0045],
+            [5.037, 45.7902, 0.0053],
+            [5.851, 45.6721, 0.0038],
+            [6.613, 45.5715, 0.0050],
+            [7.504, 45.4536, 0.0041],
+            [8.264, 45.3609, 0.0056],
+            [9.635, 45.1885, 0.0042],
+            [11.69, 44.947, 0.002],
+            [17.67, 44.264, 0.002],
+            [22.38, 43.776, 0.003],
+            [29.38, 43.073, 0.009],
+            [37.71, 42.278, 0.008],
+            [46.03, 41.544, 0.017],
+            [52.73, 40.999, 0.009],
+            [26.32, 43.164, 0.006],
+            [30.98, 42.772, 0.005],
+            [34.21, 42.407, 0.003],
+            [38.45, 42.093, 0.004],
+            [43.37, 41.610, 0.004],
+            [47.49, 41.280, 0.007],
+        ]
+    )
+
+    PV[:, 0] = PV[:, 0] * 1.0e9
+    PV[:, 1] = molar_volume_from_unit_cell_volume(PV[:, 1], 2.0)
+    PV[:, 2] = molar_volume_from_unit_cell_volume(PV[:, 2], 2.0)
+
+    # Use only data points where P > 15 GPa in the fitting
+    mask = PV[:, 0] > 15.0e9
+    PTV = np.array(
+        [
+            PV[mask, 0],
+            PV[mask, 0] * 0.0 + 298.15,
+            PV[mask, 1],
+        ]
+    ).T
+
+    nul = 0.0 * PTV.T[0]
+    PTV_covariances = np.array(
+        [
+            [0.03 * PTV.T[0], nul, nul],
+            [nul, nul, nul],
+            [nul, nul, PV[mask, 2]],
+        ]
+    ).T
+    PTV_covariances = np.power(PTV_covariances, 2.0)
+
+    # The mineral parameters are automatically updated during fitting
+    stv = burnman.minerals.HP_2011_ds62.stv()
+    params = ["V_0", "K_0", "Kprime_0"]
+    fitted_eos = burnman.eos_fitting.fit_PTV_data(
+        stv, params, PTV, PTV_covariances, verbose=False
+    )
+
+    # Evaluate some volumes for plotting later
+    pressures = np.linspace(1.0e5, 100.0e9, 101)
+    temperatures = 300.0 + 0.0 * pressures
+    V_fit = stv.evaluate(["V"], pressures, temperatures)[0]
+    confidence_interval = 0.95
+    cp_bands = burnman.nonlinear_fitting.confidence_prediction_bands(
+        model=fitted_eos,
+        x_array=np.array([pressures, temperatures, V_fit]).T,
+        confidence_interval=0.95,
+        f=attribute_function(stv, "V"),
+        flag="V",
+    )
+
+    # Print the optimized parameters
+    print("Optimized equation of state for stishovite with no priors on parameters:")
+    pretty_print_values(fitted_eos.popt, fitted_eos.pcov, fitted_eos.fit_params)
+    print(f"Weighted sum of squares: {fitted_eos.WSS:.2f}")
+    print(f"Goodness of fit: {fitted_eos.goodness_of_fit:.2f}")
+    print("")
+
+    # Now define a weak prior on K_0' while leaving V_0 and K_0 free
+    prior_values = np.array([0.0, 0.0, 4.0])
+    prior_cov = np.power(np.diag([np.inf, np.inf, 1.0]), 2.0)
+    prior_inv_cov = np.linalg.inv(prior_cov)
+
+    # Refit
+    fitted_eos = burnman.eos_fitting.fit_PTV_data(
+        stv,
+        params,
+        PTV,
+        PTV_covariances,
+        param_priors=prior_values,
+        param_prior_inv_cov_matrix=prior_inv_cov,
+        verbose=False,
+    )
+    V_fit_with_priors = stv.evaluate(["V"], pressures, temperatures)[0]
+
+    print("Optimized equation of state for stishovite with weak prior; K' = 4(1):")
+    pretty_print_values(fitted_eos.popt, fitted_eos.pcov, fitted_eos.fit_params)
+    print(f"Weighted sum of squares: {fitted_eos.WSS:.2f}")
+    print(f"Goodness of fit: {fitted_eos.goodness_of_fit:.2f}")
+    print("")
+
+    cp_bands_with_priors = burnman.nonlinear_fitting.confidence_prediction_bands(
+        model=fitted_eos,
+        x_array=np.array([pressures, temperatures, V_fit_with_priors]).T,
+        confidence_interval=0.95,
+        f=attribute_function(stv, "V"),
+        flag="V",
+    )
+
+    fig = plt.figure()
+    ax = [fig.add_subplot(1, 1, i) for i in range(1, 2)]
+
+    ax[0].scatter(
+        PV[~mask, 0] / 1.0e9,
+        PV[~mask, 1] * 1.0e6,
+        label="Andrault et al., 2003 (not fitted)",
+    )
+    ax[0].scatter(
+        PV[mask, 0] / 1.0e9, PV[mask, 1] * 1.0e6, label="Andrault et al., 2003 (fitted)"
+    )
+    ax[0].errorbar(
+        PV[:, 0] / 1.0e9,
+        PV[:, 1] * 1.0e6,
+        xerr=0.03 * PV[:, 0] / 1.0e9,
+        yerr=PV[:, 2] * 1.0e6,
+        linestyle="",
+    )
+
+    ax[0].plot(
+        pressures / 1.0e9, V_fit * 1.0e6, label="Fit without priors", color="orange"
+    )
+    ax[0].fill_between(
+        pressures / 1.0e9,
+        cp_bands[0] * 1.0e6,
+        cp_bands[1] * 1.0e6,
+        alpha=0.15,
+        label="95% confidence interval",
+        color="orange",
+    )
+
+    ax[0].plot(
+        pressures / 1.0e9,
+        V_fit_with_priors * 1.0e6,
+        label="Fit with weak prior (K'=4$\\pm$1)",
+        color="blue",
+    )
+    ax[0].fill_between(
+        pressures / 1.0e9,
+        cp_bands_with_priors[0] * 1.0e6,
+        cp_bands_with_priors[1] * 1.0e6,
+        alpha=0.15,
+        label="95% confidence interval",
+        color="blue",
+    )
+
+    ax[0].set_xlabel("Pressure (GPa)")
+    ax[0].set_ylabel("Volume (cm$^3$/mol)")
+    ax[0].legend()
+    plt.show()

--- a/misc/ref/example_fit_eos.py.out
+++ b/misc/ref/example_fit_eos.py.out
@@ -1,13 +1,13 @@
 Least squares equation of state fitting
 
-1) Fitting to room temperature PV data
+1) Fitting to stishovite room temperature PV data
 
 Optimized equation of state for stishovite:
-V_0: (1.4003 +/- 0.0009) x 1e-05
-K_0: (3.19 +/- 0.09) x 1e+11
-Kprime_0: (3.9 +/- 0.5) x 1e+00
+V_0: (1.4005 +/- 0.0001) x 1e-05
+K_0: (3.12 +/- 0.03) x 1e+11
+Kprime_0: (4.4 +/- 0.2) x 1e+00
 
-2) Fitting to high pressure PTV data only
+2) Fitting to periclase high pressure PTV data only
 
 Optimized equation of state:
 V_0: (1.1232 +/- 0.0004) x 1e-05
@@ -16,11 +16,14 @@ Kprime_0: (4.4 +/- 0.4) x 1e+00
 grueneisen_0: (1.9 +/- 0.2) x 1e+00
 q_0: (3.9 +/- 0.9) x 1e+00
 
+Goodness of fit:
+1.2212890225970556
+
 Fitting an equation of state using only high pressure P-T-V data can produce some surprising (incorrect) thermodynamic predictions. We must use additional data to provide strong constraints on all parameters. In this case, we would like to improve our constraints on grueneisen_0 and q_0.
 
 How should we improve on this "optimal" PVT fit?
 
-2) Fitting to PTV *and* PT-enthalpy data
+3) Fitting to periclase PTV *and* PT-enthalpy data
 
 Optimized equation of state:
 V_0: (1.1237 +/- 0.0002) x 1e-05
@@ -30,6 +33,9 @@ grueneisen_0: (1.40 +/- 0.03) x 1e+00
 q_0: (-3 +/- 4) x 1e-01
 Debye_0: (7.8 +/- 0.1) x 1e+02
 F_0: (-6.9 +/- 0.2) x 1e+03
+
+Goodness of fit:
+1.3184129992486777
 
 Hmmm, looks promising. The heat capacities don't blow up any more. Let's check the new weighted residuals...
 
@@ -52,7 +58,7 @@ Debye_0: (7.75 +/- 0.05) x 1e+02
 F_0: (-7.00 +/- 0.09) x 1e+03
 
 Goodness of fit:
-0.320602656406
+0.3206021030322475
 
 
 Hurrah! That looks much better! The patches of positive and negative weighted residuals in P-T space have completely disappeared, and the weighted residuals are now distributed more evenly about zero. The uncertainties on all the parameters have got much smaller, and several have moved outside the previous 1-s.d. uncertainty bounds. Cool, huh?! Let's finish this example by looking at some pretty plots characterising our optimised equation of state.

--- a/misc/ref/example_fit_eos_with_priors.py.out
+++ b/misc/ref/example_fit_eos_with_priors.py.out
@@ -1,0 +1,16 @@
+Least squares equation of state fitting with Gaussian priors
+
+Optimized equation of state for stishovite with no priors on parameters:
+V_0: (1.42 +/- 0.02) x 1e-05
+K_0: (2.4 +/- 0.7) x 1e+11
+Kprime_0: (6 +/- 2) x 1e+00
+Weighted sum of squares: 7.56
+Goodness of fit: 0.84
+
+Optimized equation of state for stishovite with weak prior; K' = 4(1):
+V_0: (1.400 +/- 0.005) x 1e-05
+K_0: (3.2 +/- 0.2) x 1e+11
+Kprime_0: (3.9 +/- 0.8) x 1e+00
+Weighted sum of squares: 8.66
+Goodness of fit: 0.96
+

--- a/test.sh
+++ b/test.sh
@@ -205,6 +205,7 @@ echo ""
 echo "*** checking contrib/perplex/ ..."
 cd contrib/perplex/
 ./download_and_install_perplex.sh
+rm -fr iron_olivine_lo_res
 testit create_lo_res_table.py $fulldir || exit 1
 testit read_lo_res_table.py $fulldir || exit 1
 testit generate_aspect_compatible_1D_adiabat_table.py $fulldir || exit 1

--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -7,7 +7,10 @@ import matplotlib.pyplot as plt
 
 import burnman
 from burnman.optimize.eos_fitting import fit_XPTp_data
-from burnman.optimize.nonlinear_fitting import nonlinear_least_squares_fit
+from burnman.optimize.nonlinear_fitting import (
+    NonLinearModel,
+    nonlinear_least_squares_fit,
+)
 from burnman.utils.misc import attribute_function, pretty_string_values
 from burnman.optimize.composition_fitting import fit_composition_to_solution
 
@@ -24,7 +27,7 @@ class test_fitting(BurnManTest):
         data = np.array([x, y]).T
         cov = np.array([[1.0 / Wx, 0.0 * Wx], [0.0 * Wy, 1.0 / Wy]]).T
 
-        class m:
+        class m(NonLinearModel):
             def __init__(self, data, cov, guessed_params, delta_params):
                 self.data = data
                 self.data_covariances = cov
@@ -63,7 +66,7 @@ class test_fitting(BurnManTest):
         data = np.array([x, y]).T
         cov = np.array([[1.0 / Wx, 0.0 * Wx], [0.0 * Wy, 1.0 / Wy]]).T
 
-        class m:
+        class m(NonLinearModel):
             def __init__(self, data, cov, guessed_params, delta_params):
                 self.data = data
                 self.data_covariances = cov


### PR DESCRIPTION
This PR adds the ability for users to add (potentially correlated) Gaussian priors to their parameters during nonlinear fitting.

Also included:
- Restructuring of the nonlinear fitting routines to use a model class derived from `burnman.nonlinear_fitting.NonLinearModel`. 
- A small fix to the fit_eos example (the same fix was previously applied to the fitting tutorial).
- A new example illustrating the new functionality.
- A new test covering the new functionality.