### PR TITLE
added relaxation documentation

### DIFF
--- a/docs/background.rst
+++ b/docs/background.rst
@@ -6,6 +6,7 @@ Here is a bit of background on the methods used to calculate thermoelastic and t
 
 .. include:: background_thermoelastics.txt
 .. include:: background_thermodynamics.txt
+.. include:: background_relaxation.txt
 .. include:: background_solutions.txt
 .. include:: background_composites.txt
 .. include:: background_equilibration.txt

--- a/docs/background_relaxation.txt
+++ b/docs/background_relaxation.txt
@@ -1,0 +1,87 @@
+Calculating Relaxed Thermodynamic Properties
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Burnman can calculate relaxed thermodynamic properties for materials that have
+isochemical degrees of freedom. This is done by minimizing the Gibbs free energy
+of the system with respect to the isochemical variables at each pressure and
+temperature point. If these isochemical variables can vary on timescales
+shorter than the timescales of changes in pressure and temperature,
+then the second derivatives of the Gibbs free energy with respect to these variables
+are affected by the relaxation. 
+
+To calculate these properties, we use
+variational calculus. Let the extent of the isochemical reactions be given by the
+vector :math:`\xi`. Let us also define the partial derivative function
+:math:`F(P,T,X,\xi) = \partial G / \partial \xi`, where :math:`G` is the Gibbs free energy
+of the system. The relaxed state is given by the condition :math:`F(P,T,X,\xi) = 0`.
+For simplicity, let us group the pressure, temperature, and composition variables
+into a single vector :math:`Z = (P,T,X)` (we aren't actually interested in the composition,
+but keep it here for completeness). Finally, we define a function
+:math:`\phi(Z) = \xi`, which gives the extent of the isochemical reactions
+at equilibrium for given pressure, temperature, and composition.
+Assuming that the reaction variables are always at equilibrium, we have:
+.. math::
+    F = F(Z, \phi(Z)) = \frac{\partial G}{\partial \xi} (Z, \phi(Z))
+
+Taking the total derivative of this expression with respect to :math:`Z`, we have:
+.. math::
+    \frac{d F}{d Z} = \frac{\partial F}{\partial Z} + \frac{\partial F}{\partial \xi}
+    \frac{\partial \phi}{\partial Z}
+
+Now, since :math:`F(Z, \phi(Z)) = 0` for all :math:`Z`, we also have :math:`d F / d Z = 0`, 
+and therefore:
+.. math::
+     \frac{\partial F}{\partial \xi}
+    \frac{\partial \phi}{\partial Z} = - \frac{\partial F}{\partial Z}
+    
+Note that the matrix :math:`\partial F / \partial \xi` is the Hessian matrix of second derivatives
+of the Gibbs free energy with respect to the isochemical variables:
+.. math::
+
+    \frac{\partial F}{\partial \xi} = \frac{\partial^2 G}{\partial \xi^2}
+
+It is therefore symmetric. Let us define the pseudo-inverse of this matrix as
+:math:`R`, so that :math:`R \partial F / \partial \xi = I`, where :math:`I` is the identity matrix.
+Then we have:
+.. math::
+    \frac{\partial \phi}{\partial Z} = - R \frac{\partial F}{\partial Z}
+
+
+Finally, define a function :math:`g(Z) = G(Z, \phi(Z))`, which gives the Gibbs free energy
+of the system at equilibrium. Using the chain rule, we can write the total derivative of this function with respect to :math:`Z` as:
+.. math::
+    \frac{d g}{d Z} = \frac{\partial G}{\partial Z} + \frac{\partial G}{\partial \xi}
+    \frac{\partial \phi}{\partial Z}
+
+However, since :math:`F = \partial G / \partial \xi = 0`, the second term on the right-hand side
+vanishes, and we have:
+.. math::
+    \frac{d g}{d Z} = \frac{\partial G(Z, \phi(Z))}{\partial Z}
+
+Taking the second derivative of :math:`g` with respect to :math:`Z`, we have:
+.. math::
+    \frac{d^2 g}{d Z^2} = \frac{\partial^2 G}{\partial Z^2} +
+    \frac{\partial^2 G}{\partial Z \partial \xi} \frac{\partial \phi}{\partial Z}
+
+
+Now, substituting in our expression for :math:`\partial \phi / \partial Z`, we have:
+.. math::
+    \frac{d^2 g}{d Z^2} = \frac{\partial^2 G}{\partial Z^2} -
+    \frac{\partial^2 G}{\partial Z \partial \xi} R
+    \frac{\partial F}{\partial Z}
+
+or, equivalently:
+.. math::
+    \frac{d^2 g}{d Z^2} = \frac{\partial^2 G}{\partial Z^2} -
+    \frac{\partial^2 G}{\partial Z \partial \xi} 
+    R
+    \frac{\partial^2 G}{\partial \xi \partial Z}
+
+This expression gives the relaxed second derivatives of the Gibbs free energy
+with respect to pressure, temperature, and composition. These second derivatives
+can then be used to calculate the relaxed thermodynamic properties of the system,
+such as the bulk modulus, thermal expansivity, and heat capacity:
+.. math::
+    K_{P,relaxed} = -V \left(\frac{\partial^2 g}{\partial P^2}\right)^{-1}, \quad
+    \alpha_{relaxed} = \frac{1}{V} \frac{\partial^2 g}{\partial P \partial T}, \quad
+    C_{P,relaxed} = - T \frac{\partial^2 g}{\partial T^2}


### PR DESCRIPTION
This pull request:
* Adds a new section, `background_relaxation.txt`, to the documentation, which explains the mathematical framework for calculating relaxed thermodynamic properties using variational calculus and the minimization of the Gibbs free energy. This section covers the derivation of the relevant equations and their application to properties like bulk modulus, thermal expansivity, and heat capacity.
* Updates `background.rst` to include the new `background_relaxation.txt` section.