### PR TITLE
restrict use of averaging schemes

### DIFF
--- a/burnman/classes/averaging_schemes.py
+++ b/burnman/classes/averaging_schemes.py
@@ -1,6 +1,6 @@
 # This file is part of BurnMan - a thermoelastic and thermodynamic toolkit
 # for the Earth and Planetary Sciences
-# Copyright (C) 2012 - 2017 by the BurnMan team, released under the GNU
+# Copyright (C) 2012 - 2025 by the BurnMan team, released under the GNU
 # GPL v2 or later.
 
 
@@ -59,87 +59,6 @@ class AveragingScheme(object):
         :rtype: float
         """
         raise NotImplementedError("")
-
-    def average_density(self, volumes, densities):
-        """
-        Average the densities of a composite, given a list of volume
-        fractions and densitites. This is implemented in the base class,
-        as how to calculate it is not dependent on the geometry of the rock.
-        The formula for density is given by
-
-        .. math::
-            \\rho = \\frac{\\Sigma_i \\rho_i V_i }{\\Sigma_i V_i}
-
-        :param volumes: List of the volume of each phase in the composite
-            :math:`[m^3]`.
-        :type volumes: list of floats
-        :param densities: List of densities of each phase in the composite
-            :math:`[kg/m^3]`.
-        :type densities: list of floats
-
-        :returns: Density :math:`\\rho` :math:`[kg/m^3]`.
-        :rtype: float
-        """
-        total_mass = np.sum(np.array(densities) * np.array(volumes))
-        total_vol = np.sum(np.array(volumes))  # should sum to one
-        density = total_mass / total_vol
-        return density
-
-    def average_thermal_expansivity(self, volumes, alphas):
-        """
-        Averages the thermal expansion coefficient of the mineral :math:`\\alpha`
-        :math:`[1/K]`.
-
-        :param volumes: List of volume fractions of each phase
-            in the composite (should sum to 1.0).
-        :type volumes: list of floats
-        :param alphas: List of thermal expansivities :math:`\\alpha`
-            of each phase in the composite. :math:`[1/K]`
-        :type alphas: list of floats
-
-        :returns: Thermal expansivity of the composite :math:`\\alpha`. :math:`[1/K]`
-        :rtype: float
-        """
-        total_vol = np.sum(np.array(volumes))
-        return np.sum(np.array(alphas) * np.array(volumes)) / total_vol
-
-    def average_heat_capacity_v(self, fractions, c_v):
-        # TODO: double-check that the formula we use is appropriate here.
-        """
-        Averages the heat capacities at constant volume :math:`C_V` by molar fractions
-        as in eqn. (16) in :cite:`Ita1992`.
-
-        :param fractions: List of molar fractions of each phase
-            in the composite (should sum to 1.0).
-        :type fractions: list of floats
-        :param c_v: List of heat capacities at constant volume :math:`C_V`
-            of each phase in the composite. :math:`[J/K/mol]`
-        :type c_v: list of floats
-
-        :returns: Heat capacity at constant volume of the composite :math:`C_V`
-            :math:`[J/K/mol]`.
-        :rtype: float
-        """
-        return np.sum(np.array(fractions) * np.array(c_v))
-
-    def average_heat_capacity_p(self, fractions, c_p):
-        # TODO: double-check that the formula we use is correct.
-        """
-        Averages the heat capacities at constant pressure :math:`C_P`
-        by molar fractions.
-
-        :param fractions: List of molar fractions of each phase in the composite
-            (should sum to 1.0).
-        :type fractions: list of floats
-        :param c_p: List of heat capacities at constant pressure :math:`C_P` of each
-            phase in the composite :math:`[J/K/mol]`.
-        :type c_p: list of floats
-
-        :returns: Heat capacity at constant pressure :math:`C_P` of the composite
-            :math:`[J/K/mol]`.
-        :rtype: float
-        """
-        return np.sum(np.array(fractions) * np.array(c_p))
 
 
 class VoigtReussHill(AveragingScheme):

--- a/burnman/classes/material.py
+++ b/burnman/classes/material.py
@@ -1,6 +1,6 @@
 # This file is part of BurnMan - a thermoelastic and thermodynamic toolkit
 # for the Earth and Planetary Sciences
-# Copyright (C) 2012 - 2017 by the BurnMan team, released under the GNU
+# Copyright (C) 2012 - 2025 by the BurnMan team, released under the GNU
 # GPL v2 or later.
 
 import numpy as np
@@ -590,7 +590,39 @@ class Material(object):
         :returns: Shear modulus in [Pa].
         :rtype: float
         """
