### PR TITLE
improve SLB24 benchmarking

### DIFF
--- a/burnman/tools/equilibration.py
+++ b/burnman/tools/equilibration.py
@@ -631,22 +631,22 @@ def get_equilibration_parameters(assemblage, composition, free_compositional_vec
 
     # Process parameter names
     prm.parameter_names = ["Pressure (Pa)", "Temperature (K)"]
-    prm.default_tolerances = [1.0, 1.0e-3]
+    prm.default_tolerances = [1.0, 1.0e-6]
     for i, n in enumerate(assemblage.endmembers_per_phase):
         prm.parameter_names.append("x({0})".format(assemblage.phases[i].name))
-        prm.default_tolerances.append(1.0e-6)
+        prm.default_tolerances.append(1.0e-9)
         if n > 1:
             p_names = [
                 "p({0} in {1})".format(n, assemblage.phases[i].name)
                 for n in assemblage.phases[i].endmember_names[1:]
             ]
             prm.parameter_names.extend(p_names)
-            prm.default_tolerances.extend([1.0e-6] * len(p_names))
+            prm.default_tolerances.extend([1.0e-9] * len(p_names))
 
     n_free_compositional_vectors = len(free_compositional_vectors)
     for i in range(n_free_compositional_vectors):
         prm.parameter_names.append(f"v_{i}")
-        prm.default_tolerances.append(1.0e-6)
+        prm.default_tolerances.append(1.0e-9)
 
     prm.default_tolerances = np.array(prm.default_tolerances)
 
@@ -1036,6 +1036,10 @@ def equilibrate(
         if sol.success and len(assemblage.reaction_affinities) > 0.0:
             maxres = np.max(np.abs(assemblage.reaction_affinities)) + 1.0e-5
             assemblage.equilibrium_tolerance = maxres
+            assert maxres < 10.0, (
+                "Equilibrium not satisfied to high enough precision. "
+                f"Max reaction affinity is {maxres} J/mol. Try reducing tol."
+            )
 
         if store_assemblage:
             sol.assemblage = assemblage.copy()


### PR DESCRIPTION
This pull request makes improvements to the equilibration precision and updates several benchmark routines to ensure more accurate and robust calculations. The most significant changes involve tightening numerical tolerances in the equilibration routines, adding assertion checks for equilibrium precision, and updating benchmark scripts to use more precise and physically consistent procedures.

**Equilibration precision improvements:**

* Reduced the default numerical tolerances for pressure, temperature, and compositional parameters in `get_equilibration_parameters` in `equilibration.py` for higher precision in equilibrium calculations.
* Added an assertion in `equilibrate` to ensure that the maximum reaction affinity is below a strict threshold of 10 J/mol, improving the reliability of equilibrium detection.

**Benchmark procedure updates:**

* In `check_fig_1_fper_relaxed` of `slb_2024_benchmarks.py`, updated the procedure to first equilibrate ferropericlase and iron at 1 bar, 1473 K, then use the resulting composition for subsequent calculations, ensuring consistency with SLB2024 Figure 1. [[1]](diffhunk://#diff-eb55b7fb5c6cb76c497ddc790ffefe8bb617f28632a7dcc9c49cc2bd2716e29eR63) [[2]](diffhunk://#diff-eb55b7fb5c6cb76c497ddc790ffefe8bb617f28632a7dcc9c49cc2bd2716e29eL83-R103)
* In `check_fig_7_fO2`, added an assertion to confirm that compositional simplification yields the expected number of endmembers, and updated the equilibrium calculation to use a stricter tolerance and the correct assemblage state when computing chemical potentials. [[1]](diffhunk://#diff-eb55b7fb5c6cb76c497ddc790ffefe8bb617f28632a7dcc9c49cc2bd2716e29eR376) [[2]](diffhunk://#diff-eb55b7fb5c6cb76c497ddc790ffefe8bb617f28632a7dcc9c49cc2bd2716e29eL438-R467)