### PR TITLE
add test for calibrant P2P covariance

### DIFF
--- a/tests/test_calibrants.py
+++ b/tests/test_calibrants.py
@@ -30,7 +30,7 @@ class test_calibrants(BurnManTest):
                         pressures.append(calibrant.pressure(V, 1000.0))
 
         pressures = np.array(pressures)
-        self.assertArraysAlmostEqual(pressures, 10.0e9 + pressures * 0.0)
+        np.testing.assert_allclose(pressures, 10.0e9 + pressures * 0.0, rtol=1e-5)
 
     def test_pressure_to_pressure(self):
         gold1 = calibrants.Anderson_1989.Au()
@@ -41,7 +41,24 @@ class test_calibrants(BurnManTest):
         pressure2 = pressure_to_pressure(gold1, gold2, pressure1, temperature)
         pressure1new = pressure_to_pressure(gold2, gold1, pressure2, temperature)
 
-        self.assertAlmostEqual(pressure1 / 1.0e9, pressure1new / 1.0e9, 4)
+        np.testing.assert_allclose(pressure1 / 1.0e9, pressure1new / 1.0e9, rtol=1e-5)
+
+    def test_pressure_to_pressure_cov(self):
+        gold1 = calibrants.Anderson_1989.Au()
+        gold2 = calibrants.Fei_2007.Au()
+
+        temperature = 1000.0
+        pressure1 = 20.0e9
+        PTcov1 = np.array([[1.0e18, 1.0e8], [1.0e8, 10.0]])
+        pressure2, PTcov2 = pressure_to_pressure(
+            gold1, gold2, pressure1, temperature, PTcov1
+        )
+        pressure1new, PTcov1new = pressure_to_pressure(
+            gold2, gold1, pressure2, temperature, PTcov2
+        )
+
+        np.testing.assert_allclose(PTcov1, PTcov1new, rtol=1e-5)
+        np.testing.assert_allclose(pressure1 / 1.0e9, pressure1new / 1.0e9, rtol=1e-5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds a test for the `burnman.calibrants.tools.pressure_to_pressure()` function for the case when a covariance matrix is provided.