### PR TITLE
complex to real eigenvectors if close

### DIFF
--- a/burnman/classes/anisotropy.py
+++ b/burnman/classes/anisotropy.py
@@ -292,6 +292,7 @@ class AnisotropicMaterial(Material):
         Tik = self.christoffel_tensor(propagation_direction)
 
         eigenvalues, eigenvectors = np.linalg.eig(Tik)
+        eigenvectors = np.real_if_close(eigenvectors)
 
         # sort eigs by decreasing eigenvalue
         idx = np.flip(eigenvalues.argsort(axis=-1), axis=-1)


### PR DESCRIPTION
A recent update to numpy left wave velocities failing to process nearly-real eigenvectors. This PR fixes this issue by converting nearly real eigenvectors to strictly real eigenvectors.