### PR TITLE
move regularization

### DIFF
--- a/burnman/optimize/nonlinear_solvers.py
+++ b/burnman/optimize/nonlinear_solvers.py
@@ -722,11 +722,6 @@ class DampedNewtonSolver:
             dx = lu_solve(luJ, -sol.F)
             dx_norm = np.linalg.norm(dx, ord=2)
 
-            is_singular = condition_number > self.max_condition_number
-            if is_singular and any(np.isnan(dx)):
-                lmda_bounds = [0.0, 0.0]
-                break
-
             lmda_bounds = self.lambda_bounds(dx, sol.x)
             h = (
                 lmda

--- a/tests/test_equilibration.py
+++ b/tests/test_equilibration.py
@@ -256,7 +256,7 @@ class equilibration(BurnManTest):
         equality_constraints = [("P", 1.0e5), ("T", 1000.0)]
         sol, _ = equilibrate(composition, a, equality_constraints)
         self.assertTrue(sol.success)  # Expect successful convergence
-        self.assertTrue(sol.code == 5)  # Expect singular system at solution
+        self.assertEqual(sol.code, 5)  # Expect singular system at solution
 
     def test_ill_posed_problem(self):
 
@@ -269,7 +269,7 @@ class equilibration(BurnManTest):
         a.phases[1].set_composition([0.5, 0.5])
         equality_constraints = [("P", 1.0e5), ("T", 300.0)]
         sol, _ = equilibrate(composition, a, equality_constraints)
-        self.assertTrue(sol.code == 2)  # Expect problem to leave the feasible region
+        self.assertEqual(sol.code, 2)  # Expect problem to leave the feasible region
 
     def test_ill_conditioned_jacobian(self):
 
@@ -282,7 +282,7 @@ class equilibration(BurnManTest):
         a.phases[1].set_composition([0.4, 0.6])
         equality_constraints = [("P", 1.0e5), ("T", 300.0)]
         sol, _ = equilibrate(composition, a, equality_constraints)
-        self.assertTrue(sol.code == 4)  # Expect singular system
+        self.assertEqual(sol.code, 4)  # Expect singular system
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request simplifies the regularization logic in the Newton step.

**Regularization improvements:**

* Changed the default value for the `regularization` parameter from `0.0` to `np.finfo(float).eps`.
* Updated the docstring to reflect the new default for `regularization`, specifying it now defaults to numpy float epsilon.

**Solver logic updates:**

* Moved the regularization of ill-conditioned Jacobian matrices earlier in the solver logic to be more consistent throughout the calculations.
* The final adjustment step now recomputes the solution vector and Jacobian without regularization to ensure tolerances are satisfied.