### PR TITLE
Remove "free" from energy argument and method names, improve solution testing

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.14238360.svg)](https://doi.org/10.5281/zenodo.14238360)
 [![DOI](https://joss.theoj.org/papers/10.21105/joss.05389/status.svg)](https://doi.org/10.21105/joss.05389)
-[![coverage](https://img.shields.io/badge/coverage-%3E92%25-green")](https://github.com/geodynamics/burnman/actions/workflows/coverage.yml)
+[![coverage](https://img.shields.io/badge/coverage-%3E93%25-green")](https://github.com/geodynamics/burnman/actions/workflows/coverage.yml)
 
 # BurnMan - a Python toolkit for planetary geophysics, geochemistry and thermodynamics
 

--- a/burnman/classes/combinedmineral.py
+++ b/burnman/classes/combinedmineral.py
@@ -34,7 +34,7 @@ class CombinedMineral(Mineral):
         self,
         mineral_list,
         molar_amounts,
-        free_energy_adjustment=[],
+        energy_adjustment=[],
         name="User-created endmember",
     ):
         model = MechanicalSolution(endmembers=[[m, ""] for m in mineral_list])
@@ -54,9 +54,9 @@ class CombinedMineral(Mineral):
             "n": sum(self.mixture.formula.values()),
         }
 
-        if free_energy_adjustment != []:
-            assert len(free_energy_adjustment) == 3
-            dE, dS, dV = free_energy_adjustment
+        if energy_adjustment != []:
+            assert len(energy_adjustment) == 3
+            dE, dS, dV = energy_adjustment
             self.property_modifiers = [
                 ["linear", {"delta_E": dE, "delta_S": dS, "delta_V": dV}]
             ]

--- a/burnman/classes/elasticsolution.py
+++ b/burnman/classes/elasticsolution.py
@@ -150,7 +150,7 @@ class ElasticSolution(Mineral):
         ]
 
         gibbs_pure = [
-            self.solution_model.endmembers[i][0].method.gibbs_free_energy(
+            self.solution_model.endmembers[i][0].method.gibbs_energy(
                 self.pressure,
                 self.temperature,
                 volumes[i],

--- a/burnman/classes/elasticsolutionmodel.py
+++ b/burnman/classes/elasticsolutionmodel.py
@@ -296,7 +296,7 @@ class ElasticIdealSolution(ElasticSolutionModel):
     def pressure_hessian(self, volume, temperature, molar_fractions):
         return np.zeros((len(molar_fractions), len(molar_fractions)))
 
-    def _configurational_entropy(self, molar_fractions):
+    def configurational_entropy(self, molar_fractions):
         site_noccupancies = np.einsum(
             "i, ij", molar_fractions, self.endmember_noccupancies
         )

--- a/burnman/classes/mineral.py
+++ b/burnman/classes/mineral.py
@@ -224,7 +224,7 @@ class Mineral(Material):
     @copy_documentation(Material.molar_gibbs)
     def molar_gibbs(self):
         return (
-            self.method.gibbs_free_energy(
+            self.method.gibbs_energy(
                 self.pressure,
                 self.temperature,
                 self._molar_volume_unmodified,

--- a/burnman/classes/solution.py
+++ b/burnman/classes/solution.py
@@ -201,7 +201,7 @@ class Solution(Mineral):
         Returns excess partial molar gibbs free energy [J/mol].
         Property specific to solutions.
         """
-        return self.solution_model.excess_partial_gibbs_free_energies(
+        return self.solution_model.excess_partial_gibbs_energies(
             self.pressure, self.temperature, self.molar_fractions
         )
 
@@ -264,7 +264,7 @@ class Solution(Mineral):
         Returns molar excess gibbs free energy [J/mol].
         Property specific to solutions.
         """
-        return self.solution_model.excess_gibbs_free_energy(
+        return self.solution_model.excess_gibbs_energy(
             self.pressure, self.temperature, self.molar_fractions
         )
 

--- a/burnman/classes/solutionmodel.py
+++ b/burnman/classes/solutionmodel.py
@@ -1251,8 +1251,11 @@ class PolynomialSolution(IdealSolution):
 
     def _make_interaction_arrays(self, Ws, n):
         """
-        A hidden convenience function that splits each
-        excess term into _summary_
+        A hidden convenience function that splits the user-defined
+        excess interaction terms into an array of interaction values
+        and a list of Interaction dataclass objects that facilitate
+        fast computation of first and second compositional derivatives
+        of thermodynamic properties.
 
         :param Ws: List of interactions in form input by the user.
         :type Ws: list of lists

--- a/burnman/classes/solutionmodel.py
+++ b/burnman/classes/solutionmodel.py
@@ -185,7 +185,7 @@ class SolutionModel(object):
         """
         pass
 
-    def excess_gibbs_free_energy(self, pressure, temperature, molar_fractions):
+    def excess_gibbs_energy(self, pressure, temperature, molar_fractions):
         """
         Given a list of molar fractions of different phases,
         compute the excess Gibbs free energy of the solution.
@@ -205,9 +205,7 @@ class SolutionModel(object):
         """
         return np.dot(
             np.array(molar_fractions),
-            self.excess_partial_gibbs_free_energies(
-                pressure, temperature, molar_fractions
-            ),
+            self.excess_partial_gibbs_energies(pressure, temperature, molar_fractions),
         )
 
     def excess_volume(self, pressure, temperature, molar_fractions):
@@ -271,13 +269,11 @@ class SolutionModel(object):
         :returns: The excess enthalpy of the solution.
         :rtype: float
         """
-        return self.excess_gibbs_free_energy(
+        return self.excess_gibbs_energy(
             pressure, temperature, molar_fractions
         ) + temperature * self.excess_entropy(pressure, temperature, molar_fractions)
 
-    def excess_partial_gibbs_free_energies(
-        self, pressure, temperature, molar_fractions
-    ):
+    def excess_partial_gibbs_energies(self, pressure, temperature, molar_fractions):
         """
         Given a list of molar fractions of different phases,
         compute the excess Gibbs free energy for each endmember
@@ -375,7 +371,7 @@ class MechanicalSolution(SolutionModel):
         self.n_endmembers = len(endmembers)
         self.site_formulae = [e[1] for e in endmembers]
 
-    def excess_gibbs_free_energy(self, pressure, temperature, molar_fractions):
+    def excess_gibbs_energy(self, pressure, temperature, molar_fractions):
         return 0.0
 
     def excess_volume(self, pressure, temperature, molar_fractions):
@@ -387,9 +383,7 @@ class MechanicalSolution(SolutionModel):
     def excess_enthalpy(self, pressure, temperature, molar_fractions):
         return 0.0
 
-    def excess_partial_gibbs_free_energies(
-        self, pressure, temperature, molar_fractions
-    ):
+    def excess_partial_gibbs_energies(self, pressure, temperature, molar_fractions):
         return np.zeros_like(molar_fractions)
 
     def excess_partial_volumes(self, pressure, temperature, molar_fractions):
@@ -440,9 +434,7 @@ class IdealSolution(SolutionModel):
         )
         self.endmember_configurational_entropies = S_conf
 
-    def excess_partial_gibbs_free_energies(
-        self, pressure, temperature, molar_fractions
-    ):
+    def excess_partial_gibbs_energies(self, pressure, temperature, molar_fractions):
         return self._ideal_excess_partial_gibbs(temperature, molar_fractions)
 
     def excess_partial_entropies(self, pressure, temperature, molar_fractions):
@@ -656,9 +648,7 @@ class AsymmetricRegularSolution(IdealSolution):
         Vint = self._non_ideal_interactions(self.Wv, molar_fractions)
         return Eint - temperature * Sint + pressure * Vint
 
-    def excess_partial_gibbs_free_energies(
-        self, pressure, temperature, molar_fractions
-    ):
+    def excess_partial_gibbs_energies(self, pressure, temperature, molar_fractions):
         ideal_gibbs = IdealSolution._ideal_excess_partial_gibbs(
             self, temperature, molar_fractions
         )
@@ -888,9 +878,7 @@ class SubregularSolution(IdealSolution):
         Eint, Sint, Vint = self._non_ideal_interactions(molar_fractions)
         return Eint - temperature * Sint + pressure * Vint
 
-    def excess_partial_gibbs_free_energies(
-        self, pressure, temperature, molar_fractions
-    ):
+    def excess_partial_gibbs_energies(self, pressure, temperature, molar_fractions):
         ideal_gibbs = IdealSolution._ideal_excess_partial_gibbs(
             self, temperature, molar_fractions
         )
@@ -1031,9 +1019,7 @@ class FunctionSolution(IdealSolution):
 
         self.volume_hessian = volume_hess
 
-    def excess_partial_gibbs_free_energies(
-        self, pressure, temperature, molar_fractions
-    ):
+    def excess_partial_gibbs_energies(self, pressure, temperature, molar_fractions):
         ideal_gibbs = IdealSolution._ideal_excess_partial_gibbs(
             self, temperature, molar_fractions
         )
@@ -1491,9 +1477,7 @@ class PolynomialSolution(IdealSolution):
         gibbs += np.einsum("i, ij->j", mbr_gibbs, mbr_gradients)
         return gibbs
 
-    def excess_partial_gibbs_free_energies(
-        self, pressure, temperature, molar_fractions
-    ):
+    def excess_partial_gibbs_energies(self, pressure, temperature, molar_fractions):
         ideal_gibbs = IdealSolution._ideal_excess_partial_gibbs(
             self, temperature, molar_fractions
         )

--- a/burnman/classes/solutionmodel.py
+++ b/burnman/classes/solutionmodel.py
@@ -462,7 +462,7 @@ class IdealSolution(SolutionModel):
     def volume_hessian(self, pressure, temperature, molar_fractions):
         return np.zeros((len(molar_fractions), len(molar_fractions)))
 
-    def _configurational_entropy(self, molar_fractions):
+    def configurational_entropy(self, molar_fractions):
         site_noccupancies = np.einsum(
             "i, ij", molar_fractions, self.endmember_noccupancies
         )

--- a/burnman/eos/aa.py
+++ b/burnman/eos/aa.py
@@ -344,7 +344,7 @@ class AA(eos.EquationOfState):
 
         return C_p
 
-    def gibbs_free_energy(self, pressure, temperature, volume, params):
+    def gibbs_energy(self, pressure, temperature, volume, params):
         """
         Returns the Gibbs free energy at the pressure and temperature of the mineral [J/mol]
         F + PV

--- a/burnman/eos/birch_murnaghan.py
+++ b/burnman/eos/birch_murnaghan.py
@@ -301,7 +301,7 @@ class BirchMurnaghanBase(eos.IsothermalEquationOfState):
 
         return -intPdV + params["E_0"]
 
-    def gibbs_free_energy(self, pressure, temperature, volume, params):
+    def gibbs_energy(self, pressure, temperature, volume, params):
         """
         Returns the Gibbs free energy :math:`\\mathcal{G}`
         of the mineral. :math:`[J/mol]`

--- a/burnman/eos/brosh_calphad.py
+++ b/burnman/eos/brosh_calphad.py
@@ -397,7 +397,7 @@ class BroshCalphad(eos.EquationOfState):
 
         return C_T
 
-    def gibbs_free_energy(self, pressure, temperature, volume, params):
+    def gibbs_energy(self, pressure, temperature, volume, params):
         """
         Returns the Gibbs free energy of the mineral. :math:`[J/mol]`
         """

--- a/burnman/eos/cork.py
+++ b/burnman/eos/cork.py
@@ -192,7 +192,7 @@ class CORK(eos.EquationOfState):
 
         return Cp0 - temperature * d2RTlnfdTdT
 
-    def gibbs_free_energy(self, pressure, temperature, volume, params):
+    def gibbs_energy(self, pressure, temperature, volume, params):
         """
         Returns the gibbs free energy [J/mol] as a function of pressure [Pa]
         and temperature [K].

--- a/burnman/eos/debye.py
+++ b/burnman/eos/debye.py
@@ -169,7 +169,7 @@ def molar_heat_capacity_v(T, debye_T, n):
 
 
 @jit(nopython=True)
-def helmholtz_free_energy(T, debye_T, n):
+def helmholtz_energy(T, debye_T, n):
     """
     Helmholtz free energy of lattice vibrations in the Debye model [J].
     It is important to note that this does NOT include the zero

--- a/burnman/eos/dks_liquid.py
+++ b/burnman/eos/dks_liquid.py
@@ -663,12 +663,12 @@ class DKS_L(eos.EquationOfState):
         ) / self.isothermal_bulk_modulus_reuss(0.0, temperature, volume, params)
         return alpha
 
-    def gibbs_free_energy(self, pressure, temperature, volume, params):
+    def gibbs_energy(self, pressure, temperature, volume, params):
         """
         Returns the Gibbs free energy at the pressure and temperature of the mineral [J/mol]
         """
         G = (
-            self._helmholtz_free_energy(pressure, temperature, volume, params)
+            self._helmholtz_energy(pressure, temperature, volume, params)
             + pressure * volume
         )
         return G
@@ -685,7 +685,7 @@ class DKS_L(eos.EquationOfState):
         )
         return S
 
-    def _helmholtz_free_energy(self, pressure, temperature, volume, params):
+    def _helmholtz_energy(self, pressure, temperature, volume, params):
         """
         Returns the Helmholtz free energy at the pressure and temperature of the mineral [J/mol]
         """
@@ -701,7 +701,7 @@ class DKS_L(eos.EquationOfState):
         """
         Returns the Helmholtz free energy at the pressure and temperature of the mineral [J/mol]
         """
-        F = self._helmholtz_free_energy(pressure, temperature, volume, params)
+        F = self._helmholtz_energy(pressure, temperature, volume, params)
         S = self.entropy(pressure, temperature, volume, params)
         return F + temperature * S
 

--- a/burnman/eos/dks_solid.py
+++ b/burnman/eos/dks_solid.py
@@ -228,12 +228,12 @@ class DKS_S(eos.EquationOfState):
         alpha = gr * C_v / K / volume
         return alpha
 
-    def gibbs_free_energy(self, pressure, temperature, volume, params):
+    def gibbs_energy(self, pressure, temperature, volume, params):
         """
         Returns the Gibbs free energy at the pressure and temperature of the mineral [J/mol]
         """
         G = (
-            self._helmholtz_free_energy(pressure, temperature, volume, params)
+            self._helmholtz_energy(pressure, temperature, volume, params)
             + pressure * volume
         )
         return G
@@ -252,7 +252,7 @@ class DKS_S(eos.EquationOfState):
 
         return S_0 + S_th
 
-    def _helmholtz_free_energy(self, pressure, temperature, volume, params):
+    def _helmholtz_energy(self, pressure, temperature, volume, params):
         """
         Returns the Helmholtz free energy at the pressure and temperature of the mineral [J/mol]
         """

--- a/burnman/eos/einstein.py
+++ b/burnman/eos/einstein.py
@@ -63,7 +63,7 @@ def molar_heat_capacity_v(T, einstein_T, n):
 
 
 @jit(nopython=True)
-def helmholtz_free_energy(T, einstein_T, n):
+def helmholtz_energy(T, einstein_T, n):
     """
     Helmholtz free energy of lattice vibrations in the Einstein model [J].
     It is important to note that this does NOT include the zero

--- a/burnman/eos/equation_of_state.py
+++ b/burnman/eos/equation_of_state.py
@@ -241,7 +241,7 @@ class EquationOfState(object):
         """
         raise NotImplementedError("")
 
-    def gibbs_free_energy(self, pressure, temperature, volume, params):
+    def gibbs_energy(self, pressure, temperature, volume, params):
         """
         :param pressure: Pressure at which to evaluate the equation of state
             :math:`[Pa]`.
@@ -264,7 +264,7 @@ class EquationOfState(object):
         """
         raise NotImplementedError("")
 
-    def helmholtz_free_energy(self, pressure, temperature, volume, params):
+    def helmholtz_energy(self, pressure, temperature, volume, params):
         """
         :param pressure: Pressure at which to evaluate the equation of state
             :math:`[Pa]`.

--- a/burnman/eos/hp.py
+++ b/burnman/eos/hp.py
@@ -97,7 +97,7 @@ class HP_TMT(eos.EquationOfState):
         )
         return Cp
 
-    def gibbs_free_energy(self, pressure, temperature, volume, params):
+    def gibbs_energy(self, pressure, temperature, volume, params):
         """
         Returns the gibbs free energy [J/mol] as a function of pressure [Pa]
         and temperature [K].
@@ -411,7 +411,7 @@ class HP_TMTL(eos.EquationOfState):
         )
         return Cp
 
-    def gibbs_free_energy(self, pressure, temperature, volume, params):
+    def gibbs_energy(self, pressure, temperature, volume, params):
         """
         Returns the gibbs free energy [J/mol] as a function of pressure [Pa]
         and temperature [K].
@@ -434,8 +434,8 @@ class HP_TMTL(eos.EquationOfState):
         # so here we take a numerical derivative.
         # TODO Derive and use the analytical derivative.
         dT = 0.1
-        G1 = self.gibbs_free_energy(pressure, temperature + dT / 2.0, volume, params)
-        G0 = self.gibbs_free_energy(pressure, temperature - dT / 2.0, volume, params)
+        G1 = self.gibbs_energy(pressure, temperature + dT / 2.0, volume, params)
+        G0 = self.gibbs_energy(pressure, temperature - dT / 2.0, volume, params)
 
         return (G0 - G1) / dT
 
@@ -633,7 +633,7 @@ class HP98(eos.EquationOfState):
         )
         return Cp
 
-    def gibbs_free_energy(self, pressure, temperature, volume, params):
+    def gibbs_energy(self, pressure, temperature, volume, params):
         """
         Returns the gibbs free energy [J/mol] as a function of pressure [Pa]
         and temperature [K].

--- a/burnman/eos/macaw.py
+++ b/burnman/eos/macaw.py
@@ -105,7 +105,7 @@ class MACAW(eos.IsothermalEquationOfState):
         I0 = (-A * (B + C) + params["P_0"]) * params["V_0"] * (Vrel - 1.0)
         return -A * I1 - I0
 
-    def gibbs_free_energy(self, pressure, temperature, volume, params):
+    def gibbs_energy(self, pressure, temperature, volume, params):
         """
         Returns the Gibbs free energy :math:`\\mathcal{G}` of the mineral. :math:`[J/mol]`
         """

--- a/burnman/eos/mie_grueneisen_debye.py
+++ b/burnman/eos/mie_grueneisen_debye.py
@@ -127,12 +127,12 @@ class MGDBase(eos.EquationOfState):
             - self._thermal_pressure(T_0, volume, params)
         )
 
-    def gibbs_free_energy(self, pressure, temperature, volume, params):
+    def gibbs_energy(self, pressure, temperature, volume, params):
         """
         Returns the Gibbs free energy at the pressure and temperature of the mineral [J/mol]
         """
         G = (
-            self._helmholtz_free_energy(pressure, temperature, volume, params)
+            self._helmholtz_energy(pressure, temperature, volume, params)
             + pressure * volume
         )
         return G
@@ -145,7 +145,7 @@ class MGDBase(eos.EquationOfState):
         S = debye.entropy(temperature, Debye_T, params["n"])
         return S
 
-    def _helmholtz_free_energy(self, pressure, temperature, volume, params):
+    def _helmholtz_energy(self, pressure, temperature, volume, params):
         """
         Returns the Helmholtz free energy at the pressure and temperature of the mineral [J/mol]
         """
@@ -160,9 +160,9 @@ class MGDBase(eos.EquationOfState):
         )
 
         Debye_T = self._debye_temperature(params["V_0"] / volume, params)
-        F_thermal = debye.helmholtz_free_energy(
+        F_thermal = debye.helmholtz_energy(
             temperature, Debye_T, params["n"]
-        ) - debye.helmholtz_free_energy(params["T_0"], Debye_T, params["n"])
+        ) - debye.helmholtz_energy(params["T_0"], Debye_T, params["n"])
 
         return params["F_0"] + F_pressure + F_thermal
 

--- a/burnman/eos/modified_tait.py
+++ b/burnman/eos/modified_tait.py
@@ -134,7 +134,7 @@ class MT(eos.IsothermalEquationOfState):
         """
         return 0.0
 
-    def gibbs_free_energy(self, pressure, temperature, volume, params):
+    def gibbs_energy(self, pressure, temperature, volume, params):
         """
         Returns the Gibbs free energy :math:`\\mathcal{G}` of the mineral. :math:`[J/mol]`
         """

--- a/burnman/eos/morse_potential.py
+++ b/burnman/eos/morse_potential.py
@@ -122,7 +122,7 @@ class Morse(eos.IsothermalEquationOfState):
 
         return -intPdV + params["E_0"]
 
-    def gibbs_free_energy(self, pressure, temperature, volume, params):
+    def gibbs_energy(self, pressure, temperature, volume, params):
         """
         Returns the Gibbs free energy :math:`\\mathcal{G}` of the mineral. :math:`[J/mol]`
         """

--- a/burnman/eos/murnaghan.py
+++ b/burnman/eos/murnaghan.py
@@ -77,7 +77,7 @@ class Murnaghan(eos.IsothermalEquationOfState):
             volume, params["E_0"], params["V_0"], params["K_0"], params["Kprime_0"]
         )
 
-    def gibbs_free_energy(self, pressure, temperature, volume, params):
+    def gibbs_energy(self, pressure, temperature, volume, params):
         """
         Returns the Gibbs free energy :math:`\\mathcal{G}` of the mineral.
         :math:`[J/mol]`

--- a/burnman/eos/property_modifiers.py
+++ b/burnman/eos/property_modifiers.py
@@ -541,7 +541,7 @@ def _debye_excesses(pressure, temperature, params):
     f = params["Cv_inf"] / 3.0 / gas_constant
     theta = params["Theta_0"]
 
-    G = debye.helmholtz_free_energy(temperature, theta, f)
+    G = debye.helmholtz_energy(temperature, theta, f)
     dGdT = -debye.entropy(temperature, theta, f)
     dGdP = 0.0
     if temperature > 1.0e-20:
@@ -603,7 +603,7 @@ def _einstein_excesses(pressure, temperature, params):
     f = params["Cv_inf"] / 3.0 / gas_constant
     theta = params["Theta_0"]
 
-    G = einstein.helmholtz_free_energy(temperature, theta, f)
+    G = einstein.helmholtz_energy(temperature, theta, f)
     dGdT = -einstein.entropy(temperature, theta, f)
     dGdP = 0.0
     if temperature > 1.0e-20:

--- a/burnman/eos/reciprocal_kprime.py
+++ b/burnman/eos/reciprocal_kprime.py
@@ -214,7 +214,7 @@ class RKprime(eos.IsothermalEquationOfState):
 
         return i1
 
-    def gibbs_free_energy(self, pressure, temperature, volume, params):
+    def gibbs_energy(self, pressure, temperature, volume, params):
         """
         Returns the Gibbs free energy :math:`\\mathcal{G}` of the mineral. :math:`[J/mol]`
         """

--- a/burnman/eos/slb.py
+++ b/burnman/eos/slb.py
@@ -407,7 +407,7 @@ class SLBBase(eos.EquationOfState):
             )
         return S
 
-    def _helmholtz_free_energy(self, pressure, temperature, volume, params):
+    def _helmholtz_energy(self, pressure, temperature, volume, params):
         """
         Returns the Helmholtz free energy at the pressure and temperature
         of the mineral [J/mol]
@@ -416,9 +416,9 @@ class SLBBase(eos.EquationOfState):
         f = 1.0 / 2.0 * (pow(x, 2.0 / 3.0) - 1.0)
         Debye_T = self._debye_temperature(params["V_0"] / volume, params)
 
-        F_quasiharmonic = debye.helmholtz_free_energy(
+        F_quasiharmonic = debye.helmholtz_energy(
             temperature, Debye_T, params["n"]
-        ) - debye.helmholtz_free_energy(params["T_0"], Debye_T, params["n"])
+        ) - debye.helmholtz_energy(params["T_0"], Debye_T, params["n"])
 
         b_iikk = 9.0 * params["K_0"]  # EQ 28
         b_iikkmm = 27.0 * params["K_0"] * (params["Kprime_0"] - 4.0)  # EQ 29
@@ -476,13 +476,13 @@ class SLBBase(eos.EquationOfState):
         C_p = C_v + alpha * alpha * K_T * volume * temperature
         return C_p
 
-    def gibbs_free_energy(self, pressure, temperature, volume, params):
+    def gibbs_energy(self, pressure, temperature, volume, params):
         """
         Returns the Gibbs free energy at the pressure and temperature
         of the mineral [J/mol]
         """
         G = (
-            self._helmholtz_free_energy(pressure, temperature, volume, params)
+            self._helmholtz_energy(pressure, temperature, volume, params)
             + pressure * volume
         )
         return G

--- a/burnman/eos/spock.py
+++ b/burnman/eos/spock.py
@@ -139,7 +139,7 @@ class SPOCK(eos.IsothermalEquationOfState):
 
         return params["E_0"] + params["P_0"] * (volume - params["V_0"]) + f * (I1 - I2)
 
-    def gibbs_free_energy(self, pressure, temperature, volume, params):
+    def gibbs_energy(self, pressure, temperature, volume, params):
         """
         Returns the Gibbs free energy :math:`\\mathcal{G}` of the mineral. :math:`[J/mol]`
         """

--- a/burnman/eos/vinet.py
+++ b/burnman/eos/vinet.py
@@ -89,7 +89,7 @@ class Vinet(eos.IsothermalEquationOfState):
         """
         return 0.0
 
-    def gibbs_free_energy(self, pressure, temperature, volume, params):
+    def gibbs_energy(self, pressure, temperature, volume, params):
         """
         Returns the Gibbs free energy :math:`\\mathcal{G}` of the mineral. :math:`[J/mol]`
         """

--- a/burnman/minerals/JH_2015.py
+++ b/burnman/minerals/JH_2015.py
@@ -129,7 +129,7 @@ class cfs(CombinedMineral):
             name="clinoferrosilite",
             mineral_list=[HP_2011_ds62.fs()],
             molar_amounts=[1.0],
-            free_energy_adjustment=[3.8e3, 3.0, 0.03e-5],
+            energy_adjustment=[3.8e3, 3.0, 0.03e-5],
         )
 
 
@@ -140,7 +140,7 @@ class crdi(CombinedMineral):
             name="chromium diopside",
             mineral_list=[HP_2011_ds62.cats(), HP_2011_ds62.kos(), HP_2011_ds62.jd()],
             molar_amounts=[1.0, 1.0, -1.0],
-            free_energy_adjustment=[-3.0e3, 0.0, 0.0],
+            energy_adjustment=[-3.0e3, 0.0, 0.0],
         )
 
 
@@ -151,7 +151,7 @@ class cess(CombinedMineral):
             name="ferric diopside",
             mineral_list=[HP_2011_ds62.cats(), HP_2011_ds62.acm(), HP_2011_ds62.jd()],
             molar_amounts=[1.0, 1.0, -1.0],
-            free_energy_adjustment=[-6.0e3, 0.0, 0.0],
+            energy_adjustment=[-6.0e3, 0.0, 0.0],
         )
 
 
@@ -162,7 +162,7 @@ class cen(CombinedMineral):
             name="clinoenstatite",
             mineral_list=[HP_2011_ds62.en()],
             molar_amounts=[1.0],
-            free_energy_adjustment=[3.5e3, 2.0, 0.048e-5],
+            energy_adjustment=[3.5e3, 2.0, 0.048e-5],
         )
 
 