-        raise NotImplementedError("need to implement shear_modulus() in derived class!")
+        raise NotImplementedError(
+            "need to implement shear_modulus() in derived class! Perhaps you meant to call effective_shear_modulus, or G_eff?"
+        )
+
+    @material_property
+    def effective_isentropic_bulk_modulus(self):
+        """
+        Returns the effective isentropic bulk modulus of the mineral.
+
+        .. note:: Needs to be implemented in derived classes.
+            Aliased with :func:`~burnman.Material.K_eff`.
+
+        :returns: Effective isentropic bulk modulus in [Pa].
+        :rtype: float
+        """
+        raise NotImplementedError(
+            "need to implement effective_isentropic_bulk_modulus() in derived class!"
+        )
+
+    @material_property
+    def effective_shear_modulus(self):
+        """
+        Returns the effective shear modulus of the mineral.
+
+        .. note:: Needs to be implemented in derived classes.
+            Aliased with :func:`~burnman.Material.G_eff`.
+
+        :returns: Effective shear modulus in [Pa].
+        :rtype: float
+        """
+        raise NotImplementedError(
+            "need to implement effective_shear_modulus() in derived class!"
+        )
 
     @material_property
     def p_wave_velocity(self):
@@ -778,6 +810,16 @@ class Material(object):
     def G(self):
         """Alias for :func:`~burnman.Material.shear_modulus`"""
         return self.shear_modulus
+
+    @property
+    def K_eff(self):
+        """Alias for :func:`~burnman.Material.effective_isentropic_bulk_modulus`"""
+        return self.effective_isentropic_bulk_modulus
+
+    @property
+    def G_eff(self):
+        """Alias for :func:`~burnman.Material.effective_shear_modulus`"""
+        return self.effective_shear_modulus
 
     @property
     def v_p(self):

--- a/contrib/CHRU2014/paper_averaging.py
+++ b/contrib/CHRU2014/paper_averaging.py
@@ -12,8 +12,8 @@ This script reproduces :cite:`Cottaar2014`, Figure 2.
 
 This example shows the effect of different averaging schemes. Currently four
 averaging schemes are available:
-1. Voight-Reuss-Hill
-2. Voight averaging
+1. Voigt-Reuss-Hill
+2. Voigt averaging
 3. Reuss averaging
 4. Hashin-Shtrikman averaging
 
