### PR TITLE
Modular Mie-Debye-Grueneisen equation of state

### DIFF
--- a/burnman/eos/__init__.py
+++ b/burnman/eos/__init__.py
@@ -1,6 +1,6 @@
 # This file is part of BurnMan - a thermoelastic and thermodynamic toolkit for
 # the Earth and Planetary Sciences
-# Copyright (C) 2012 - 2021 by the BurnMan team, released under the GNU
+# Copyright (C) 2012 - 2025 by the BurnMan team, released under the GNU
 # GPL v2 or later.
 
 
@@ -17,6 +17,13 @@ from .murnaghan import Murnaghan
 from .birch_murnaghan import BM3Shear2, BM3, BM4
 from .mie_grueneisen_debye import MGD2, MGD3
 from .slb import SLB2, SLB3, SLB3Conductive
+from .modular_mie_grueneisen_debye import ModularMGD
+from .debye_temperature_models import (
+    DebyeTemperatureModelBase,
+    SLB,
+    PowerLawGammaSimple,
+    PowerLawGamma,
+)
 from .modified_tait import MT
 from .hp import HP_TMT
 from .hp import HP_TMTL

--- a/burnman/eos/anharmonic_debye_pade.py
+++ b/burnman/eos/anharmonic_debye_pade.py
@@ -1,0 +1,362 @@
+# This file is part of BurnMan - a thermoelastic and thermodynamic toolkit for the Earth and Planetary Sciences
+# Copyright (C) 2012 - 2025 by the BurnMan team, released under the GNU
+# GPL v2 or later.
+
+import numpy as np
+
+try:
+    import os
+
+    if "NUMBA_DISABLE_JIT" in os.environ and int(os.environ["NUMBA_DISABLE_JIT"]) == 1:
+        raise ImportError("NOOOO!")
+    from numba import jit
+except ImportError:
+
+    def jit(nopython=True):
+        def decorator(fn):
+            return fn
+
+        return decorator
+
+
+# Pade coefficients for approximation of the anharmonic contribution to the
+# Helmholtz energy. Based on the Taylor expansion of the integral of the
+# Debye thermal energy at x_0 = 0.4 divided by x^4,
+# followed by a 3-5 Pade approximation multiplied by x^4.
+p = np.array([0.0, 0.0, 0.0, 0.0, 0.235256039, -0.00744162069, 23.0722431, 366.827130])
+q = np.array([1.0, 4.1784544, 46.00154792, 168.5910059, 568.90929887, 737.13224108])
+
+# First derivatives
+p1 = np.polyder(p[::-1])[::-1]
+q1 = np.polyder(q[::-1])[::-1]
+
+# Second derivatives
+p2 = np.polyder(p1[::-1])[::-1]
+q2 = np.polyder(q1[::-1])[::-1]
+
+
+@jit(nopython=True)
+def _helmholtz_pade_pq(t, to_nth_derivative=0):
+    """
+    Evaluate the Pade approximant to the nondimensional Helmholtz energy
+    at a given nondimensional temperature. See the documentation of
+    `helmholtz_energy` for details on the model.
+
+    :param t: Nondimensional temperature, defined as
+    :math:`T / T_{D}`, where :math:`T_{D}` is the
+    Debye temperature.
+    :param to_nth_derivative: If 0, return p and q. If 1, also return the
+    first derivatives of p and q. If 2, also return the second derivatives
+    of p and q.
+    :return: A tuple containing the coefficients of the Pade approximant in
+    the form ([p, ...], [q, ...]) up to the desired derivative.
+    :rtype: tuple of (list, list)
+    """
+    t2 = t * t
+    t3 = t2 * t
+    t4 = t3 * t
+    t5 = t4 * t
+    t6 = t5 * t
+    t7 = t6 * t
+
+    xp = [p[4] * t4 + p[5] * t5 + p[6] * t6 + p[7] * t7]
+    xq = [q[0] + q[1] * t + q[2] * t2 + q[3] * t3 + q[4] * t4 + q[5] * t5]
+
+    if to_nth_derivative > 0:
+        xp.append(p1[3] * t3 + p1[4] * t4 + p1[5] * t5 + p1[6] * t6)
+        xq.append(q1[0] + q1[1] * t + q1[2] * t2 + q1[3] * t3 + q1[4] * t4)
+
+    if to_nth_derivative > 1:
+        xp.append(p2[2] * t2 + p2[3] * t3 + p2[4] * t4 + p2[5] * t5)
+        xq.append(q2[0] + q2[1] * t + q2[2] * t2 + q2[3] * t3)
+
+    return xp, xq
+
+
+@jit(nopython=True)
+def _helmholtz_pade(t):
+    """
+    Evaluate the Pade approximant to the nondimensional Helmholtz energy
+    at a given nondimensional temperature. See the documentation of
+    `helmholtz_energy` for details on the model.
+
+    :param t: Nondimensional temperature, defined as
+    :math:`T / T_{D}`, where :math:`T_{D}` is the
+    Debye temperature.
+    :return: Nondimensional Helmholtz energy.
+    :rtype: float
+    """
+    xp, xq = _helmholtz_pade_pq(t, to_nth_derivative=0)
+    return xp[0] / xq[0]
+
+
+@jit(nopython=True)
+def _dhelmholtzdt_pade(t):
+    """
+    Evaluate the first derivative of the Pade approximant to the
+    nondimensional Helmholtz energy with respect to nondimensional temperature.
+    See the documentation of `helmholtz_energy` for details on the model.
+
+    :param t: Nondimensional temperature, defined as
+    :math:`T / T_{D}`, where :math:`T_{D}` is the
+    Debye temperature.
+    :return: float
+    """
+    xp, xq = _helmholtz_pade_pq(t, to_nth_derivative=1)
+    return (xp[1] * xq[0] - xp[0] * xq[1]) / (xq[0] * xq[0])
+
+
+@jit(nopython=True)
+def _d2helmholtzdt2_pade(t):
+    """
+    Evaluate the second derivative of the Pade approximant to the
+    nondimensional Helmholtz energy with respect to nondimensional temperature.
+    See the documentation of `helmholtz_energy` for details on the model.
+
+    :param t: Nondimensional temperature, defined as
+    :math:`T / T_{D}`, where :math:`T_{D}` is the
+    Debye temperature.
+    :return: float
+    """
+    xp, xq = _helmholtz_pade_pq(t, to_nth_derivative=2)
+    return (
+        xp[2] * xq[0] * xq[0]
+        - xp[0] * xq[2] * xq[0]
+        - 2.0 * (xp[1] * xq[0] - xp[0] * xq[1]) * xq[1]
+    ) / (xq[0] * xq[0] * xq[0])
+
+
+@jit(nopython=True)
+def _nondimensional_helmholtz_energy(T, debye_T):
+    """
+    Helmholtz free energy of the anharmonic contribution
+    at a given temperature.
+
+    This model is based on a 3-5 Pade approximation to the following
+    expression:
+    :math:`\\int_0^x (E_{D}/3nR) dt / x^{4}`, which is then
+    post-multiplied by :math:`x^{4}` to yield the Helmholtz energy.
+    The :math:`E_{D}` term inside the integral is the thermal energy of a
+    Debye solid per mole of atoms. This expression is chosen because it
+    matches the behaviour of the anharmonic contribution to the entropy
+    at low and high temperatures - i.e., it is equal to zero at low temperature
+    (with all derivatives also equal to zero) and linear at high temperature.
+    See Figure 3 in
+    Oganov and Dorogokupets (2004; dx.doi.org/10.1088/0953-8984/16/8/018).
+
+    :param T: Temperature in Kelvin.
+    :type T: float
+    :param debye_T: Debye temperature in Kelvin, which is used to
+    nondimensionalise the temperature.
+    :type debye_T: float
+    :return: Helmholtz energy
+    :rtype: float
+    """
+    t = T / debye_T
+    return _helmholtz_pade(t)
+
+
+@jit(nopython=True)
+def _nondimensional_entropy(T, debye_T):
+    """
+    Entropy of the anharmonic contribution. See the documentation of
+    `helmholtz_energy` for details on the model.
+
+    :param T: Temperature in Kelvin.
+    :type T: float
+    :param debye_T: Debye temperature in Kelvin.
+    :type debye_T: float
+    :return: Entropy
+    :rtype: float
+    """
+    t = T / debye_T
+    return -_dhelmholtzdt_pade(t) / debye_T
+
+
+@jit(nopython=True)
+def _nondimensional_heat_capacity(T, debye_T):
+    """
+    Heat capacity of the anharmonic contribution. See the documentation of
+    `helmholtz_energy` for details on the model.
+
+    :param T: Temperature in Kelvin.
+    :type T: float
+    :param debye_T: Debye temperature in Kelvin.
+    :type debye_T: float
+    :return: Heat capacity
+    :rtype: float
+    """
+    t = T / debye_T
+    return -t * _d2helmholtzdt2_pade(t) / debye_T
+
+
+@jit(nopython=True)
+def _nondimensional_dhelmholtz_dTheta(T, debye_T):
+    """
+    Derivative of the anharmonic contribution to the Helmholtz energy
+    with respect to the Debye temperature. See the documentation of
+    `helmholtz_energy` for details on the model.
+
+    :param T: Temperature in Kelvin.
+    :type T: float
+    :param debye_T: Debye temperature in Kelvin.
+    :type debye_T: float
+    :return: Derivative of Helmholtz energy with respect to Debye temperature
+    :rtype: float
+    """
+    t = T / debye_T
+    return -_dhelmholtzdt_pade(t) * t / debye_T
+
+
+@jit(nopython=True)
+def _nondimensional_d2helmholtz_dTheta2(T, debye_T):
+    """
+    Second derivative of the anharmonic contribution to the Helmholtz energy
+    with respect to the Debye temperature. See the documentation of
+    `helmholtz_energy` for details on the model.
+
+    :param T: Temperature in Kelvin.
+    :type T: float
+    :param debye_T: Debye temperature in Kelvin.
+    :type debye_T: float
+    :return: Second derivative of Helmholtz energy with respect to Debye temperature
+    :rtype: float
+    """
+    t = T / debye_T
+    return t * (t * _d2helmholtzdt2_pade(t) + 2.0 * _dhelmholtzdt_pade(t)) / debye_T**2
+
+
+@jit(nopython=True)
+def _nondimensional_dentropy_dTheta(T, debye_T):
+    """
+    Derivative of the anharmonic contribution to the entropy
+    with respect to the Debye temperature. See the documentation of
+    `helmholtz_energy` for details on the model.
+
+    :param T: Temperature in Kelvin.
+    :type T: float
+    :param debye_T: Debye temperature in Kelvin.
+    :type debye_T: float
+    :return: Derivative of entropy with respect to Debye temperature
+    :rtype: float
+    """
+    t = T / debye_T
+    return (_d2helmholtzdt2_pade(t) * t + _dhelmholtzdt_pade(t)) / debye_T**2
+
+
+class AnharmonicDebyePade:
+    """
+    Class providing methods to compute the anharmonic contribution to the
+    Helmholtz free energy, pressure, entropy, isochoric heat capacity,
+    isothermal bulk modulus and thermal expansion coefficient
+    multiplied by the isothermal bulk modulus.
+
+    The full Helmholtz free energy (relative to the reference isotherm) is
+    given by :math:`F = A * (F_a - F_a(T_0))`, where
+    :math:`A = a_{anh} * (V/V_0)^{m_{anh}}`, with both :math:`a_{anh}`
+    and :math:`m_{anh}` being parameters of the model.
+    The term :math:`F_a` is calculated using the 3-5 Pade approximant to
+    the function: :math:`\\int_0^x (E_{D}/3nR) dt / x^{4}`, then
+    post-multiplied by :math:`x^{4}`.
+
+    The :math:`E_{D}` term inside the integral is the thermal energy of a
+    Debye solid per mole of atoms. This expression is chosen because it
+    matches the behaviour of the anharmonic contribution to the entropy
+    at low and high temperatures - i.e., it is equal to zero at low temperature
+    (with all derivatives also equal to zero) and linear at high temperature.
+    See Figure 3 in Oganov and Dorogokupets
+    (2004; dx.doi.org/10.1088/0953-8984/16/8/018).
+
+    :return: _description_
+    :rtype: _type_
+    """
+
+    @staticmethod
+    def helmholtz_energy(temperature, volume, params):
+        x = volume / params["V_0"]
+        A = params["a_anh"] * np.power(x, params["m_anh"])
+        theta_model = params["debye_temperature_model"]
+        debye_T = theta_model(x, params)
+        F_a = _nondimensional_helmholtz_energy(temperature, debye_T)
+        F_a0 = _nondimensional_helmholtz_energy(params["T_0"], debye_T)
+        return A * (F_a - F_a0)
+
+    @staticmethod
+    def entropy(temperature, volume, params):
+        x = volume / params["V_0"]
+        A = params["a_anh"] * np.power(x, params["m_anh"])
+        theta_model = params["debye_temperature_model"]
+        debye_T = theta_model(x, params)
+        S_a = _nondimensional_entropy(temperature, debye_T)
+        return A * S_a
+
+    @staticmethod
+    def heat_capacity_v(temperature, volume, params):
+        x = volume / params["V_0"]
+        A = params["a_anh"] * np.power(x, params["m_anh"])
+        theta_model = params["debye_temperature_model"]
+        debye_T = theta_model(x, params)
+        Cv_a = _nondimensional_heat_capacity(temperature, debye_T)
+        return A * Cv_a
+
+    @staticmethod
+    def pressure(temperature, volume, params):
+        x = volume / params["V_0"]
+        A = params["a_anh"] * np.power(x, params["m_anh"])
+        theta_model = params["debye_temperature_model"]
+        debye_T = theta_model(x, params)
+        F_a = _nondimensional_helmholtz_energy(temperature, debye_T)
+        F_a0 = _nondimensional_helmholtz_energy(params["T_0"], debye_T)
+        F_ad = _nondimensional_dhelmholtz_dTheta(temperature, debye_T)
+        F_ad0 = _nondimensional_dhelmholtz_dTheta(params["T_0"], debye_T)
+        return -A * (
+            (params["m_anh"] / volume) * (F_a - F_a0)
+            + (theta_model.dVrel(x, params) / params["V_0"]) * (F_ad - F_ad0)
+        )
+
+    @staticmethod
+    def isothermal_bulk_modulus(temperature, volume, params):
+        x = volume / params["V_0"]
+        A = params["a_anh"] * np.power(x, params["m_anh"])
+        theta_model = params["debye_temperature_model"]
+        debye_T = theta_model(x, params)
+
+        F_a = _nondimensional_helmholtz_energy(temperature, debye_T)
+        F_a0 = _nondimensional_helmholtz_energy(params["T_0"], debye_T)
+        F_ad = _nondimensional_dhelmholtz_dTheta(temperature, debye_T)
+        F_ad0 = _nondimensional_dhelmholtz_dTheta(params["T_0"], debye_T)
+        F_add = _nondimensional_d2helmholtz_dTheta2(temperature, debye_T)
+        F_add0 = _nondimensional_d2helmholtz_dTheta2(params["T_0"], debye_T)
+
+        return (
+            A
+            * volume
+            * (
+                params["m_anh"] * (params["m_anh"] - 1.0) / volume**2 * (F_a - F_a0)
+                + 2
+                * params["m_anh"]
+                / volume
+                * (F_ad - F_ad0)
+                * theta_model.dVrel(x, params)
+                / params["V_0"]
+                + (F_add - F_add0) * (theta_model.dVrel(x, params) / params["V_0"]) ** 2
+                + (F_ad - F_ad0) * theta_model.d2dVrel2(x, params) / params["V_0"] ** 2
+            )
+        )
+
+    @staticmethod
+    def dSdV(temperature, volume, params):
+        x = volume / params["V_0"]
+        A = params["a_anh"] * np.power(x, params["m_anh"])
+        theta_model = params["debye_temperature_model"]
+        debye_T = theta_model(x, params)
+
+        S_a = _nondimensional_entropy(temperature, debye_T)
+        S_ad = _nondimensional_dentropy_dTheta(temperature, debye_T)
+
+        aK_T = A * (
+            (params["m_anh"] / volume) * S_a
+            + (theta_model.dVrel(x, params) / params["V_0"]) * S_ad
+        )
+
+        return aK_T