@@ -173,7 +173,7 @@ class cfm(CombinedMineral):
             name="ordered clinoferroenstatite",
             mineral_list=[HP_2011_ds62.en(), HP_2011_ds62.fs()],
             molar_amounts=[0.5, 0.5],
-            free_energy_adjustment=[-3.0e3, 0.0, 0.0],
+            energy_adjustment=[-3.0e3, 0.0, 0.0],
         )
 
 
@@ -281,7 +281,7 @@ class fm(CombinedMineral):
             name="ordered ferroenstatite",
             mineral_list=[HP_2011_ds62.en(), HP_2011_ds62.fs()],
             molar_amounts=[0.5, 0.5],
-            free_energy_adjustment=[-6.0e3, 0.0, 0.0],
+            energy_adjustment=[-6.0e3, 0.0, 0.0],
         )
 
 
@@ -292,7 +292,7 @@ class odi(CombinedMineral):
             name="orthodiopside",
             mineral_list=[HP_2011_ds62.di()],
             molar_amounts=[1.0],
-            free_energy_adjustment=[-0.1e3, -0.211, 0.005e-5],
+            energy_adjustment=[-0.1e3, -0.211, 0.005e-5],
         )  # note sign of *entropy* change.
 
 
@@ -303,7 +303,7 @@ class cren(CombinedMineral):
             name="chromium enstatite",
             mineral_list=[HP_2011_ds62.mgts(), HP_2011_ds62.kos(), HP_2011_ds62.jd()],
             molar_amounts=[1.0, 1.0, -1.0],