@@ -96,41 +96,41 @@ if __name__ == "__main__":
 
     # evaluate the end members
     rho_pv, vp_pv, vs_pv, vphi_pv, K_pv, G_pv = perovskitite.evaluate(
-        ["rho", "v_p", "v_s", "v_phi", "K_S", "G"], pressures, temperatures
+        ["rho", "v_p", "v_s", "v_phi", "K_eff", "G_eff"], pressures, temperatures
     )
 
     rho_fp, vp_fp, vs_fp, vphi_fp, K_fp, G_fp = periclasite.evaluate(
-        ["rho", "v_p", "v_s", "v_phi", "K_S", "G"], pressures, temperatures
+        ["rho", "v_p", "v_s", "v_phi", "K_eff", "G_eff"], pressures, temperatures
     )
 
     # Voigt Reuss Hill averaging
     rock.set_averaging_scheme(burnman.averaging_schemes.VoigtReussHill())
     rho_vrh, vp_vrh, vs_vrh, vphi_vrh, K_vrh, G_vrh = rock.evaluate(
-        ["rho", "v_p", "v_s", "v_phi", "K_S", "G"], pressures, temperatures
+        ["rho", "v_p", "v_s", "v_phi", "K_eff", "G_eff"], pressures, temperatures
     )
 
     # Voigt averaging
     rock.set_averaging_scheme(burnman.averaging_schemes.Voigt())
     rho_v, vp_v, vs_v, vphi_v, K_v, G_v = rock.evaluate(
-        ["rho", "v_p", "v_s", "v_phi", "K_S", "G"], pressures, temperatures
+        ["rho", "v_p", "v_s", "v_phi", "K_eff", "G_eff"], pressures, temperatures
     )
 
     # Reuss averaging
     rock.set_averaging_scheme(burnman.averaging_schemes.Reuss())
     rho_r, vp_r, vs_r, vphi_r, K_r, G_r = rock.evaluate(
-        ["rho", "v_p", "v_s", "v_phi", "K_S", "G"], pressures, temperatures
+        ["rho", "v_p", "v_s", "v_phi", "K_eff", "G_eff"], pressures, temperatures
     )
 
     # Upper bound for Hashin-Shtrikman averaging
     rock.set_averaging_scheme(burnman.averaging_schemes.HashinShtrikmanUpper())
     rho_hsu, vp_hsu, vs_hsu, vphi_hsu, K_hsu, G_hsu = rock.evaluate(
-        ["rho", "v_p", "v_s", "v_phi", "K_S", "G"], pressures, temperatures
+        ["rho", "v_p", "v_s", "v_phi", "K_eff", "G_eff"], pressures, temperatures
     )
 
     # Lower bound for Hashin-Shtrikman averaging
     rock.set_averaging_scheme(burnman.averaging_schemes.HashinShtrikmanLower())
     rho_hsl, vp_hsl, vs_hsl, vphi_hsl, K_hsl, G_hsl = rock.evaluate(
-        ["rho", "v_p", "v_s", "v_phi", "K_S", "G"], pressures, temperatures
+        ["rho", "v_p", "v_s", "v_phi", "K_eff", "G_eff"], pressures, temperatures
     )
 
     # linear fit

--- a/contrib/CHRU2014/paper_incorrect_averaging.py
+++ b/contrib/CHRU2014/paper_incorrect_averaging.py
@@ -158,13 +158,13 @@ if __name__ == "__main__":
     preferred_mixture.set_method(method)
 
     mat_rho_1, mat_vp_1, mat_vs_1, mat_vphi_1, mat_K_1, mat_G_1 = perovskitite.evaluate(
-        ["rho", "v_p", "v_s", "v_phi", "K_S", "G"], seis_p, temperature_bs
+        ["rho", "v_p", "v_s", "v_phi", "K_eff", "G_eff"], seis_p, temperature_bs
     )
     mat_rho_2, mat_vp_2, mat_vs_2, mat_vphi_2, mat_K_2, mat_G_2 = periclasite.evaluate(
-        ["rho", "v_p", "v_s", "v_phi", "K_S", "G"], seis_p, temperature_bs
+        ["rho", "v_p", "v_s", "v_phi", "K_eff", "G_eff"], seis_p, temperature_bs
     )
     mat_rho_3, mat_vp_3, mat_vs_3, mat_vphi_3, mat_K_3, mat_G_3 = pyrolite.evaluate(
-        ["rho", "v_p", "v_s", "v_phi", "K_S", "G"], seis_p, temperature_bs
+        ["rho", "v_p", "v_s", "v_phi", "K_eff", "G_eff"], seis_p, temperature_bs
     )
     (
         mat_rho_4,
@@ -174,7 +174,7 @@ if __name__ == "__main__":
         mat_K_4,
         mat_G_4,
     ) = preferred_mixture.evaluate(
-        ["rho", "v_p", "v_s", "v_phi", "K_S", "G"], seis_p, temperature_bs
+        ["rho", "v_p", "v_s", "v_phi", "K_eff", "G_eff"], seis_p, temperature_bs
     )
 
     # HERE IS THE STEP WITH THE INCORRECT MIXING ###