--- a/burnman/eos/debye.py
+++ b/burnman/eos/debye.py
@@ -1,5 +1,5 @@
 # This file is part of BurnMan - a thermoelastic and thermodynamic toolkit for the Earth and Planetary Sciences
-# Copyright (C) 2012 - 2017 by the BurnMan team, released under the GNU
+# Copyright (C) 2012 - 2025 by the BurnMan team, released under the GNU
 # GPL v2 or later.
 
 
@@ -138,6 +138,24 @@ def debye_fn_cheb(x):
         return ((val_infinity / x) / x) / x
 
 
+"""
+# The following functions are the derivatives of the Debye function
+# with respect to x, which is the inverse of the
+# dimensionless temperature.
+# Currently not used but kept here for reference.
+
+def ddebye_fn_dx(x):
+    D = debye_fn_cheb(x)
+    return 3.0 / (np.exp(x) - 1.0) - 3.0 * D / x
+
+
+def d2debye_fn_dx2(x):
+    D = debye_fn_cheb(x)
+    D1 = 3.0 / (np.exp(x) - 1.0) - 3.0 * D / x
+    return -3.0 * np.exp(x) / (np.exp(x) - 1.0) ** 2 - 3.0 * (x * D1 - D) / x**2
+"""
+
+
 @jit(nopython=True)
 def thermal_energy(T, debye_T, n):
     """
@@ -220,3 +238,44 @@ def dmolar_heat_capacity_v_dT(T, debye_T, n):
     dCvdT = 3.0 * C_v_over_T + (C_v_over_T - 4.0 * E_over_Tsqr) * x / (1.0 - np.exp(-x))
 
     return dCvdT
+
+
+def dhelmholtz_dTheta(T, debye_T, n):
+    """
+    First derivative of the Helmholtz free energy with respect to the Debye temperature
+    [J/K].
+    """
+    if T <= eps:
+        return 0.0
+    x = debye_T / T
+    return 3.0 * n * constants.gas_constant * debye_fn(x) / x
+
+
+def d2helmholtz_dTheta2(T, debye_T, n):
+    """
+    Second derivative of the Helmholtz free energy with respect to the Debye temperature
+    [J/K^2].
+    """
+    if T <= eps:
+        return 0.0
+    x = debye_T / T
+    D = debye_fn(x)
+    return (
+        3.0
+        * n
+        * constants.gas_constant
+        / T
+        * (3.0 / (x * (np.exp(x) - 1.0)) - 4.0 * D / x**2)
+    )
+
+
+def dentropy_dTheta(T, debye_T, n):
+    """
+    First derivative of the entropy with respect to the Debye temperature
+    [J/K].
+    """
+    if T <= eps:
+        return 0.0
+    x = debye_T / T
+    D = debye_fn(x)
+    return n * constants.gas_constant / T * (9.0 / (np.exp(x) - 1.0) - 12.0 * D / x)

--- a/burnman/eos/debye_temperature_models.py
+++ b/burnman/eos/debye_temperature_models.py
@@ -157,8 +157,8 @@ class PowerLawGamma(DebyeTemperatureModelBase):
 
     This class is based on a power-law model for the Grueneisen parameter,
     which is defined as:
-    :math:`\\gamma(V) = c_0 + c_1 (V/V_0)^{q_1} + c_2 (V/V_0)^{q_2}`
-    where :math:`c_0`, :math:`c_1`, :math:`c_2`, :math:`q_1`, and :math:`q_2`
+    :math:`\\gamma(V) = grueneisen_0 + c_1 ((V/V_0)^{q_1} - 1) + c_2 ((V/V_0)^{q_2} - 1)`
+    where :math:`grueneisen_0`, :math:`c_1`, :math:`c_2`, :math:`q_1`, and :math:`q_2`
     are parameters that define the Grueneisen parameter's dependence on volume.
 
     The Debye temperature is computed as:
@@ -174,7 +174,7 @@ class PowerLawGamma(DebyeTemperatureModelBase):
         # This method computes the Debye temperature.
         return (
             params["Debye_0"]
-            * np.power(Vrel, -params["c_0"])
+            * np.power(Vrel, params["c_2"] + params["c_1"] - params["grueneisen_0"])
             * np.exp(
                 -params["c_1"] / params["q_1"] * (np.power(Vrel, params["q_1"]) - 1.0)
                 - params["c_2"] / params["q_2"] * (np.power(Vrel, params["q_2"]) - 1.0)
@@ -183,9 +183,9 @@ class PowerLawGamma(DebyeTemperatureModelBase):
 
     def _gamma(self, Vrel, params):
         return (
-            params["c_0"]
-            + params["c_1"] * np.power(Vrel, params["q_1"])
-            + params["c_2"] * np.power(Vrel, params["q_2"])
+            params["grueneisen_0"]
+            + params["c_1"] * (np.power(Vrel, params["q_1"]) - 1.0)
+            + params["c_2"] * (np.power(Vrel, params["q_2"]) - 1.0)
         )
 
     def _gamma_prime(self, Vrel, params):

--- a/burnman/eos/debye_temperature_models.py
+++ b/burnman/eos/debye_temperature_models.py
@@ -1,0 +1,194 @@
+# This file is part of BurnMan - a thermoelastic and thermodynamic toolkit
+# for the Earth and Planetary Sciences
+# Copyright (C) 2012 - 2025 by the BurnMan team, released under the GNU
+# GPL v2 or later.
+
+import numpy as np
+from abc import ABC, abstractmethod
+
+
+def singleton(cls):
+    instances = {}
+
+    def get_instance(*args, **kwargs):
+        if cls not in instances:
+            instances[cls] = cls(*args, **kwargs)
+        return instances[cls]
+
+    return get_instance
+
+
+class DebyeTemperatureModelBase(ABC):
+    """Abstract base class for Debye temperature models."""
+
+    @abstractmethod
+    def __call__(self, Vrel: float, params: dict) -> float:
+        """Return the Debye temperature for the given relative volume."""
+
+    @abstractmethod
+    def _gamma(self, Vrel: float, params: dict) -> float:
+        """Return the Grueneisen parameter at given relative volume."""
+
+    @abstractmethod
+    def _gamma_prime(self, Vrel: float, params: dict) -> float:
+        """Return the derivative of Grueneisen parameter wrt relative volume."""
+
+    def dVrel(self, Vrel: float, params: dict) -> float:
+        """First derivative of Debye temperature wrt relative volume."""
+        theta = self.__call__(Vrel, params)
+        gamma = self._gamma(Vrel, params)
+        return -theta * gamma / Vrel
+
+    def d2dVrel2(self, Vrel: float, params: dict) -> float:
+        """Second derivative of Debye temperature wrt relative volume."""
+        theta = self.__call__(Vrel, params)
+        gamma = self._gamma(Vrel, params)
+        gamma_prime = self._gamma_prime(Vrel, params)
+        return theta / Vrel**2 * (gamma * (gamma + 1.0) - Vrel * gamma_prime)
+
+
+@singleton
+class SLB(DebyeTemperatureModelBase):
+    """
+    A class that provides the Debye temperature as a function of relative volume,
+    and its first and second derivatives with respect to relative volume.
+    This class is used in the Extended Mie-Grueneisen-Debye equation of state.
+
+    This class is based on a finite strain expansion for the
+    squared frequencies of the phonon modes (Stixrude and Lithgow-Bertelloni, 2005).
+    The Debye temperature is:
+    :math:`\\Theta(V) = \\Theta_0 \\sqrt{1 + a_1 f + 0.5 a_2 f^2}`, where
+    :math:`f = 0.5 (f)^{-2/3} - 1`, and :math:`a_1` and :math:`a_2` are
+    parameters that define the Grueneisen parameter's dependence on volume and equal
+    :math:`a_1 = 6 \\gamma_0`, :math:`a_2 = -12 \\gamma_0 + 36 \\gamma_0^2 - 18 q_0 \\gamma_0`.
+
+    :param Vrel: Relative volume, defined as :math:`V/V_0`, where V_0 is the reference volume.
+    :type Vrel: float
+    :param params: A dictionary containing the parameters for the model.
+    :type params: dict
+    """
+
+    def __call__(self, Vrel, params):
+        # This method computes the Debye temperature.
+        a1_ii, a2_iikk, f = self.a1_a2_and_f(Vrel, params)
+        nu_o_nu0_sq = 1.0 + a1_ii * f + (1.0 / 2.0) * a2_iikk * f * f
+        debye_temperature = params["Debye_0"] * np.sqrt(nu_o_nu0_sq)  # EQ 41
+        return debye_temperature
+
+    def _gamma(self, Vrel, params):
+        a1_ii, a2_iikk, f = self.a1_a2_and_f(Vrel, params)
+        nu_o_nu0_sq = 1.0 + a1_ii * f + (1.0 / 2.0) * a2_iikk * f * f
+        gr = 1.0 / 6.0 / nu_o_nu0_sq * (2.0 * f + 1.0) * (a1_ii + a2_iikk * f)
+        return gr
+
+    def _gamma_prime(self, Vrel, params):
+        a1_ii, a2_iikk, f = self.a1_a2_and_f(Vrel, params)
+        fprime = -(1.0 / 3.0) * Vrel ** (-5.0 / 3.0)
+
+        N = (2.0 * f + 1.0) * (a1_ii + a2_iikk * f)
+        D = 6.0 * (1.0 + a1_ii * f + 0.5 * a2_iikk * f * f)
+
+        Nprime = 2.0 * (a1_ii + a2_iikk * f) + (2.0 * f + 1.0) * a2_iikk
+        Dprime = 6.0 * (a1_ii + a2_iikk * f)
+        gprime = ((Nprime * D - N * Dprime) / (D * D)) * fprime
+
+        return gprime
+
+    def a1_a2_and_f(self, Vrel, params):
+        """
+        Returns a1, a2 and f for the given relative volume.
+        This is useful for debugging and testing purposes.
+        """
+        a1_ii = 6.0 * params["grueneisen_0"]
+        a2_iikk = (
+            -12.0 * params["grueneisen_0"]
+            + 36.0 * pow(params["grueneisen_0"], 2.0)
+            - 18.0 * params["q_0"] * params["grueneisen_0"]
+        )
+        f = 0.5 * (pow(Vrel, -2.0 / 3.0) - 1.0)
+        return a1_ii, a2_iikk, f
+
+
+@singleton
+class PowerLawGammaSimple(DebyeTemperatureModelBase):
+    """
+    A class that provides the Debye temperature as a function of relative volume,
+    and its first and second derivatives with respect to relative volume.
+    This class is used in the Extended Mie-Grueneisen-Debye equation of state.
+
+    This class is based on a power-law model for the Grueneisen parameter,
+    which is defined as (Matas et al., 2007):
+    :math:`\\gamma(V) = \\gamma_0 (V/V_0)^{q_0}`
+    where :math:`\\gamma_0` and :math:`q_0`
+    are parameters that define the Grueneisen parameter's dependence on volume.
+
+    The Debye temperature is computed as:
+    :math:`\\Theta(V) = \\Theta_0 \\exp(-\\int_1^{V/V_0} \\gamma(x)/x dx)`.
+
+    :param Vrel: Relative volume, defined as :math:`V/V_0`, where V_0 is the reference volume.
+    :type Vrel: float
+    :param params: A dictionary containing the parameters for the model.
+    :type params: dict
+    """
+
+    def __call__(self, Vrel, params):
+        # This method computes the Debye temperature.
+        return params["Debye_0"] * np.exp(
+            -params["grueneisen_0"]
+            / params["q_0"]
+            * (np.power(Vrel, params["q_0"]) - 1.0)
+        )
+
+    def _gamma(self, Vrel, params):
+        return params["grueneisen_0"] * np.power(Vrel, params["q_0"])
+
+    def _gamma_prime(self, Vrel, params):
+        return (
+            params["grueneisen_0"] * params["q_0"] * np.power(Vrel, params["q_0"] - 1.0)
+        )
+
+
+@singleton
+class PowerLawGamma(DebyeTemperatureModelBase):
+    """
+    A class that provides the Debye temperature as a function of relative volume,
+    and its first and second derivatives with respect to relative volume.
+    This class is used in the Extended Mie-Grueneisen-Debye equation of state.
+
+    This class is based on a power-law model for the Grueneisen parameter,
+    which is defined as:
+    :math:`\\gamma(V) = c_0 + c_1 (V/V_0)^{q_1} + c_2 (V/V_0)^{q_2}`
+    where :math:`c_0`, :math:`c_1`, :math:`c_2`, :math:`q_1`, and :math:`q_2`
+    are parameters that define the Grueneisen parameter's dependence on volume.
+
+    The Debye temperature is computed as:
+    :math:`\\Theta(V) = \\Theta_0 \\exp(-\\int_1^{V/V_0} \\gamma(x)/x dx)`.
+
+    :param Vrel: Relative volume, defined as :math:`V/V_0`, where V_0 is the reference volume.
+    :type Vrel: float
+    :param params: A dictionary containing the parameters for the model.
+    :type params: dict
+    """
+
+    def __call__(self, Vrel, params):
+        # This method computes the Debye temperature.
+        return (
+            params["Debye_0"]
+            * np.power(Vrel, -params["c_0"])
+            * np.exp(
+                -params["c_1"] / params["q_1"] * (np.power(Vrel, params["q_1"]) - 1.0)
+                - params["c_2"] / params["q_2"] * (np.power(Vrel, params["q_2"]) - 1.0)
+            )
+        )
+
+    def _gamma(self, Vrel, params):
+        return (
+            params["c_0"]
+            + params["c_1"] * np.power(Vrel, params["q_1"])
+            + params["c_2"] * np.power(Vrel, params["q_2"])
+        )
+
+    def _gamma_prime(self, Vrel, params):
+        return params["c_1"] * params["q_1"] * np.power(
+            Vrel, params["q_1"] - 1.0
+        ) + params["c_2"] * params["q_2"] * np.power(Vrel, params["q_2"] - 1.0)

--- a/burnman/eos/helper.py
+++ b/burnman/eos/helper.py
@@ -1,11 +1,12 @@
 # This file is part of BurnMan - a thermoelastic and thermodynamic toolkit for the Earth and Planetary Sciences
-# Copyright (C) 2012 - 2017 by the BurnMan team, released under the GNU
+# Copyright (C) 2012 - 2025 by the BurnMan team, released under the GNU
 # GPL v2 or later.
 
 
 import inspect
 from . import slb
 from . import mie_grueneisen_debye as mgd
+from . import modular_mie_grueneisen_debye as mmgd
 from . import murnaghan
 from . import birch_murnaghan as bm
 from . import modified_tait as mt
@@ -60,6 +61,8 @@ def create(method):
             return slb.SLB3()
         elif method == "slb3-conductive":
             return slb.SLB3Conductive()
+        elif method == "modular_mgd":
+            return mmgd.ModularMGD()
         elif method == "murnaghan":
             return murnaghan.Murnaghan()
         elif method == "bm3shear2":

--- a/burnman/eos/modular_mie_grueneisen_debye.py
+++ b/burnman/eos/modular_mie_grueneisen_debye.py
@@ -1,0 +1,237 @@
+# This file is part of BurnMan - a thermoelastic and thermodynamic toolkit
+# for the Earth and Planetary Sciences
+# Copyright (C) 2012 - 2025 by the BurnMan team, released under the GNU
+# GPL v2 or later.
+
+
+import scipy.optimize as opt
+
+# Try to import the jit from numba.  If it is
+# not available, just go with the standard
+# python interpreter
+try:
+    from numba import jit
+except ImportError:
+
+    def jit(nopython=True):
+        def decorator(fn):
+            return fn
+
+        return decorator
+
+
+from . import debye
+from . import equation_of_state as eos
+from ..utils.math import bracket
+
+
+class ModularMGD(eos.EquationOfState):
+    """
+    Base class for a modular Mie-Grueneisen-Debye equation of state.
+    The user must provide the following parameters in the params dictionary:
+    - V_0: reference volume [m^3]
+    - T_0: reference temperature [K]
+    - n: number of formula units in the mineral
+    - molar_mass: molar mass of the mineral [kg/mol]
+    The params dictionary must also contain the following
+    - reference_eos: an instance of an equation of state that gas methods
+      for pressure, isothermal bulk modulus, and Gibbs energy.
+    - debye_temperature_model: an instance of a class that provides
+      the Debye temperature as a function of relative volume from method "__call__",
+      and its first and second derivatives with respect to relative volume
+      from methods "dVrel" and "d2dVrel2", respectively.
+    """
+
+    def volume(self, pressure, temperature, params):
+        """
+        Returns volume [m^3] as a function of pressure [Pa] and temperature [K]
+        """
+
+        def func(V):
+            P = self.pressure(temperature, V, params)
+            return P - pressure
+
+        try:
+            sol = bracket(func, params["V_0"], 1.0e-2 * params["V_0"])
+        except:
+            raise ValueError(
+                "Cannot find a volume, perhaps you are outside of the range of validity for the equation of state?"
+            )
+        volume = opt.brentq(func, sol[0], sol[1])
+        return volume
+
+    def pressure(self, temperature, volume, params):
+        """
+        Returns the pressure of the mineral at a given temperature and volume
+        [Pa]
+        """
+        P_ref = params["reference_eos"].pressure(params["T_0"], volume, params)
+        Debye_T = params["debye_temperature_model"](volume / params["V_0"], params)
+        dThetadV = (
+            params["debye_temperature_model"].dVrel(volume / params["V_0"], params)
+            / params["V_0"]
+        )
+        P_th = -dThetadV * (
+            debye.dhelmholtz_dTheta(temperature, Debye_T, params["n"])
+            - debye.dhelmholtz_dTheta(params["T_0"], Debye_T, params["n"])
+        )
+        return P_ref + P_th
+
+    def isothermal_bulk_modulus_reuss(self, pressure, temperature, volume, params):
+        """
+        Returns isothermal bulk modulus :math:`[Pa]`
+        """
+        KT_ref = params["reference_eos"].isothermal_bulk_modulus_reuss(
+            0.0, params["T_0"], volume, params
+        )
+        Debye_T = params["debye_temperature_model"](volume / params["V_0"], params)
+        V = volume
+        d2ThetadV2 = (
+            params["debye_temperature_model"].d2dVrel2(V / params["V_0"], params)
+            / params["V_0"] ** 2
+        )
+        dThetadV = (
+            params["debye_temperature_model"].dVrel(V / params["V_0"], params)
+            / params["V_0"]
+        )
+        dFthdTheta = debye.dhelmholtz_dTheta(temperature, Debye_T, params["n"])
+        dFthdTheta_T0 = debye.dhelmholtz_dTheta(params["T_0"], Debye_T, params["n"])
+        d2FthdTheta2 = debye.d2helmholtz_dTheta2(temperature, Debye_T, params["n"])
+        d2FthdTheta2_T0 = debye.d2helmholtz_dTheta2(params["T_0"], Debye_T, params["n"])
+        d2FthdV2 = d2ThetadV2 * (dFthdTheta - dFthdTheta_T0) + dThetadV**2 * (
+            d2FthdTheta2 - d2FthdTheta2_T0
+        )
+        return KT_ref + V * d2FthdV2
+
+    def _molar_heat_capacity_v(self, pressure, temperature, volume, params):
+        """
+        Returns heat capacity at constant volume. :math:`[J/K/mol]`
+        """
+        debye_T = params["debye_temperature_model"](volume / params["V_0"], params)
+        C_v = debye.molar_heat_capacity_v(temperature, debye_T, params["n"])
+        return C_v
+
+    def thermal_expansivity(self, pressure, temperature, volume, params):
+        """
+        Returns thermal expansivity. :math:`[1/K]`
+        """
+        debye_T = params["debye_temperature_model"](volume / params["V_0"], params)
+        dThetadV = (
+            params["debye_temperature_model"].dVrel(volume / params["V_0"], params)
+            / params["V_0"]
+        )
+        dSdTheta = debye.dentropy_dTheta(temperature, debye_T, params["n"])
+        aKT = dSdTheta * dThetadV
+
+        KT = self.isothermal_bulk_modulus_reuss(pressure, temperature, volume, params)
+
+        return aKT / KT
+
+    def entropy(self, pressure, temperature, volume, params):
+        """
+        Returns the entropy at the pressure and temperature
+        of the mineral [J/K/mol]
+        """
+        Debye_T = params["debye_temperature_model"](volume / params["V_0"], params)
+        S = debye.entropy(temperature, Debye_T, params["n"])
+        return S
+
+    def _helmholtz_energy(self, pressure, temperature, volume, params):
+        """
+        Returns the Helmholtz free energy at the pressure and temperature
+        of the mineral [J/mol]
+        """
+        P_ref = params["reference_eos"].pressure(params["T_0"], volume, params)
+        G_ref = params["reference_eos"].gibbs_energy(
+            P_ref, params["T_0"], volume, params
+        )
+        F_ref = G_ref - volume * params["reference_eos"].pressure(
+            params["T_0"], volume, params
+        )
+        Debye_T = params["debye_temperature_model"](volume / params["V_0"], params)
+
+        F_th = debye.helmholtz_energy(
+            temperature, Debye_T, params["n"]
+        ) - debye.helmholtz_energy(params["T_0"], Debye_T, params["n"])
+
+        return F_ref + F_th
+
+    # Derived properties from here
+    # These functions can use pressure as an argument,
+    # as pressure should have been determined self-consistently
+    # by the point at which these functions are called.
+    def _grueneisen_parameter(self, pressure, temperature, volume, params):
+        """
+        Returns grueneisen parameter (-dlnT/dlnV at fixed entropy) :math:`[unitless]`
+        The grueneisen parameter is a product of partial derivatives of the
+        Helmholtz energy, but the product involves a division by the heat capacity
+        (which goes to zero at low temperatures).
+        Therefore we reset the temperature to a small value
+        if it is too low, to avoid division by zero.
+        """
+        temperature = max(temperature, 1.0e-6)
+        K_T = self.isothermal_bulk_modulus_reuss(pressure, temperature, volume, params)
+        alpha = self.thermal_expansivity(pressure, temperature, volume, params)
+        C_v = self._molar_heat_capacity_v(pressure, temperature, volume, params)
+        return alpha * K_T * volume / C_v
+
+    def molar_heat_capacity_p(self, pressure, temperature, volume, params):
+        """
+        Returns heat capacity at constant pressure. :math:`[J/K/mol]`
+        """
+        alpha = self.thermal_expansivity(pressure, temperature, volume, params)
+        K_T = self.isothermal_bulk_modulus_reuss(pressure, temperature, volume, params)
+        C_v = self._molar_heat_capacity_v(pressure, temperature, volume, params)
+        C_p = C_v + alpha * alpha * K_T * volume * temperature
+        return C_p
+
+    def gibbs_energy(self, pressure, temperature, volume, params):
+        """
+        Returns the Gibbs free energy at the pressure and temperature
+        of the mineral [J/mol]
+        """
+        G = (
+            self._helmholtz_energy(pressure, temperature, volume, params)
+            + pressure * volume
+        )
+        return G
+
+    def validate_parameters(self, params):
+        """
+        Check for existence and validity of the parameters
+        """
+        # First, let's check the EoS parameters for the reference EoS
+        params["reference_eos"].validate_parameters(params)
+
+        # And check that the reference EoS has the required methods
+        required_methods = ["pressure", "isothermal_bulk_modulus_reuss", "gibbs_energy"]
+        for method in required_methods:
+            if not hasattr(params["reference_eos"], method):
+                raise AttributeError(
+                    "Reference EoS does not have the required method: " + method
+                )
+
+        # Now check that the params dictionary contains a model for the Debye temperature.
+        if "debye_temperature_model" not in params:
+            raise KeyError(
+                "params object missing 'debye_temperature_model' key, which must be a class instance."
+            )
+
+        if not hasattr(params["debye_temperature_model"], "__call__"):
+            raise AttributeError(
+                "params['debye_temperature_model'] must have a __call__ method to compute the Debye temperature as a function of Vrel and params."
+            )
+        if not hasattr(params["debye_temperature_model"], "dVrel"):
+            raise AttributeError(
+                "params['debye_temperature_model'] must have a dVrel method to compute the first derivative of the Debye temperature with respect to Vrel. Arguments should be Vrel and the params dictionary."
+            )
+        if not hasattr(params["debye_temperature_model"], "d2dVrel2"):
+            raise AttributeError(
+                "params['debye_temperature_model'] must have a d2dVrel2 method to compute the second derivative of the Debye temperature with respect to Vrel. Arguments should be Vrel and the params dictionary."
+            )
+
+        # Now check all the other required keys are in the dictionary
+        expected_keys = ["molar_mass", "n", "T_0", "V_0"]
+        for k in expected_keys:
+            if k not in params:
+                raise KeyError("params object missing parameter : " + k)

--- a/tests/test_anharmonic.py
+++ b/tests/test_anharmonic.py
@@ -1,0 +1,72 @@
+import unittest
+from util import BurnManTest
+
+from burnman.eos.anharmonic_debye_pade import AnharmonicDebyePade
+from burnman.eos.debye_temperature_models import SLB as theta_SLB
+
+
+params = {
+    "a_anh": 1500.0,
+    "V_0": 2.0e-6,
+    "m_anh": 3.0,
+    "Debye_0": 1000.0,
+    "grueneisen_0": 1.2,
+    "q_0": 1.1,
+    "debye_temperature_model": theta_SLB(),
+    "T_0": 300.0,
+}
+
+
+class Anharmonic(BurnManTest):
+    def test_derivatives(self):
+        V_0 = params["V_0"]
+        V = V_0 * 0.9
+        T = 2000.0
+
+        S = AnharmonicDebyePade.entropy(T, V, params)
+        C_v = AnharmonicDebyePade.heat_capacity_v(T, V, params)
+        P = AnharmonicDebyePade.pressure(T, V, params)
+        K_T = AnharmonicDebyePade.isothermal_bulk_modulus(T, V, params)
+        alphaK_T = AnharmonicDebyePade.dSdV(T, V, params)
+
+        # Test partial derivatives
+        dV = 1.0e-11
+        dT = 1.0e-2
+
+        dFdV = (
+            AnharmonicDebyePade.helmholtz_energy(T, V + dV, params)
+            - AnharmonicDebyePade.helmholtz_energy(T, V - dV, params)
+        ) / (2.0 * dV)
+        dFdT = (
+            AnharmonicDebyePade.helmholtz_energy(T + dT, V, params)
+            - AnharmonicDebyePade.helmholtz_energy(T - dT, V, params)
+        ) / (2.0 * dT)
+
+        dSdV = (
+            AnharmonicDebyePade.entropy(T, V + dV, params)
+            - AnharmonicDebyePade.entropy(T, V - dV, params)
+        ) / (2.0 * dV)
+        dSdT = (
+            AnharmonicDebyePade.entropy(T + dT, V, params)
+            - AnharmonicDebyePade.entropy(T - dT, V, params)
+        ) / (2.0 * dT)
+
+        dPdV = (
+            AnharmonicDebyePade.pressure(T, V + dV, params)
+            - AnharmonicDebyePade.pressure(T, V - dV, params)
+        ) / (2.0 * dV)
+        dPdT = (
+            AnharmonicDebyePade.pressure(T + dT, V, params)
+            - AnharmonicDebyePade.pressure(T - dT, V, params)
+        ) / (2.0 * dT)
+
+        self.assertAlmostEqual(S, -dFdT, places=6)
+        self.assertAlmostEqual(C_v, T * dSdT, places=6)
+        self.assertAlmostEqual(P / 1.0e8, -dFdV / 1.0e8, places=6)
+        self.assertAlmostEqual(K_T / 1.0e8, -V * dPdV / 1.0e8, places=6)
+        self.assertAlmostEqual(alphaK_T / 1.0e3, dSdV / 1.0e3, places=6)
+        self.assertAlmostEqual(alphaK_T / 1.0e3, dPdT / 1.0e3, places=6)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_debye.py
+++ b/tests/test_debye.py
@@ -65,6 +65,35 @@ class Debye(BurnManTest):
         )
         self.assertFloatEqual(test_thermal_energy, 0.0)
 
+    def test_theta_derivatives(self):
+        rock = mypericlase()
+        T = 300.0
+        debye_T = rock.params["Debye_0"]
+        n = rock.params["n"]
+
+        # Numerical derivatives
+        delta = 1e-6
+        dF_dTheta_num = (
+            burnman.eos.debye.helmholtz_energy(T, debye_T + delta, n)
+            - burnman.eos.debye.helmholtz_energy(T, debye_T - delta, n)
+        ) / (2 * delta)
+        d2F_dTheta2_num = (
+            burnman.eos.debye.dhelmholtz_dTheta(T, debye_T + delta, n)
+            - burnman.eos.debye.dhelmholtz_dTheta(T, debye_T - delta, n)
+        ) / (2 * delta)
+        dS_dTheta_num = (
+            burnman.eos.debye.entropy(T, debye_T + delta, n)
+            - burnman.eos.debye.entropy(T, debye_T - delta, n)
+        ) / (2 * delta)
+
+        # Analytical derivatives
+        dF_dTheta_analytical = burnman.eos.debye.dhelmholtz_dTheta(T, debye_T, n)
+        d2F_dTheta2_analytical = burnman.eos.debye.d2helmholtz_dTheta2(T, debye_T, n)
+        dS_dTheta_analytical = burnman.eos.debye.dentropy_dTheta(T, debye_T, n)
+        self.assertFloatEqual(dF_dTheta_num, dF_dTheta_analytical)
+        self.assertFloatEqual(d2F_dTheta2_num, d2F_dTheta2_analytical)
+        self.assertFloatEqual(dS_dTheta_num, dS_dTheta_analytical)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_modular_mgd.py
+++ b/tests/test_modular_mgd.py
@@ -1,0 +1,220 @@
+import unittest
+from util import BurnManTest
+
+from burnman import Mineral
+from burnman.utils.chemistry import dictionarize_formula, formula_mass
+from burnman.eos.helper import create
+from burnman.tools.eos import check_eos_consistency
+from burnman.eos.debye_temperature_models import SLB as theta_SLB
+from burnman.eos.debye_temperature_models import PowerLawGamma as PLG
+from burnman.eos.debye_temperature_models import PowerLawGammaSimple as PLGS
+
+
+formula = "Mg2SiO4"
+formula = dictionarize_formula(formula)
+mineral_params = {
+    "name": "Forsterite",
+    "formula": formula,
+    "equation_of_state": "modular_mgd",
+    "E_0": -2055403.0,
+    "V_0": 4.3603e-05,
+    "K_0": 1.279555e11,
+    "Kprime_0": 4.21796,
+    "T_0": 298.15,
+    "n": sum(formula.values()),
+    "molar_mass": formula_mass(formula),
+}
+
+
+class ModularMGD(BurnManTest):
+    def test_setup(self):
+        params = mineral_params.copy()
+        params["reference_eos"] = create("bm3")
+        params["debye_temperature_model"] = theta_SLB()
+        params["Debye_0"] = 1000.0
+        params["grueneisen_0"] = 1.2
+        params["q_0"] = 1.1
+
+        _ = Mineral(params)
+
+    def test_SLB_derivatives(self):
+        params = mineral_params.copy()
+        params["reference_eos"] = create("bm3")
+        params["debye_temperature_model"] = theta_SLB()
+        params["Debye_0"] = 1000.0
+        params["grueneisen_0"] = 1.2
+        params["q_0"] = 1.1
+
+        t = theta_SLB()
+
+        dVrel = 1.0e-6
+        Vrel = 0.7
+        dtdVrel_numerical = (t(Vrel + dVrel, params) - t(Vrel - dVrel, params)) / (2.0 * dVrel)
+        dtdVrel_analytical = t.dVrel(Vrel, params)
+        d2tdVrel2_numerical = (t.dVrel(Vrel + dVrel, params) - t.dVrel(Vrel - dVrel, params)) / (
+            2.0 * dVrel
+        )
+        d2tdVrel2_analytical = t.d2dVrel2(Vrel, params)
+        self.assertAlmostEqual(dtdVrel_numerical, dtdVrel_analytical, places=6)
+        self.assertAlmostEqual(d2tdVrel2_numerical, d2tdVrel2_analytical, places=6)
+
+    def test_PLG_derivatives(self):
+        params = mineral_params.copy()
+        params["reference_eos"] = create("bm3")
+        params["debye_temperature_model"] = PLG()
+        params["Debye_0"] = 1000.0
+        params["grueneisen_0"] = 1.
+        params["c_1"] = 0.2
+        params["c_2"] = 0.1
+        params["q_1"] = 1.0
+        params["q_2"] = 2.0
+
+        t = PLG()
+
+        dVrel = 1.0e-6
+        Vrel = 0.7
+        dtdVrel_numerical = (t(Vrel + dVrel, params) - t(Vrel - dVrel, params)) / (2.0 * dVrel)
+        dtdVrel_analytical = t.dVrel(Vrel, params)
+        d2tdVrel2_numerical = (t.dVrel(Vrel + dVrel, params) - t.dVrel(Vrel - dVrel, params)) / (
+            2.0 * dVrel
+        )
+        d2tdVrel2_analytical = t.d2dVrel2(Vrel, params)
+        self.assertAlmostEqual(dtdVrel_numerical, dtdVrel_analytical, places=6)
+        self.assertAlmostEqual(d2tdVrel2_numerical, d2tdVrel2_analytical, places=6)
+
+    def test_PLGS_derivatives(self):
+        params = mineral_params.copy()
+        params["reference_eos"] = create("bm3")
+        params["debye_temperature_model"] = PLGS()
+        params["Debye_0"] = 1000.0
+        params["grueneisen_0"] = 1.2
+        params["q_0"] = 1.1
+
+        t = PLGS()
+
+        dVrel = 1.0e-6
+        Vrel = 0.7
+        dtdVrel_numerical = (t(Vrel + dVrel, params) - t(Vrel - dVrel, params)) / (2.0 * dVrel)
+        dtdVrel_analytical = t.dVrel(Vrel, params)
+        d2tdVrel2_numerical = (t.dVrel(Vrel + dVrel, params) - t.dVrel(Vrel - dVrel, params)) / (
+            2.0 * dVrel
+        )
+        d2tdVrel2_analytical = t.d2dVrel2(Vrel, params)
+        self.assertAlmostEqual(dtdVrel_numerical, dtdVrel_analytical, places=6)
+        self.assertAlmostEqual(d2tdVrel2_numerical, d2tdVrel2_analytical, places=6)
+
+    def test_check_SLB_consistency(self):
+        params = mineral_params.copy()
+        params["reference_eos"] = create("bm3")
+        params["debye_temperature_model"] = theta_SLB()
+        params["Debye_0"] = 1000.0
+        params["grueneisen_0"] = 1.2
+        params["q_0"] = 1.1
+
+        m = Mineral(params)
+        consistent = check_eos_consistency(m, 2.0e9, 2000.0, including_shear_properties=False, tol=1.0e-4)
+        self.assertTrue(consistent)
+
+    def test_check_PLG_consistency(self):
+        params = mineral_params.copy()
+        params["reference_eos"] = create("bm3")
+        params["debye_temperature_model"] = PLG()
+        params["Debye_0"] = 1000.0
+        params["grueneisen_0"] = 1.0
+        params["c_1"] = 0.2
+        params["c_2"] = 0.1
+        params["q_1"] = 1.0
+        params["q_2"] = 2.0
+
+        m = Mineral(params)
+        consistent = check_eos_consistency(m, 2.0e9, 2000.0, including_shear_properties=False, tol=1.0e-4)
+        self.assertTrue(consistent)
+
+    def test_check_PLGS_consistency(self):
+        params = mineral_params.copy()
+        params["reference_eos"] = create("bm3")
+        params["debye_temperature_model"] = PLGS()
+        params["Debye_0"] = 1000.0
+        params["grueneisen_0"] = 1.0
+        params["q_0"] = 1.0
+
+        m = Mineral(params)
+        consistent = check_eos_consistency(m, 2.0e9, 2000.0, including_shear_properties=False, tol=1.0e-4)
+        self.assertTrue(consistent)
+
+    def test_SLB_grueneisen(self):
+        params = mineral_params.copy()
+        params["reference_eos"] = create("bm3")
+        params["debye_temperature_model"] = theta_SLB()
+        params["Debye_0"] = 1000.0
+        params["grueneisen_0"] = 1.2
+        params["q_0"] = 1.1
+        params["P_0"] = 1.e5
+
+        m = Mineral(params)
+        m.set_state(1.e5, 298.15)
+        self.assertAlmostEqual(m.gr, params["grueneisen_0"], places=6)
+
+    def test_PLG_grueneisen(self):
+        params = mineral_params.copy()
+        params["reference_eos"] = create("bm3")
+        params["debye_temperature_model"] = PLG()
+        params["Debye_0"] = 1000.0
+        params["grueneisen_0"] = 1.0
+        params["c_1"] = 0.2
+        params["c_2"] = 0.1
+        params["q_1"] = 1.0
+        params["q_2"] = 2.0
+        params["P_0"] = 1.e5
+
+        m = Mineral(params)
+        m.set_state(1.e5, 298.15)
+        self.assertAlmostEqual(m.gr, params["grueneisen_0"], places=6)
+
+    def test_PLGS_grueneisen(self):
+        params = mineral_params.copy()
+        params["reference_eos"] = create("bm3")
+        params["debye_temperature_model"] = PLGS()
+        params["Debye_0"] = 1000.0
+        params["grueneisen_0"] = 1.2
+        params["q_0"] = 1.1
+        params["P_0"] = 1.e5
+
+        m = Mineral(params)
+        m.set_state(1.e5, 298.15)
+        self.assertAlmostEqual(m.gr, params["grueneisen_0"], places=6)
+
+    def test_SLB_electronic_contribution(self):
+        params = mineral_params.copy()
+        params["reference_eos"] = create("bm3")
+        params["debye_temperature_model"] = theta_SLB()
+        params["Debye_0"] = 1000.0
+        params["grueneisen_0"] = 1.2
+        params["q_0"] = 1.1
+        params["P_0"] = 1.e5
+        params["bel_0"] = 0.005
+        params["gel"] = 1.5
+
+        m = Mineral(params)
+        consistent = check_eos_consistency(m, 2.0e9, 2000.0, including_shear_properties=False, tol=1.0e-4)
+        self.assertTrue(consistent)
+
+    def test_SPOCK_isothermal_contribution(self):
+        params = mineral_params.copy()
+        params["reference_eos"] = create("spock")
+        params["debye_temperature_model"] = theta_SLB()
+        params["Debye_0"] = 1000.0
+        params["grueneisen_0"] = 1.2
+        params["q_0"] = 1.1
+        params["P_0"] = 1.e5
+        params["Kprime_inf"] = 2.0
+        params["Kprime_0"] = 4.21796
+        params["Kdprime_0"] = -4 / 1.0e11
+
+        m = Mineral(params)
+        consistent = check_eos_consistency(m, 2.0e9, 2000.0, including_shear_properties=False, tol=1.0e-4)
+        self.assertTrue(consistent)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_modular_mgd.py
+++ b/tests/test_modular_mgd.py
@@ -49,11 +49,13 @@ class ModularMGD(BurnManTest):
 
         dVrel = 1.0e-6
         Vrel = 0.7
-        dtdVrel_numerical = (t(Vrel + dVrel, params) - t(Vrel - dVrel, params)) / (2.0 * dVrel)
-        dtdVrel_analytical = t.dVrel(Vrel, params)
-        d2tdVrel2_numerical = (t.dVrel(Vrel + dVrel, params) - t.dVrel(Vrel - dVrel, params)) / (
+        dtdVrel_numerical = (t(Vrel + dVrel, params) - t(Vrel - dVrel, params)) / (
             2.0 * dVrel
         )
+        dtdVrel_analytical = t.dVrel(Vrel, params)
+        d2tdVrel2_numerical = (
+            t.dVrel(Vrel + dVrel, params) - t.dVrel(Vrel - dVrel, params)
+        ) / (2.0 * dVrel)
         d2tdVrel2_analytical = t.d2dVrel2(Vrel, params)
         self.assertAlmostEqual(dtdVrel_numerical, dtdVrel_analytical, places=6)
         self.assertAlmostEqual(d2tdVrel2_numerical, d2tdVrel2_analytical, places=6)
@@ -63,7 +65,7 @@ class ModularMGD(BurnManTest):
         params["reference_eos"] = create("bm3")
         params["debye_temperature_model"] = PLG()
         params["Debye_0"] = 1000.0
-        params["grueneisen_0"] = 1.
+        params["grueneisen_0"] = 1.0
         params["c_1"] = 0.2
         params["c_2"] = 0.1
         params["q_1"] = 1.0
@@ -73,11 +75,13 @@ class ModularMGD(BurnManTest):
 
         dVrel = 1.0e-6
         Vrel = 0.7
-        dtdVrel_numerical = (t(Vrel + dVrel, params) - t(Vrel - dVrel, params)) / (2.0 * dVrel)
-        dtdVrel_analytical = t.dVrel(Vrel, params)
-        d2tdVrel2_numerical = (t.dVrel(Vrel + dVrel, params) - t.dVrel(Vrel - dVrel, params)) / (
+        dtdVrel_numerical = (t(Vrel + dVrel, params) - t(Vrel - dVrel, params)) / (
             2.0 * dVrel
         )
+        dtdVrel_analytical = t.dVrel(Vrel, params)
+        d2tdVrel2_numerical = (
+            t.dVrel(Vrel + dVrel, params) - t.dVrel(Vrel - dVrel, params)
+        ) / (2.0 * dVrel)
         d2tdVrel2_analytical = t.d2dVrel2(Vrel, params)
         self.assertAlmostEqual(dtdVrel_numerical, dtdVrel_analytical, places=6)
         self.assertAlmostEqual(d2tdVrel2_numerical, d2tdVrel2_analytical, places=6)
@@ -94,11 +98,13 @@ class ModularMGD(BurnManTest):
 
         dVrel = 1.0e-6
         Vrel = 0.7
-        dtdVrel_numerical = (t(Vrel + dVrel, params) - t(Vrel - dVrel, params)) / (2.0 * dVrel)
-        dtdVrel_analytical = t.dVrel(Vrel, params)
-        d2tdVrel2_numerical = (t.dVrel(Vrel + dVrel, params) - t.dVrel(Vrel - dVrel, params)) / (
+        dtdVrel_numerical = (t(Vrel + dVrel, params) - t(Vrel - dVrel, params)) / (
             2.0 * dVrel
         )
+        dtdVrel_analytical = t.dVrel(Vrel, params)
+        d2tdVrel2_numerical = (
+            t.dVrel(Vrel + dVrel, params) - t.dVrel(Vrel - dVrel, params)
+        ) / (2.0 * dVrel)
         d2tdVrel2_analytical = t.d2dVrel2(Vrel, params)
         self.assertAlmostEqual(dtdVrel_numerical, dtdVrel_analytical, places=6)
         self.assertAlmostEqual(d2tdVrel2_numerical, d2tdVrel2_analytical, places=6)
@@ -112,7 +118,9 @@ class ModularMGD(BurnManTest):
         params["q_0"] = 1.1
 
         m = Mineral(params)
-        consistent = check_eos_consistency(m, 2.0e9, 2000.0, including_shear_properties=False, tol=1.0e-4)
+        consistent = check_eos_consistency(
+            m, 2.0e9, 2000.0, including_shear_properties=False, tol=1.0e-4
+        )
         self.assertTrue(consistent)
 
     def test_check_PLG_consistency(self):
@@ -127,7 +135,9 @@ class ModularMGD(BurnManTest):
         params["q_2"] = 2.0
 
         m = Mineral(params)
-        consistent = check_eos_consistency(m, 2.0e9, 2000.0, including_shear_properties=False, tol=1.0e-4)
+        consistent = check_eos_consistency(
+            m, 2.0e9, 2000.0, including_shear_properties=False, tol=1.0e-4
+        )
         self.assertTrue(consistent)
 
     def test_check_PLGS_consistency(self):
@@ -139,7 +149,9 @@ class ModularMGD(BurnManTest):
         params["q_0"] = 1.0
 
         m = Mineral(params)
-        consistent = check_eos_consistency(m, 2.0e9, 2000.0, including_shear_properties=False, tol=1.0e-4)
+        consistent = check_eos_consistency(
+            m, 2.0e9, 2000.0, including_shear_properties=False, tol=1.0e-4
+        )
         self.assertTrue(consistent)
 
     def test_SLB_grueneisen(self):
@@ -149,10 +161,10 @@ class ModularMGD(BurnManTest):
         params["Debye_0"] = 1000.0
         params["grueneisen_0"] = 1.2
         params["q_0"] = 1.1
-        params["P_0"] = 1.e5
+        params["P_0"] = 1.0e5
 
         m = Mineral(params)
-        m.set_state(1.e5, 298.15)
+        m.set_state(1.0e5, 298.15)
         self.assertAlmostEqual(m.gr, params["grueneisen_0"], places=6)
 
     def test_PLG_grueneisen(self):
@@ -165,10 +177,10 @@ class ModularMGD(BurnManTest):
         params["c_2"] = 0.1
         params["q_1"] = 1.0
         params["q_2"] = 2.0
-        params["P_0"] = 1.e5
+        params["P_0"] = 1.0e5
 
         m = Mineral(params)
-        m.set_state(1.e5, 298.15)
+        m.set_state(1.0e5, 298.15)
         self.assertAlmostEqual(m.gr, params["grueneisen_0"], places=6)
 
     def test_PLGS_grueneisen(self):
@@ -178,10 +190,10 @@ class ModularMGD(BurnManTest):
         params["Debye_0"] = 1000.0
         params["grueneisen_0"] = 1.2
         params["q_0"] = 1.1
-        params["P_0"] = 1.e5
+        params["P_0"] = 1.0e5
 
         m = Mineral(params)
-        m.set_state(1.e5, 298.15)
+        m.set_state(1.0e5, 298.15)
         self.assertAlmostEqual(m.gr, params["grueneisen_0"], places=6)
 
     def test_SLB_electronic_contribution(self):
@@ -191,12 +203,14 @@ class ModularMGD(BurnManTest):
         params["Debye_0"] = 1000.0
         params["grueneisen_0"] = 1.2
         params["q_0"] = 1.1
-        params["P_0"] = 1.e5
+        params["P_0"] = 1.0e5
         params["bel_0"] = 0.005
         params["gel"] = 1.5
 
         m = Mineral(params)
-        consistent = check_eos_consistency(m, 2.0e9, 2000.0, including_shear_properties=False, tol=1.0e-4)
+        consistent = check_eos_consistency(
+            m, 2.0e9, 2000.0, including_shear_properties=False, tol=1.0e-4
+        )
         self.assertTrue(consistent)
 
     def test_SPOCK_isothermal_contribution(self):
@@ -206,13 +220,15 @@ class ModularMGD(BurnManTest):
         params["Debye_0"] = 1000.0
         params["grueneisen_0"] = 1.2
         params["q_0"] = 1.1
-        params["P_0"] = 1.e5
+        params["P_0"] = 1.0e5
         params["Kprime_inf"] = 2.0
         params["Kprime_0"] = 4.21796
         params["Kdprime_0"] = -4 / 1.0e11
 
         m = Mineral(params)
-        consistent = check_eos_consistency(m, 2.0e9, 2000.0, including_shear_properties=False, tol=1.0e-4)
+        consistent = check_eos_consistency(
+            m, 2.0e9, 2000.0, including_shear_properties=False, tol=1.0e-4
+        )
         self.assertTrue(consistent)
 
 

--- a/tests/test_modular_mgd.py
+++ b/tests/test_modular_mgd.py
@@ -204,14 +204,45 @@ class ModularMGD(BurnManTest):
         params["grueneisen_0"] = 1.2
         params["q_0"] = 1.1
         params["P_0"] = 1.0e5
-        params["bel_0"] = 0.005
-        params["gel"] = 1.5
+        m_without_component = Mineral(params)
 
-        m = Mineral(params)
+        params2 = params.copy()
+        params2["bel_0"] = 0.005
+        params2["gel"] = 1.5
+
+        m = Mineral(params2)
         consistent = check_eos_consistency(
             m, 2.0e9, 2000.0, including_shear_properties=False, tol=1.0e-4
         )
         self.assertTrue(consistent)
+
+        m.set_state(2.0e9, 2000.0)
+        m_without_component.set_state(2.0e9, 2000.0)
+        self.assertFalse(m_without_component.S == m.S)
+
+    def test_SLB_anharmonic_contribution(self):
+        params = mineral_params.copy()
+        params["reference_eos"] = create("bm3")
+        params["debye_temperature_model"] = theta_SLB()
+        params["Debye_0"] = 1000.0
+        params["grueneisen_0"] = 1.2
+        params["q_0"] = 1.1
+        params["P_0"] = 1.0e5
+        m_without_component = Mineral(params)
+
+        params2 = params.copy()
+        params2["a_anh"] = 1000.0
+        params2["m_anh"] = 3.0
+
+        m = Mineral(params2)
+        consistent = check_eos_consistency(
+            m, 2.0e9, 2000.0, including_shear_properties=False, tol=1.0e-4
+        )
+        self.assertTrue(consistent)
+
+        m.set_state(2.0e9, 2000.0)
+        m_without_component.set_state(2.0e9, 2000.0)
+        self.assertFalse(m_without_component.S == m.S)
 
     def test_SPOCK_isothermal_contribution(self):
         params = mineral_params.copy()


### PR DESCRIPTION
This PR adds a new modular Mie-Debye-Grueneisen (F(V, T)) equation of state.

The equation of state allows the user to pick the:
- isothermal equation of state (e.g. BM3, Vinet, SPOCK)
- model for the Debye temperature (Theta_D(V/V_0)), of which three models have been implemented.

and also allows for the addition of electronic (Bukowinski) and anharmonic (Debye-based) contributions to the Helmholtz energy.

Tests are included that cover the new functionality.