-            free_energy_adjustment=[3.0e3, 0.0, 0.0],
+            energy_adjustment=[3.0e3, 0.0, 0.0],
         )
 
 
@@ -314,7 +314,7 @@ class mess(CombinedMineral):
             name="ferrienstatite",
             mineral_list=[HP_2011_ds62.mgts(), HP_2011_ds62.acm(), HP_2011_ds62.jd()],
             molar_amounts=[1.0, 1.0, -1.0],
-            free_energy_adjustment=[-15.0e3, 0.0, 0.15e-5],
+            energy_adjustment=[-15.0e3, 0.0, 0.15e-5],
         )
 
 

--- a/examples/example_mineral.py
+++ b/examples/example_mineral.py
@@ -104,7 +104,7 @@ if __name__ == "__main__":
         name="ordered ferroenstatite",
         mineral_list=[HGP_2018_ds633.en(), HGP_2018_ds633.fs()],
         molar_amounts=[0.5, 0.5],
-        free_energy_adjustment=[-6.0e3, 0.0, 0.0],
+        energy_adjustment=[-6.0e3, 0.0, 0.0],
     )
     print(
         f"Formula of CombinedMineral {fe_mg_orthopyroxene.name}: "

--- a/examples/example_solution.py
+++ b/examples/example_solution.py
@@ -295,7 +295,7 @@ if __name__ == "__main__":
         molar_fractions = [1.0 - c, 0.0, c]
         g3.set_composition(molar_fractions)
         g3.set_state(P, T)
-        Sconf = g3.solution_model._configurational_entropy(molar_fractions)
+        Sconf = g3.solution_model.configurational_entropy(molar_fractions)
         Gex = g3.solution_model._ideal_excess_partial_gibbs(T, molar_fractions)
         g3_configurational_entropy[i] = Sconf
         g3_excess_entropy[i] = -np.dot(molar_fractions, Gex) / T

--- a/misc/benchmarks/solidsolution_benchmarks.py
+++ b/misc/benchmarks/solidsolution_benchmarks.py
@@ -56,7 +56,7 @@ for i, c in enumerate(comp):
     molar_fractions = [1.0 - c, c]
     sp.set_composition(np.array(molar_fractions))
     sp.set_state(1e5, 298.15)
-    sp_entropies[i] = sp.solution_model._configurational_entropy(molar_fractions)
+    sp_entropies[i] = sp.solution_model.configurational_entropy(molar_fractions)
     sp_entropies_NK1967[i] = -8.3145 * (
         c * np.log(c)
         + (1.0 - c) * np.log(1.0 - c)
@@ -147,7 +147,7 @@ for idx, model in enumerate(opx_models):
         molar_fractions = [1.0 - c, c]
         model.set_composition(np.array(molar_fractions))
         model.set_state(0.0, 0.0)
-        opx_entropies[idx][i] = model.solution_model._configurational_entropy(
+        opx_entropies[idx][i] = model.solution_model.configurational_entropy(
             molar_fractions
         )
 

--- a/tests/test_debye.py
+++ b/tests/test_debye.py
@@ -36,7 +36,7 @@ class Debye(BurnManTest):
     def test_return_zero(self):
         rock = mypericlase()
         x = 0.0
-        test_helmholtz = burnman.eos.debye.helmholtz_free_energy(
+        test_helmholtz = burnman.eos.debye.helmholtz_energy(
             x, rock.params["Debye_0"], rock.params["n"]
         )
         self.assertFloatEqual(test_helmholtz, 0.0)
@@ -52,7 +52,7 @@ class Debye(BurnManTest):
     def test_small(self):
         rock = mypericlase()
         x = 1e-16
-        test_helmholtz = burnman.eos.debye.helmholtz_free_energy(
+        test_helmholtz = burnman.eos.debye.helmholtz_energy(
             x, rock.params["Debye_0"], rock.params["n"]
         )
         self.assertFloatEqual(test_helmholtz, 0.0)

--- a/tests/test_eos.py
+++ b/tests/test_eos.py
@@ -443,8 +443,8 @@ class test_eos_validation(BurnManTest):
         ) / dT
         S2 = (
             -(
-                debye.helmholtz_free_energy(T + dT / 2.0, debye_T, n)
-                - debye.helmholtz_free_energy(T - dT / 2.0, debye_T, n)
+                debye.helmholtz_energy(T + dT / 2.0, debye_T, n)
+                - debye.helmholtz_energy(T - dT / 2.0, debye_T, n)
             )
             / dT
         )

--- a/tests/test_solution.py
+++ b/tests/test_solution.py
@@ -1441,6 +1441,43 @@ class test_solidsolution(BurnManTest):
         self.assertEqual(old_formula, new_formula)
         self.assertAlmostEqual(ss.gibbs, new_ss.gibbs)
 
+    def test_solution_model_functions(self):
+        sm = burnman.classes.solutionmodel.SolutionModel()
+        P = 1.0e9
+        T = 1000.0
+        f = np.array([1.0, 0.0])
+        pGs = sm.excess_partial_gibbs_energies(P, T, f)
+        pSs = sm.excess_partial_entropies(P, T, f)
+        pVs = sm.excess_partial_volumes(P, T, f)
+        zeros = np.zeros(2)
+        np.testing.assert_allclose(pGs, zeros)
+        np.testing.assert_allclose(pSs, zeros)
+        np.testing.assert_allclose(pVs, zeros)
+
+    def test_mechanical_solution_model_functions(self):
+        sm = burnman.classes.solutionmodel.MechanicalSolution(
+            [[forsterite(), ""], [fayalite(), ""]]
+        )
+        P = 1.0e9
+        T = 1000.0
+        f = np.array([1.0, 0.0])
+        pGs = sm.excess_partial_gibbs_energies(P, T, f)
+        pSs = sm.excess_partial_entropies(P, T, f)
+        pVs = sm.excess_partial_volumes(P, T, f)
+
+        H_xs = sm.excess_enthalpy(P, T, f)
+        gammas = sm.activity_coefficients(P, T, f)
+        alphas = sm.activities(P, T, f)
+
+        zeros = np.zeros(2)
+        ones = np.ones(2)
+        np.testing.assert_allclose(pGs, zeros)
+        np.testing.assert_allclose(pSs, zeros)
+        np.testing.assert_allclose(pVs, zeros)
+        np.testing.assert_allclose(gammas, ones)
+        np.testing.assert_allclose(alphas, ones)
+        np.testing.assert_almost_equal(H_xs, 0.0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_solution.py
+++ b/tests/test_solution.py
@@ -19,6 +19,7 @@ from burnman.minerals.SLB_2011 import mg_post_perovskite
 from burnman.minerals.SLB_2011 import fe_post_perovskite
 from burnman.minerals.SLB_2011 import al_post_perovskite
 from burnman.tools.eos import check_eos_consistency
+from burnman.tools.solution import transform_solution_to_new_basis
 
 
 class forsterite(Mineral):
@@ -1327,6 +1328,118 @@ class test_solidsolution(BurnManTest):
             ropx.isothermal_compressibility_reuss
             > ropx.unrelaxed.isothermal_compressibility_reuss
         )
+
+    def test_transform_ideal(self):
+        ol = olivine_ideal_ss()
+        new_ol = transform_solution_to_new_basis(
+            ol, [[0.25, 0.75], [0.75, 0.25]], endmember_names=["fafo", "fofa"]
+        )
+
+        P = 1.0e9
+        T = 1000.0
+        ol.set_composition([0.5, 0.5])
+        new_ol.set_composition([0.5, 0.5])
+        ol.set_state(P, T)
+        new_ol.set_state(P, T)
+        old_formula = burnman.utils.chemistry.formula_to_string(ol.formula)
+        new_formula = burnman.utils.chemistry.formula_to_string(new_ol.formula)
+        self.assertEqual(old_formula, new_formula)
+        self.assertAlmostEqual(ol.gibbs, new_ol.gibbs)
+
+    def test_transform_asymmetric(self):
+        cpx = burnman.minerals.JH_2015.clinopyroxene()
+        new_cpx = transform_solution_to_new_basis(
+            cpx,
+            [[1, 1, 0, 0, 0, 0, 0, -1], [0, 0, 1, 0, 0, 0, 0, 0]],
+            solution_name="fdi-cats",
+        )
+
+        P = 1.0e9
+        T = 1000.0
+        cpx.set_composition([0.5, 0.5, 0.5, 0, 0, 0, 0, -0.5])
+        new_cpx.set_composition([0.5, 0.5])
+        cpx.set_state(P, T)
+        new_cpx.set_state(P, T)
+        old_formula = burnman.utils.chemistry.formula_to_string(cpx.formula)
+        new_formula = burnman.utils.chemistry.formula_to_string(new_cpx.formula)
+        self.assertEqual(old_formula, new_formula)
+        self.assertAlmostEqual(cpx.gibbs, new_cpx.gibbs)
+
+    def test_transform_asymmetric_new_disordered_endmember(self):
+        cpx = burnman.minerals.JH_2015.clinopyroxene()
+        new_cpx = transform_solution_to_new_basis(
+            cpx,
+            [[0.5, 0.5, 0, 0, 0, 0, 0, 0.0], [0, 0, 1, 0, 0, 0, 0, 0]],
+            solution_name="fdi-cats",
+        )
+
+        P = 1.0e9
+        T = 1000.0
+        cpx.set_composition([0.25, 0.25, 0.5, 0, 0, 0, 0, 0])
+        new_cpx.set_composition([0.5, 0.5])
+        cpx.set_state(P, T)
+        new_cpx.set_state(P, T)
+        old_formula = burnman.utils.chemistry.formula_to_string(cpx.formula)
+        new_formula = burnman.utils.chemistry.formula_to_string(new_cpx.formula)
+        self.assertEqual(old_formula, new_formula)
+        self.assertAlmostEqual(cpx.gibbs, new_cpx.gibbs)
+
+    def test_transform_subregular_new_disordered_endmember(self):
+        ss = two_site_ss_subregular_ternary()
+        new_ss = transform_solution_to_new_basis(
+            ss,
+            [[0.25, 0.75, 0], [0, 0, 1], [0.75, 0.25, 0.0]],
+            solution_name="new",
+        )
+
+        P = 1.0e9
+        T = 1000.0
+        ss.set_composition([0.5, 0.5, 0.0])
+        new_ss.set_composition([0.5, 0.0, 0.5])
+        ss.set_state(P, T)
+        new_ss.set_state(P, T)
+        old_formula = burnman.utils.chemistry.formula_to_string(ss.formula)
+        new_formula = burnman.utils.chemistry.formula_to_string(new_ss.formula)
+        self.assertEqual(old_formula, new_formula)
+        self.assertAlmostEqual(ss.gibbs, new_ss.gibbs)
+
+    def test_transform_subregular_new_disordered_endmember_cut(self):
+        ss = two_site_ss_subregular_ternary()
+        new_ss = transform_solution_to_new_basis(
+            ss,
+            [[0.25, 0.75, 0], [0, 0, 1], [0.75, 0.25, 0.0]],
+            solution_name="new",
+            n_mbrs=2,
+        )
+
+        P = 1.0e9
+        T = 1000.0
+        ss.set_composition([0.125, 0.375, 0.5])
+        new_ss.set_composition([0.5, 0.5])
+        ss.set_state(P, T)
+        new_ss.set_state(P, T)
+        old_formula = burnman.utils.chemistry.formula_to_string(ss.formula)
+        new_formula = burnman.utils.chemistry.formula_to_string(new_ss.formula)
+        self.assertEqual(old_formula, new_formula)
+        self.assertAlmostEqual(ss.gibbs, new_ss.gibbs)
+
+    def test_transform_subregular_one_disordered_endmember(self):
+        ss = two_site_ss_subregular_ternary()
+        new_ss = transform_solution_to_new_basis(
+            ss,
+            [[0.5, 0.5, 0]],
+            solution_name="new",
+        )
+
+        P = 1.0e9
+        T = 1000.0
+        ss.set_composition([0.5, 0.5, 0.0])
+        ss.set_state(P, T)
+        new_ss.set_state(P, T)
+        old_formula = burnman.utils.chemistry.formula_to_string(ss.formula)
+        new_formula = burnman.utils.chemistry.formula_to_string(new_ss.formula)
+        self.assertEqual(old_formula, new_formula)
+        self.assertAlmostEqual(ss.gibbs, new_ss.gibbs)
 
 
 if __name__ == "__main__":

--- a/tutorial/tutorial_01_material_classes.ipynb
+++ b/tutorial/tutorial_01_material_classes.ipynb
@@ -302,7 +302,7 @@
         "                                      mineral_list=[HP_2011_ds62.en(),\n",
         "                                                    HP_2011_ds62.fs()],\n",
         "                                      molar_amounts=[0.5, 0.5],\n",
-        "                                      free_energy_adjustment=[-6.e3, 0., 0.])\n",
+        "                                      energy_adjustment=[-6.e3, 0., 0.])\n",
         "print(fe_mg_orthopyroxene.formula)"
       ]
     },


### PR DESCRIPTION
This PR makes a few changes to the solution model structure:
- `burnman.tools.solution.transform_solution_to_new_basis()` now correctly calculates the new endmember entropies, incorporating a term from configurational entropy when the new endmembers are disordered on one or more sites.
- Functions and arguments with `free_energ` in their names have been replaced by the same name but without the "free", in line with IUPAC recommendations.
- Several functions in `burnman/classes/solution.py` now have improved docstrings
- The hidden method `_configurational_entropy()` in `burnman/classes/solutionmodel.py` is now `configurational_entropy()`, given its use in several examples.
- There are now several more tests in `tests/test_solution.py`, increasing overall coverage to >93%