--- a/contrib/CHRU2014/paper_onefit.py
+++ b/contrib/CHRU2014/paper_onefit.py
@@ -321,7 +321,7 @@ if __name__ == "__main__":
     temperature = burnman.geotherm.adiabatic(pressure, anchor_t, rock)
     rock.set_averaging_scheme(burnman.averaging_schemes.HashinShtrikmanAverage())
     rho, vp, vs, vphi, K, G = rock.evaluate(
-        ["rho", "v_p", "v_s", "v_phi", "K_S", "G"], pressure, temperature
+        ["rho", "v_p", "v_s", "v_phi", "K_eff", "G_eff"], pressure, temperature
     )
 
     err_vs, err_vphi, err_rho = np.square(
@@ -401,7 +401,7 @@ if __name__ == "__main__":
     temperature = burnman.geotherm.adiabatic(pressure, anchor_t, rock)
     rock.set_averaging_scheme(burnman.averaging_schemes.HashinShtrikmanAverage())
     rho, vp, vs, vphi, K, G = rock.evaluate(
-        ["rho", "v_p", "v_s", "v_phi", "K_S", "G"], pressure, temperature
+        ["rho", "v_p", "v_s", "v_phi", "K_eff", "G_eff"], pressure, temperature
     )
     plt.plot(
         pressure / 1.0e9,

--- a/examples/example_composite_seismic_velocities.py
+++ b/examples/example_composite_seismic_velocities.py
@@ -130,7 +130,7 @@ if __name__ == "__main__":
     rock.debug_print()
 
     mat_rho, mat_vp, mat_vphi, mat_vs, mat_K, mat_G = rock.evaluate(
-        ["density", "v_p", "v_phi", "v_s", "K_S", "G"], seis_p, temperature
+        ["density", "v_p", "v_phi", "v_s", "K_eff", "G_eff"], seis_p, temperature
     )
 
     [vs_err, vphi_err, rho_err] = burnman.utils.math.chisqr_profiles(

--- a/examples/example_optimize_pv.py
+++ b/examples/example_optimize_pv.py
@@ -70,7 +70,7 @@ if __name__ == "__main__":
 
         # Compute velocities
         mat_rho, mat_vp, mat_vs, mat_vphi, mat_K, mat_G = rock.evaluate(
-            ["density", "v_p", "v_s", "v_phi", "K_S", "G"], seis_p, temperature
+            ["density", "v_p", "v_s", "v_phi", "K_eff", "G_eff"], seis_p, temperature
         )
 
         print("Calculations are done for:")

--- a/examples/example_woutput.py
+++ b/examples/example_woutput.py
@@ -53,7 +53,7 @@ if __name__ == "__main__":
     rock.debug_print()
 
     mat_rho, mat_vp, mat_vs, mat_vphi, mat_K, mat_G = rock.evaluate(
-        ["density", "v_p", "v_s", "v_phi", "K_S", "G"], pressures, temperature
+        ["density", "v_p", "v_s", "v_phi", "K_eff", "G_eff"], pressures, temperature
     )
     # write to file:
     output_filename = "example_woutput.txt"

--- a/tests/test_averaging.py
+++ b/tests/test_averaging.py
@@ -73,7 +73,9 @@ class VRH(BurnManTest):
         rock.set_method("slb3")
         rock.set_averaging_scheme(avg.VoigtReussHill())
         rho, v_p, v_s, v_phi, K_vrh, G_vrh = rock.evaluate(
-            ["rho", "v_p", "v_s", "v_phi", "K_S", "G"], [10.0e9], [300.0]
+            ["rho", "v_p", "v_s", "v_phi", "K_eff", "G_eff"],
+            [10.0e9],
+            [300.0],
         )
         self.assertFloatEqual(3791.392, rho[0])
         self.assertFloatEqual(10285.368, v_p[0])
@@ -88,7 +90,9 @@ class VRH(BurnManTest):
         rock.set_method("slb3")
         rock.set_averaging_scheme(avg.VoigtReussHill())
         rho, v_p, v_s, v_phi, K_vrh, G_vrh = rock.evaluate(
-            ["rho", "v_p", "v_s", "v_phi", "K_S", "G"], [10.0e9], [300.0]
+            ["rho", "v_p", "v_s", "v_phi", "K_eff", "G_eff"],
+            [10.0e9],
+            [300.0],
         )
         self.assertFloatEqual(3791.392, rho[0])
         self.assertFloatEqual(10285.368, v_p[0])
@@ -110,7 +114,9 @@ class VRH(BurnManTest):
         rock.set_method("slb3")
         rock.set_averaging_scheme(avg.VoigtReussHill())
         rho, v_p, v_s, v_phi, K_vrh, G_vrh = rock.evaluate(
-            ["rho", "v_p", "v_s", "v_phi", "K_S", "G"], [10.0e9], [300.0]
+            ["rho", "v_p", "v_s", "v_phi", "K_eff", "G_eff"],
+            [10.0e9],
+            [300.0],
         )
         self.assertFloatEqual(4881.469, rho[0])
         self.assertFloatEqual(9957.665, v_p[0])
@@ -125,7 +131,9 @@ class Reuss(BurnManTest):
         rock = burnman.Composite([mypericlase()], [1.0])
         rock.set_averaging_scheme(avg.Reuss())
         rho, v_p, v_s, v_phi, K, G = rock.evaluate(
-            ["rho", "v_p", "v_s", "v_phi", "K_S", "G"], [10.0e9], [300.0]
+            ["rho", "v_p", "v_s", "v_phi", "K_eff", "G_eff"],
+            [10.0e9],
+            [300.0],
         )
         self.assertFloatEqual(3791.392, rho[0])
         self.assertFloatEqual(10285.368, v_p[0])
@@ -138,7 +146,9 @@ class Reuss(BurnManTest):
         rock = burnman.Composite([mypericlase()] * number, [1.0 / number] * number)
         rock.set_averaging_scheme(avg.Reuss())
         rho, v_p, v_s, v_phi, K, G = rock.evaluate(
-            ["rho", "v_p", "v_s", "v_phi", "K_S", "G"], [10.0e9], [300.0]
+            ["rho", "v_p", "v_s", "v_phi", "K_eff", "G_eff"],
+            [10.0e9],
+            [300.0],
         )
         self.assertFloatEqual(3791.392, rho[0])
         self.assertFloatEqual(10285.368, v_p[0])
@@ -159,7 +169,9 @@ class Reuss(BurnManTest):
         )
         rock.set_averaging_scheme(avg.Reuss())
         rho, v_p, v_s, v_phi, K, G = rock.evaluate(
-            ["rho", "v_p", "v_s", "v_phi", "K_S", "G"], [10.0e9], [300.0]
+            ["rho", "v_p", "v_s", "v_phi", "K_eff", "G_eff"],
+            [10.0e9],
+            [300.0],
         )
         self.assertFloatEqual(4881.469, rho[0])
         self.assertFloatEqual(9887.625, v_p[0])
@@ -174,7 +186,16 @@ class Reuss(BurnManTest):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             rho, v_p, v_s, v_phi, K, G = rock.evaluate(
-                ["rho", "v_p", "v_s", "v_phi", "K_S", "G"], 10.0e9, 300.0
+                [
+                    "rho",
+                    "v_p",
+                    "v_s",
+                    "v_phi",
+                    "K_eff",
+                    "G_eff",
+                ],
+                10.0e9,
+                300.0,
             )
             assert len(w) == 2  # we expect two errors to be thrown when p_nonrigid = 0
         self.assertFloatEqual(150.901, G / 1.0e9)
@@ -185,7 +206,16 @@ class Reuss(BurnManTest):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             rho, v_p, v_s, v_phi, K, G = rock.evaluate(
-                ["rho", "v_p", "v_s", "v_phi", "K_S", "G"], 10.0e9, 300.0
+                [
+                    "rho",
+                    "v_p",
+                    "v_s",
+                    "v_phi",
+                    "K_eff",
+                    "G_eff",
+                ],
+                10.0e9,
+                300.0,
             )
             assert (
                 len(w) == 4
@@ -198,7 +228,9 @@ class Voigt(BurnManTest):
         rock = burnman.Composite([mypericlase()], [1.0])
         rock.set_averaging_scheme(avg.Voigt())
         rho, v_p, v_s, v_phi, K, G = rock.evaluate(
-            ["rho", "v_p", "v_s", "v_phi", "K_S", "G"], [10.0e9], [300.0]
+            ["rho", "v_p", "v_s", "v_phi", "K_eff", "G_eff"],
+            [10.0e9],
+            [300.0],
         )
         self.assertFloatEqual(3791.392, rho[0])
         self.assertFloatEqual(10285.368, v_p[0])
@@ -211,7 +243,9 @@ class Voigt(BurnManTest):
         rock = burnman.Composite([mypericlase()] * number, [1.0 / number] * number)
         rock.set_averaging_scheme(avg.Voigt())
         rho, v_p, v_s, v_phi, K, G = rock.evaluate(
-            ["rho", "v_p", "v_s", "v_phi", "K_S", "G"], [10.0e9], [300.0]
+            ["rho", "v_p", "v_s", "v_phi", "K_eff", "G_eff"],
+            [10.0e9],
+            [300.0],
         )
         self.assertFloatEqual(3791.392, rho[0])
         self.assertFloatEqual(10285.368, v_p[0])
@@ -232,7 +266,9 @@ class Voigt(BurnManTest):
         )
         rock.set_averaging_scheme(avg.Voigt())
         rho, v_p, v_s, v_phi, K, G = rock.evaluate(
-            ["rho", "v_p", "v_s", "v_phi", "K_S", "G"], [10.0e9], [300.0]
+            ["rho", "v_p", "v_s", "v_phi", "K_eff", "G_eff"],
+            [10.0e9],
+            [300.0],
         )
         self.assertFloatEqual(4881.469, rho[0])
         self.assertFloatEqual(10027.216, v_p[0])
@@ -247,7 +283,9 @@ class HSLower(BurnManTest):
         rock = burnman.Composite([mypericlase()], [1.0])
         rock.set_averaging_scheme(avg.HashinShtrikmanLower())
         rho, v_p, v_s, v_phi, K, G = rock.evaluate(
-            ["rho", "v_p", "v_s", "v_phi", "K_S", "G"], [10.0e9], [300.0]
+            ["rho", "v_p", "v_s", "v_phi", "K_eff", "G_eff"],
+            [10.0e9],
+            [300.0],
         )
         self.assertFloatEqual(3791.392, rho[0])
         self.assertFloatEqual(10285.368, v_p[0])
@@ -260,7 +298,9 @@ class HSLower(BurnManTest):
         rock = burnman.Composite([mypericlase()] * number, [1.0 / number] * number)
         rock.set_averaging_scheme(avg.HashinShtrikmanLower())
         rho, v_p, v_s, v_phi, K, G = rock.evaluate(
-            ["rho", "v_p", "v_s", "v_phi", "K_S", "G"], [10.0e9], [300.0]
+            ["rho", "v_p", "v_s", "v_phi", "K_eff", "G_eff"],
+            [10.0e9],
+            [300.0],
         )
         self.assertFloatEqual(3791.392, rho[0])
         self.assertFloatEqual(10285.368, v_p[0])
@@ -281,7 +321,9 @@ class HSLower(BurnManTest):
         )
         rock.set_averaging_scheme(avg.HashinShtrikmanLower())
         rho, v_p, v_s, v_phi, K, G = rock.evaluate(
-            ["rho", "v_p", "v_s", "v_phi", "K_S", "G"], [10.0e9], [300.0]
+            ["rho", "v_p", "v_s", "v_phi", "K_eff", "G_eff"],
+            [10.0e9],
+            [300.0],
         )
         self.assertFloatEqual(4881.469, rho[0])
         self.assertFloatEqual(9951.957, v_p[0])
@@ -296,7 +338,9 @@ class HSUpper(BurnManTest):
         rock = burnman.Composite([mypericlase()], [1.0])
         rock.set_averaging_scheme(avg.HashinShtrikmanUpper())
         rho, v_p, v_s, v_phi, K, G = rock.evaluate(
-            ["rho", "v_p", "v_s", "v_phi", "K_S", "G"], [10.0e9], [300.0]
+            ["rho", "v_p", "v_s", "v_phi", "K_eff", "G_eff"],
+            [10.0e9],
+            [300.0],
         )
         self.assertFloatEqual(3791.392, rho[0])
         self.assertFloatEqual(10285.368, v_p[0])
@@ -309,7 +353,9 @@ class HSUpper(BurnManTest):
         rock = burnman.Composite([mypericlase()] * number, [1.0 / number] * number)
         rock.set_averaging_scheme(avg.HashinShtrikmanUpper())
         rho, v_p, v_s, v_phi, K, G = rock.evaluate(
-            ["rho", "v_p", "v_s", "v_phi", "K_S", "G"], [10.0e9], [300.0]
+            ["rho", "v_p", "v_s", "v_phi", "K_eff", "G_eff"],
+            [10.0e9],
+            [300.0],
         )
         self.assertFloatEqual(3791.392, rho[0])
         self.assertFloatEqual(10285.368, v_p[0])
@@ -330,7 +376,9 @@ class HSUpper(BurnManTest):
         )
         rock.set_averaging_scheme(avg.HashinShtrikmanUpper())
         rho, v_p, v_s, v_phi, K, G = rock.evaluate(
-            ["rho", "v_p", "v_s", "v_phi", "K_S", "G"], [10.0e9], [300.0]
+            ["rho", "v_p", "v_s", "v_phi", "K_eff", "G_eff"],
+            [10.0e9],
+            [300.0],
         )
         self.assertFloatEqual(4881.469, rho[0])
         self.assertFloatEqual(9952.798, v_p[0])
@@ -345,7 +393,9 @@ class HSAverage(BurnManTest):
         rock = burnman.Composite([mypericlase()], [1.0])
         rock.set_averaging_scheme(avg.HashinShtrikmanAverage())
         rho, v_p, v_s, v_phi, K, G = rock.evaluate(
-            ["rho", "v_p", "v_s", "v_phi", "K_S", "G"], [10.0e9], [300.0]
+            ["rho", "v_p", "v_s", "v_phi", "K_eff", "G_eff"],
+            [10.0e9],
+            [300.0],
         )
         self.assertFloatEqual(10285.368, v_p[0])
         self.assertFloatEqual(6308.811, v_s[0])
@@ -357,7 +407,9 @@ class HSAverage(BurnManTest):
         rock = burnman.Composite([mypericlase()] * number, [1.0 / number] * number)
         rock.set_averaging_scheme(avg.HashinShtrikmanAverage())
         rho, v_p, v_s, v_phi, K, G = rock.evaluate(
-            ["rho", "v_p", "v_s", "v_phi", "K_S", "G"], [10.0e9], [300.0]
+            ["rho", "v_p", "v_s", "v_phi", "K_eff", "G_eff"],
+            [10.0e9],
+            [300.0],
         )
         self.assertFloatEqual(3791.392, rho[0])
         self.assertFloatEqual(10285.368, v_p[0])
@@ -378,7 +430,9 @@ class HSAverage(BurnManTest):
         )
         rock.set_averaging_scheme(avg.HashinShtrikmanAverage())
         rho, v_p, v_s, v_phi, K, G = rock.evaluate(
-            ["rho", "v_p", "v_s", "v_phi", "K_S", "G"], [10.0e9], [300.0]
+            ["rho", "v_p", "v_s", "v_phi", "K_eff", "G_eff"],
+            [10.0e9],
+            [300.0],
         )
         self.assertFloatEqual(4881.469, rho[0])
         self.assertFloatEqual(9952.378, v_p[0])


### PR DESCRIPTION
BREAKING CHANGE

This pull request:
* Refactors the `Composite` class to compute `density`, `thermal_expansivity`, `molar_heat_capacity_p`, `molar_heat_capacity_v`, `grueneisen_parameter`, `isentropic_bulk_modulus_reuss`, `isothermal_bulk_modulus_reuss`, and related properties directly using thermodynamically-motivated formulas, rather than delegating to the averaging scheme for scalar properties.
* Introduces `effective_isentropic_bulk_modulus` (`K_eff`) and `effective_shear_modulus` (`G_eff`) as new properties in both `Material` and `Composite`, with appropriate aliases and documentation, to clarify the distinction between thermodynamically-defined properties and effective properties of mixtures. These functions are averaged using the active AveragingScheme.
* Uses `K_eff` and `G_eff` in the functions used to calculate seismic velocities.
* Updates all example scripts (such as `paper_averaging.py` and `paper_incorrect_averaging.py`) to use the new `K_eff` and `G_eff` property names in place of the previous `K_S` and `G`, which are reserved for thermodynamic properties.
* Removes the unused averaging methods for scalar properties (density, thermal expansivity, heat capacities) from the `AveragingScheme` base class, since these are now handled directly in `Composite`.
* Adds new tests to make sure that thermodynamic properties are the same whether the material is a phase or a Composite containing a single phase.
* Improves documentation, clarified copyright years, and fixed minor typos in docstrings and comments across several files.

These changes improve the physical correctness, clarity, and maintainability of the BurnMan codebase, and provide a more consistent API for users working with composite materials.